### PR TITLE
Add `HttpError.toJSON()` method

### DIFF
--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/fetcher",
-  "version": "1.0.1",
+  "version": "1.1.0-dev.20230413",
   "description": "Fetcher library of Nestia SDK",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/fetcher/src/HttpError.ts
+++ b/packages/fetcher/src/HttpError.ts
@@ -7,6 +7,11 @@
  */
 export class HttpError extends Error {
     /**
+     * @internal
+     */
+    private body_: any = NOT_YET;
+
+    /**
      * Initializer Constructor.
      *
      * @param method Method of the HTTP request.
@@ -27,4 +32,40 @@ export class HttpError extends Error {
         if (Object.setPrototypeOf) Object.setPrototypeOf(this, proto);
         else (this as any).__proto__ = proto;
     }
+
+    /**
+     * `HttpError` to JSON.
+     *
+     * When you call `JSON.stringify()` function on current `HttpError` instance,
+     * this `HttpError.toJSON()` method would be automatically called.
+     *
+     * Also, if response body from the remote HTTP server forms a JSON object,
+     * this `HttpError.toJSON()` method would be useful because it returns the
+     * parsed JSON object about the {@link message} property.
+     *
+     * @template T Expected type of the response body.
+     * @returns JSON object of the `HttpError`.
+     */
+    public toJSON<T>(): HttpError.IProps<T> {
+        if (this.body_ === NOT_YET) this.body_ = JSON.parse(this.message);
+        return {
+            method: this.method,
+            path: this.path,
+            status: this.status,
+            message: this.body_,
+        };
+    }
 }
+export namespace HttpError {
+    /**
+     * Returned type of {@link HttpError.toJSON} method.
+     */
+    export interface IProps<T> {
+        method: "GET" | "DELETE" | "POST" | "PUT" | "PATCH";
+        path: string;
+        status: number;
+        message: T;
+    }
+}
+
+const NOT_YET = {} as any;


### PR DESCRIPTION
New method `HttpError.toJSON()` method for parsing response body.

```typescript
export class HttpError extends Error {
    public readonly method: "GET" | "DELETE" | "POST" | "PUT" | "PATCH";
    public readonly path: string;
    public readonly status: number;

    pubilc toJSON<T>(): HttpError.IProps<T>;
}
export namespace HttpError {
    export interface IProps<T> {
        method: "GET" | "DELETE" | "POST" | "PUT" | "PATCH";
        path: string;
        status: number;
        message: T;
    }
}
```