### PR TITLE
Close #266 by accepting #247 - enhance Fetcher

### DIFF
--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/fetcher",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Fetcher library of Nestia SDK",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/fetcher/src/Fetcher.ts
+++ b/packages/fetcher/src/Fetcher.ts
@@ -55,7 +55,7 @@ export class Fetcher {
         encrypted: Fetcher.IEncrypted,
         method: "POST" | "PUT" | "PATCH" | "DELETE",
         path: string,
-        input: Input,
+        input?: Input,
         stringify?: (input: Input) => string,
     ): Promise<Primitive<Output>>;
 


### PR DESCRIPTION
From now on, `DELETE` method can use request body.

Also, about `POST`, `PUT`, `PATCH` methods, they can omit the request body.

The new version of `@nestia/fetcher` is v1.0.1