### PR TITLE
Check existence of `ttypescript` in SDK

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/sdk",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Nestia SDK and Swagger generator",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/sdk/src/NestiaSdkApplication.ts
+++ b/packages/sdk/src/NestiaSdkApplication.ts
@@ -157,10 +157,19 @@ export class NestiaSdkApplication {
                 NestiaConfigCompilerOptions.DEFAULT_OPTIONS as any;
         const absoluted: boolean = !!this.config_.compilerOptions?.baseUrl;
 
+        const ttsc: boolean = (() => {
+            try {
+                require.resolve("ttypescript");
+                return true;
+            } catch (e) {
+                return false;
+            }
+        })();
+
         // MOUNT TS-NODE
         runner.register({
             emit: false,
-            compiler: "ttypescript",
+            compiler: ttsc ? "ttypescript" : undefined,
             compilerOptions: this.config_.compilerOptions,
             require: absoluted ? ["tsconfig-paths/register"] : undefined,
         });


### PR DESCRIPTION
SDK and Swagger generator imported `ttypescript` without existence check.

Therefore, fixed the bug.