### PR TITLE
Close #220 - use Express' `req.is` to verify MIME type to be `application/json`

### DIFF
--- a/packages/core/src/decorators/TypedBody.ts
+++ b/packages/core/src/decorators/TypedBody.ts
@@ -31,7 +31,7 @@ export function TypedBody<T>(
         context: ExecutionContext,
     ) {
         const request: express.Request = context.switchToHttp().getRequest();
-        if (isApplicationJson(request.headers["content-type"]) === false) {
+        if (!request.is("application/json")) {
             throw new BadRequestException(
                 "Request body is not the application/json.",
             );
@@ -47,10 +47,3 @@ export function TypedBody<T>(
 Object.assign(TypedBody, assert);
 Object.assign(TypedBody, is);
 Object.assign(TypedBody, validate);
-
-const isApplicationJson = (text?: string) =>
-    text !== undefined &&
-    text
-        .split(";")
-        .map((str) => str.trim())
-        .some((str) => str === "application/json");


### PR DESCRIPTION
use Express' `req.is` to verify MIME type to be `application/json`