### PR TITLE
Update README -> 50x faster stringify

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ If you want to install and configure `nestia` manually, read [Guide Documents ->
 Super-fast validation decorators for NestJS.
 
   - 15,000x faster request body validation
-  - 10x faster JSON response, even type safe
+  - 50x faster JSON response, even type safe
   - Do not need DTO class definition, just fine with interface
 
 `@nestia/core` is a transformer library of NestJS, supporting super-fast validation decorators, by wrapping [typia](https://github.com/samchon/typia). Comparing validation speed with `class-validator`, [typia](https://github.com/samchon/typia) is maximum **15,000x times faster** and it is even much safer.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -8,7 +8,7 @@
 Super-fast validation decorators for NestJS.
 
   - 15,000x faster request body validation
-  - 10x faster JSON response, even type safe
+  - 50x faster JSON response, even type safe
   - Do not need DTO class definition, just fine with interface
 
 `@nestia/core` is a transformer library of NestJS, supporting super-fast validation decorators, by wrapping [typia](https://github.com/samchon/typia). Comparing validation speed with `class-validator`, [typia](https://github.com/samchon/typia) is maximum **15,000x times faster** and it is even much safer.
@@ -29,7 +29,7 @@ export class BbsArticlesController {
      * @param inupt Content to store
      * @returns Newly archived article
      */
-    @TypedRoute.Post() // 10x faster and safer JSON.stringify()
+    @TypedRoute.Post() // 50x faster and safer JSON.stringify()
     public async store(
         @TypedBody() input: IBbsArticle.IStore // super-fast validator
     ): Promise<IBbsArticle>; 

--- a/packages/sdk/src/INestiaConfig.ts
+++ b/packages/sdk/src/INestiaConfig.ts
@@ -56,11 +56,11 @@ export interface INestiaConfig {
     assert?: boolean;
 
     /**
-     * Whether to optimize JSON string conversion 10x faster or not.
+     * Whether to optimize JSON string conversion 50x faster or not.
      *
      * If you configure this property to be `true`, the SDK library would utilize the
      * [typia](https://github.com/samchon/typia#enhanced-json)
-     * and the JSON string conversion speed really be 10x faster.
+     * and the JSON string conversion speed really be 50x faster.
      *
      * @default false
      */


### PR DESCRIPTION
Comparing `typia.stringify()` with `class-transformer.serialize()`, `typia` is 50x faster.

Therefore, update README documents.