### PR TITLE
Support build CLI even when not installed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestia",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "Nestia CLI",
   "main": "bin/index.js",
   "bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,13 +69,15 @@ async function main(): Promise<void> {
         type === "swagger"
     ) {
         try {
-            await import("@nestia/sdk");
+            await import(process.cwd() + "/node_modules/@nestia/sdk");
         } catch {
             halt(
                 `@nestia/sdk has not been installed. Run "npx nestia setup" before.`,
             );
         }
-        await import("@nestia/sdk/lib/executable/sdk");
+        await import(
+            process.cwd() + "/node_modules/@nestia/sdk/lib/executable/sdk"
+        );
     } else halt(USAGE);
 }
 main().catch((exp) => {


### PR DESCRIPTION
There had been someone trying SDK build without installing `nestia`.

Therefore, just make `nestia` can be build SDK library even when not installed.