### PR TITLE
Trace error from user defined controller

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/sdk",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Nestia SDK and Swagger generator",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -42,7 +42,7 @@
     "tsconfck": "^2.0.1",
     "tsconfig-paths": "^4.1.1",
     "tstl": "^2.5.13",
-    "typia": "^3.8.4"
+    "typia": "^3.8.5"
   },
   "peerDependencies": {
     "@nestjs/common": ">= 7.0.1",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/sdk",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Nestia SDK and Swagger generator",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/sdk/src/NestiaSdkApplication.ts
+++ b/packages/sdk/src/NestiaSdkApplication.ts
@@ -185,7 +185,7 @@ export class NestiaSdkApplication {
                         c.paths.length *
                         c.functions
                             .map((f) => f.paths.length)
-                            .reduce((a, b) => a + b),
+                            .reduce((a, b) => a + b, 0),
                 )
                 .reduce((a, b) => a + b, 0)}`,
         );

--- a/packages/sdk/src/analyses/ReflectAnalyzer.ts
+++ b/packages/sdk/src/analyses/ReflectAnalyzer.ts
@@ -17,7 +17,21 @@ export namespace ReflectAnalyzer {
         unique: WeakSet<any>,
         file: string,
     ): Promise<IController[]> {
-        const module: IModule = await import(file);
+        const module: IModule = await (async () => {
+            try {
+                return await import(file);
+            } catch (exp) {
+                console.log(
+                    ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>",
+                );
+                console.log(`Error on "${file}" file. Check your code.`);
+                console.log(exp);
+                console.log(
+                    ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>",
+                );
+                process.exit(-1);
+            }
+        })();
         const ret: IController[] = [];
 
         for (const tuple of Object.entries(module)) {


### PR DESCRIPTION
There're some people that directly running script in controller files. In that case, when runs `npx nestia sdk` command, SDK generation would be halted without detailed error tracing (only `Error.message` would be shown).

Therefore, enhance `@nestia/sdk` to trace error from user defined controller, and report it detaily.