### PR TITLE
Fix: exact `package.json` exploration logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestia",
-  "version": "4.0.7",
+  "version": "4.0.8",
   "description": "Nestia CLI",
   "main": "bin/index.js",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/core",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "Super-fast validation decorators of NestJS",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/core/src/executable/internal/FileRetriever.ts
+++ b/packages/core/src/executable/internal/FileRetriever.ts
@@ -4,11 +4,11 @@ import path from "path";
 export namespace FileRetriever {
     export const directory =
         (name: string) =>
-        (directory: string, depth: number = 0): string | null => {
-            const location: string = path.join(directory, name);
-            if (fs.existsSync(location)) return directory;
+        (dir: string, depth: number = 0): string | null => {
+            const location: string = path.join(dir, name);
+            if (fs.existsSync(location)) return dir;
             else if (depth > 2) return null;
-            return file(name)(path.join(directory, ".."), depth + 1);
+            return directory(name)(path.join(dir, ".."), depth + 1);
         };
 
     export const file =

--- a/src/internal/FileRetriever.ts
+++ b/src/internal/FileRetriever.ts
@@ -4,11 +4,11 @@ import path from "path";
 export namespace FileRetriever {
     export const directory =
         (name: string) =>
-        (directory: string, depth: number = 0): string | null => {
-            const location: string = path.join(directory, name);
-            if (fs.existsSync(location)) return directory;
+        (dir: string, depth: number = 0): string | null => {
+            const location: string = path.join(dir, name);
+            if (fs.existsSync(location)) return dir;
             else if (depth > 2) return null;
-            return file(name)(path.join(directory, ".."), depth + 1);
+            return directory(name)(path.join(dir, ".."), depth + 1);
         };
 
     export const file =


### PR DESCRIPTION
Exact `package.json` exploration logic when running `npx nestia setup` command.