### PR TITLE
Fix non-Error type bug of `@nestia/e2e`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ bin/
 lib/
 node_modules/
 packages/*/*.tgz
-package-lock.json
+pnpm-lock.yaml

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/e2e",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "E2E test utilify functions",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/e2e/src/TestValidator.ts
+++ b/packages/e2e/src/TestValidator.ts
@@ -106,7 +106,7 @@ export namespace TestValidator {
         <T>(task: () => T): T extends Promise<any> ? Promise<void> : void => {
             const message = () =>
                 `Bug on ${title}: status code must be ${status}.`;
-            const predicate = (exp: any) =>
+            const predicate = (exp: any): Error | null =>
                 typeof exp === "object" &&
                 exp.constructor.name === "HttpError" &&
                 exp.status === status
@@ -122,7 +122,7 @@ export namespace TestValidator {
                                 if (res) reject(res);
                                 else resolve();
                             })
-                            .then(() => reject(message())),
+                            .then(() => reject(new Error(message()))),
                     ) as any;
                 else throw new Error(message());
             } catch (exp) {


### PR DESCRIPTION
`TestValidator` class had thrown `string` value instead of `Error` class typed instance. Also, `DynamicExecutor` could not handle such non `Error` typed exception.

Before submitting a Pull Request, please test your code. 

If you created a new created a new feature, then create the unit test function, too.

```bash
# COMPILE THE BACKEND SERVER
npm run build

# RUN THE TEST AUTOMATION PROGRAM
npm run test
```

Learn more about the [CONTRIBUTING](CONTRIBUTING.md)