### PR TITLE
Fix: broken bash command in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,7 +577,7 @@ npx nestia <nestia|swagger> <source_directories_or_patterns> \
 
 # EXAMPLES
 npx nestia nestia "src/controllers" --out "src/api"
-npx nestia swagger "src/**/*.controller.ts" -- out "swagger.json"
+npx nestia swagger "src/**/*.controller.ts" --out "swagger.json"
 npx nestia swagger "src/main/controllers" "src/sub/controllers" \
     --exclude "src/main/test" \
     --out "composite.swagger.json"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npx nestia sdk "src/controller" \
     --out "src/api"
 
 # BUILDING SWAGGER.JSON IS ALSO POSSIBLE
-npx nestia swagger "src/controller" -- out "swagger.json"
+npx nestia swagger "src/controller" --out "swagger.json"
 ```
 
 Don't write any swagger comment and DTO decorator. Just run the `nestia` up.


### PR DESCRIPTION
Thank you for creating this awesome package!
I ran the command copied from the README.md and found that the `--out` tag is broken, so I updated the README.md.
(Sorry for letting the formatter modify the last line of this file, while I was editing directly on Github)