### PR TITLE
Add `peerDependencies` in core and sdk

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/core",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "description": "Super-fast validation decorators of NestJS",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -10,7 +10,8 @@
     "dev": "npm run build -- --watch",
     "eslint": "eslint ./**/*.ts",
     "eslint:fix": "eslint ./**/*.ts --fix",
-    "package": "npm publish --access public",
+    "package:latest": "npm publish --access public",
+    "package:next": "npm publish --tag next --access public",
     "prettier": "prettier ./**/*.ts --write",
     "test": "node bin/test"
   },
@@ -52,15 +53,15 @@
     "typescript-transform-paths": "^3.4.6"
   },
   "dependencies": {
-    "@nestia/fetcher": "^1.0.0",
-    "@nestjs/common": "*",
-    "@nestjs/core": "*",
-    "@nestjs/platform-express": "*",
+    "@nestia/fetcher": "^1.0.1",
+    "@nestjs/common": ">= 7.0.1",
+    "@nestjs/core": ">= 7.0.1",
+    "@nestjs/platform-express": ">= 7.0.1",
     "detect-ts-node": "^1.0.5",
-    "raw-body": "*",
-    "reflect-metadata": "*",
-    "rxjs": "*",
-    "typia": "^3.7.4"
+    "raw-body": ">= 2.0.0",
+    "reflect-metadata": ">= 0.1.12",
+    "rxjs": ">= 6.0.0",
+    "typia": "^3.7.5"
   },
   "peerDependencies": {
     "typescript": ">= 4.5.2 && < 5.0.0"

--- a/packages/core/src/decorators/EncryptedModule.ts
+++ b/packages/core/src/decorators/EncryptedModule.ts
@@ -1,5 +1,5 @@
 import { IEncryptionPassword } from "@nestia/fetcher/lib/IEncryptionPassword";
-import { Module, ModuleMetadata } from "@nestjs/common";
+import { Module } from "@nestjs/common";
 
 import { Creator } from "../typings/Creator";
 import { ENCRYPTION_METADATA_KEY } from "./internal/EncryptedConstant";
@@ -36,7 +36,7 @@ import { load_controllers } from "./internal/load_controller";
  * @author Jeongho Nam - https://github.com/samchon
  */
 export function EncryptedModule(
-    metadata: ModuleMetadata,
+    metadata: Parameters<typeof Module>[0],
     password: IEncryptionPassword | IEncryptionPassword.Closure,
 ): ClassDecorator {
     return function (target: any) {
@@ -66,7 +66,7 @@ export namespace EncryptedModule {
     export async function dynamic(
         path: string,
         password: IEncryptionPassword | IEncryptionPassword.Closure,
-        options: Omit<ModuleMetadata, "controllers"> = {},
+        options: Omit<Parameters<typeof Module>[0], "controllers"> = {},
     ): Promise<object> {
         // LOAD CONTROLLERS
         const controllers: Creator<object>[] = await load_controllers(path);

--- a/packages/core/src/decorators/EncryptedRoute.ts
+++ b/packages/core/src/decorators/EncryptedRoute.ts
@@ -13,7 +13,7 @@ import {
 } from "@nestjs/common";
 import { HttpArgumentsHost } from "@nestjs/common/interfaces";
 import express from "express";
-import { Observable, catchError, map } from "rxjs";
+import { catchError, map } from "rxjs/operators";
 
 import {
     assertStringify,
@@ -141,10 +141,7 @@ class EncryptedRouteInterceptor implements NestInterceptor {
         private readonly stringify: (input: any) => string,
     ) {}
 
-    public intercept(
-        context: ExecutionContext,
-        next: CallHandler,
-    ): Observable<any> {
+    public intercept(context: ExecutionContext, next: CallHandler) {
         const http: HttpArgumentsHost = context.switchToHttp();
         return next.handle().pipe(
             map((value) => {

--- a/packages/core/src/decorators/TypedRoute.ts
+++ b/packages/core/src/decorators/TypedRoute.ts
@@ -12,7 +12,7 @@ import {
 } from "@nestjs/common";
 import { HttpArgumentsHost } from "@nestjs/common/interfaces";
 import express from "express";
-import { Observable, catchError, map } from "rxjs";
+import { catchError, map } from "rxjs/operators";
 
 import {
     assertStringify,
@@ -127,10 +127,7 @@ for (const method of [
 class TypedRouteInterceptor implements NestInterceptor {
     public constructor(private readonly stringify: (input: any) => string) {}
 
-    public intercept(
-        context: ExecutionContext,
-        next: CallHandler,
-    ): Observable<any> {
+    public intercept(context: ExecutionContext, next: CallHandler) {
         const http: HttpArgumentsHost = context.switchToHttp();
         const response: express.Response = http.getResponse();
         response.header("Content-Type", "application/json");

--- a/packages/core/src/decorators/internal/route_error.ts
+++ b/packages/core/src/decorators/internal/route_error.ts
@@ -1,13 +1,10 @@
 import { HttpException } from "@nestjs/common";
 import express from "express";
-import { Observable, throwError } from "rxjs";
+import { throwError } from "rxjs";
 
 import { ExceptionManager } from "../../utils/ExceptionManager";
 
-export function route_error(
-    request: express.Request,
-    error: any,
-): Observable<never> {
+export function route_error(request: express.Request, error: any) {
     error = (() => {
         // HTTP-ERROR
         if (error instanceof HttpException) return error;

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/sdk",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "description": "Nestia SDK and Swagger generator",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -10,7 +10,8 @@
   "scripts": {
     "build": "rimraf lib && ttsc",
     "dev": "rimraf lib && ttsc --watch",
-    "package": "npm publish --access public",
+    "package:latest": "npm publish --access public",
+    "package:next": "npm publish --tag next --access public",
     "prettier": "prettier --write ./**/*.ts",
     "test": "node lib/test"
   },
@@ -32,8 +33,25 @@
     "url": "https://github.com/samchon/nestia/issues"
   },
   "homepage": "https://github.com/samchon/nestia",
+  "dependencies": {
+    "cli": "^1.0.1",
+    "glob": "^7.2.0",
+    "path-to-regexp": "^6.2.1",
+    "tgrid": "^0.8.7",
+    "tsconfck": "^2.0.1",
+    "tsconfig-paths": "^4.1.1",
+    "tstl": "^2.5.13",
+    "typia": "^3.7.5"
+  },
+  "peerDependencies": {
+    "@nestjs/common": ">= 7.0.1",
+    "@nestjs/core": ">= 7.0.1",
+    "reflect-metadata": ">= 0.1.12",
+    "ts-node": ">= 10.6.0",
+    "typescript": ">= 4.5.2"
+  },
   "devDependencies": {
-    "@nestia/core": "^1.0.17",
+    "@nestia/core": "^1.0.20",
     "@nestia/fetcher": "^1.0.1",
     "@trivago/prettier-plugin-sort-imports": "^4.0.0",
     "@types/cli": "^0.11.21",
@@ -47,21 +65,11 @@
     "eslint": "^8.29.0",
     "prettier": "^2.8.1",
     "rimraf": "^3.0.2",
-    "ts-node": "^10.9.1",
+    "ts-node": "^10.6.0",
     "ttypescript": "^1.5.15",
     "typescript": "^4.9.5",
     "typescript-transform-paths": "^3.4.4",
     "uuid": "^9.0.0"
-  },
-  "dependencies": {
-    "cli": "^1.0.1",
-    "glob": "^7.2.0",
-    "path-to-regexp": "^6.2.1",
-    "tgrid": "^0.8.7",
-    "tsconfck": "^2.0.1",
-    "tsconfig-paths": "^4.1.1",
-    "tstl": "^2.5.13",
-    "typia": "^3.6.9"
   },
   "files": [
     "assets",


### PR DESCRIPTION
Succeeded to complicate dependency relationship of NestJS.

Therefore, restrict dependencies of NestJS through `peerDependencies`