### PR TITLE
Close #380 - prohibit non-strict option

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/core",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Super-fast validation decorators of NestJS",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -44,7 +44,7 @@
     "raw-body": ">= 2.0.0",
     "reflect-metadata": ">= 0.1.12",
     "rxjs": ">= 6.0.0",
-    "typia": "^4.0.3"
+    "typia": "^4.0.4"
   },
   "peerDependencies": {
     "@nestia/fetcher": "^1.2.1",

--- a/packages/core/src/transform.ts
+++ b/packages/core/src/transform.ts
@@ -6,12 +6,22 @@ import { FileTransformer } from "./transformers/FileTransformer";
 export const transform = (
     program: ts.Program,
     options?: INestiaTransformOptions,
-): ts.TransformerFactory<ts.SourceFile> =>
-    FileTransformer.transform({
+): ts.TransformerFactory<ts.SourceFile> => {
+    const compilerOptions: ts.CompilerOptions = program.getCompilerOptions();
+    const strict: boolean =
+        compilerOptions.strictNullChecks !== undefined
+            ? !!compilerOptions.strictNullChecks
+            : !!compilerOptions.strict;
+    if (strict === false)
+        throw new Error(
+            `Error on "tsconfig.json": nestia requires \`compilerOptions.strictNullChecks\` to be true.`,
+        );
+    return FileTransformer.transform({
         program,
-        compilerOptions: program.getCompilerOptions(),
+        compilerOptions,
         checker: program.getTypeChecker(),
         printer: ts.createPrinter(),
         options: options || {},
     });
+};
 export default transform;

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/sdk",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "description": "Nestia SDK and Swagger generator",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -43,7 +43,7 @@
     "tsconfck": "^2.0.1",
     "tsconfig-paths": "^4.1.1",
     "tstl": "^2.5.13",
-    "typia": "^4.0.3"
+    "typia": "^4.0.4"
   },
   "peerDependencies": {
     "@nestia/fetcher": ">= 1.3.1",

--- a/packages/sdk/src/analyses/ControllerAnalyzer.ts
+++ b/packages/sdk/src/analyses/ControllerAnalyzer.ts
@@ -70,6 +70,7 @@ export namespace ControllerAnalyzer {
                 controller,
                 genericDict,
                 runtime,
+                declaration,
                 property,
             );
             ret.push(...routes);
@@ -85,6 +86,7 @@ export namespace ControllerAnalyzer {
         controller: IController,
         genericDict: GenericAnalyzer.Dictionary,
         func: IController.IFunction,
+        declaration: ts.Declaration,
         symbol: ts.Symbol,
     ): IRoute[] {
         // PREPARE ASSETS
@@ -141,6 +143,9 @@ export namespace ControllerAnalyzer {
             status: func.status,
 
             symbol: `${controller.name}.${func.name}()`,
+            location: `${declaration.getSourceFile().fileName}:${
+                declaration.pos
+            }`,
             description: CommentFactory.description(symbol),
             tags,
             setHeaders: tags

--- a/packages/sdk/src/analyses/ImportAnalyzer.ts
+++ b/packages/sdk/src/analyses/ImportAnalyzer.ts
@@ -100,18 +100,12 @@ export namespace ImportAnalyzer {
         }
 
         // NO SYMBOL
-        else if (symbol === undefined) {
-            const raw: string = checker.typeToString(
+        else if (symbol === undefined)
+            return checker.typeToString(
                 type,
                 undefined,
                 ts.TypeFormatFlags.NoTruncation,
             );
-            if (raw === "__object")
-                throw new Error(
-                    "Error on ImportAnalyzer.analyze(): unnamed type exists.",
-                );
-            return raw;
-        }
 
         //----
         // SPECIALIZATION

--- a/packages/sdk/src/executable/internal/NestiaConfigCompilerOptions.ts
+++ b/packages/sdk/src/executable/internal/NestiaConfigCompilerOptions.ts
@@ -14,5 +14,6 @@ export namespace NestiaConfigCompilerOptions {
         ...ESSENTIAL_OPTIONS,
         target: "es5",
         module: "commonjs",
+        strictNullChecks: true,
     };
 }

--- a/packages/sdk/src/executable/internal/NestiaSdkCommand.ts
+++ b/packages/sdk/src/executable/internal/NestiaSdkCommand.ts
@@ -78,10 +78,11 @@ export namespace NestiaSdkCommand {
                 (await get_nestia_config(props.validate)) ??
                 parse_cli(props)(command)(include);
 
-            const options = await get_typescript_options();
+            const options: ts.CompilerOptions | null =
+                await get_typescript_options();
             config.compilerOptions = {
-                ...options,
-                ...(config.compilerOptions || {}),
+                ...(options ?? {}),
+                ...(config.compilerOptions ?? {}),
             };
 
             // CALL THE APP.GENERATE()

--- a/packages/sdk/src/generates/SdkGenerator.ts
+++ b/packages/sdk/src/generates/SdkGenerator.ts
@@ -12,6 +12,18 @@ export namespace SdkGenerator {
         async (routes: IRoute[]): Promise<void> => {
             console.log("Generating SDK Library");
 
+            // FIND IMPLICIT TYPES
+            const implicit: IRoute[] = routes.filter(is_implicit_return_typed);
+            if (implicit.length > 0)
+                throw new Error(
+                    "NestiaApplication.sdk(): implicit return type is not allowed.\n" +
+                        "\n" +
+                        "List of implicit return typed routes:\n" +
+                        implicit
+                            .map((it) => `  - ${it.symbol} at "${it.location}"`)
+                            .join("\n"),
+                );
+
             // PREPARE NEW DIRECTORIES
             try {
                 await fs.promises.mkdir(config.output!);
@@ -63,3 +75,20 @@ export namespace SdkGenerator {
         "api",
     );
 }
+
+const is_implicit_return_typed = (route: IRoute): boolean => {
+    const name: string = route.output.name;
+    if (name === "void") return false;
+    else if (name.indexOf("readonly [") !== -1) return true;
+
+    const pos: number = name.indexOf("__object");
+    if (pos === -1) return false;
+
+    const before: number = pos - 1;
+    const after: number = pos + "__object".length;
+    for (const i of [before, after])
+        if (name[i] === undefined) continue;
+        else if (VARIABLE.test(name[i])) return false;
+    return true;
+};
+const VARIABLE = /[a-zA-Z_$0-9]/;

--- a/packages/sdk/src/structures/IRoute.ts
+++ b/packages/sdk/src/structures/IRoute.ts
@@ -14,6 +14,7 @@ export interface IRoute {
     imports: [string, string[]][];
     output: ITypeTuple;
 
+    location: string;
     symbol: string;
     description?: string;
     tags: ts.JSDocTagInfo[];

--- a/test/features/distribute-assert/packages/api/package.json
+++ b/test/features/distribute-assert/packages/api/package.json
@@ -34,6 +34,6 @@
   },
   "dependencies": {
     "@nestia/fetcher": "^1.3.1",
-    "typia": "^4.0.3"
+    "typia": "^4.0.5"
   }
 }

--- a/test/features/distribute-json/packages/api/package.json
+++ b/test/features/distribute-json/packages/api/package.json
@@ -34,6 +34,6 @@
   },
   "dependencies": {
     "@nestia/fetcher": "^1.3.1",
-    "typia": "^4.0.3"
+    "typia": "^4.0.5"
   }
 }

--- a/test/features/implicit-error/nestia.config.ts
+++ b/test/features/implicit-error/nestia.config.ts
@@ -1,0 +1,16 @@
+import { INestiaConfig } from "@nestia/sdk";
+
+export const NESTIA_CONFIG: INestiaConfig = {
+    input: ["src/controllers"],
+    output: "src/api",
+    e2e: "src/test",
+    swagger: {
+        output: "swagger.json",
+        security: {
+            bearer: {
+                type: "apiKey",
+            },
+        },
+    },
+};
+export default NESTIA_CONFIG;

--- a/test/features/implicit-error/src/Backend.ts
+++ b/test/features/implicit-error/src/Backend.ts
@@ -1,0 +1,28 @@
+import { INestApplication } from "@nestjs/common";
+import { NestFactory } from "@nestjs/core";
+
+import core from "@nestia/core";
+
+export class Backend {
+    private application_?: INestApplication;
+
+    public async open(): Promise<void> {
+        this.application_ = await NestFactory.create(
+            await core.EncryptedModule.dynamic(__dirname + "/controllers", {
+                key: "A".repeat(32),
+                iv: "B".repeat(16),
+            }),
+            { logger: false },
+        );
+        await this.application_.listen(37_000);
+    }
+
+    public async close(): Promise<void> {
+        if (this.application_ === undefined) return;
+
+        const app = this.application_;
+        await app.close();
+
+        delete this.application_;
+    }
+}

--- a/test/features/implicit-error/src/controllers/ImplicitController.ts
+++ b/test/features/implicit-error/src/controllers/ImplicitController.ts
@@ -1,0 +1,112 @@
+import { Controller } from "@nestjs/common";
+
+import core from "@nestia/core";
+
+@Controller("implicit")
+export class ImplicitController {
+    @core.TypedRoute.Get("number")
+    public async number() {
+        return 1;
+    }
+
+    @core.TypedRoute.Get("object1")
+    public async object1() {
+        return {
+            cpu: process.cpuUsage(),
+            memory: process.memoryUsage(),
+            resource: process.resourceUsage(),
+        };
+    }
+
+    @core.TypedRoute.Get("object2")
+    public async object2() {
+        return {
+            arch: process.arch,
+            platform: process.platform,
+            versions: process.versions,
+        }
+    }
+
+    @core.TypedRoute.Get("objectConstant")
+    public async objectConstant() {
+        return {
+            cpu: process.cpuUsage(),
+            memory: process.memoryUsage(),
+            resource: process.resourceUsage(),
+        } as const;
+    }
+
+    @core.TypedRoute.Get("array")
+    public async array() {
+        return [
+            {
+                cpu: process.cpuUsage(),
+                memory: process.memoryUsage(),
+                resource: process.resourceUsage(),
+            },
+        ];
+    }
+
+    @core.TypedRoute.Get("arrayUnion")
+    public async arrayUnion() {
+        return [
+            {
+                cpu: process.cpuUsage(),
+                memory: process.memoryUsage(),
+                resource: process.resourceUsage(),
+            },
+            {
+                arch: process.arch,
+                platform: process.platform,
+                versions: process.versions,
+            },
+        ];
+    }
+
+    @core.TypedRoute.Get("matrix")
+    public async matrix() {
+        return [
+            [
+                {
+                    cpu: process.cpuUsage(),
+                    memory: process.memoryUsage(),
+                    resource: process.resourceUsage(),
+                }
+            ]
+        ];
+    }
+
+    @core.TypedRoute.Get("matrixUnion")
+    public async matrixUnion() {
+        return [
+            [
+                {
+                    cpu: process.cpuUsage(),
+                    memory: process.memoryUsage(),
+                    resource: process.resourceUsage(),
+                },
+                {
+                    arch: process.arch,
+                    platform: process.platform,
+                    versions: process.versions,
+                },
+            ],
+        ];
+    }
+
+    @core.TypedRoute.Get("tuple")
+    public async tuple() {
+        return [
+            {
+                cpu: process.cpuUsage(),
+                memory: process.memoryUsage(),
+                resource: process.resourceUsage(),
+            },
+            {
+                arch: process.arch,
+                platform: process.platform,
+                versions: process.versions,
+            },
+        ] as const;
+    }
+}

--- a/test/features/implicit-error/src/test/index.ts
+++ b/test/features/implicit-error/src/test/index.ts
@@ -1,0 +1,42 @@
+import core from "@nestia/core";
+import { DynamicExecutor } from "@nestia/e2e";
+
+import { INestApplication } from "@nestjs/common";
+import { NestFactory } from "@nestjs/core";
+
+async function main(): Promise<void> {
+    const server: INestApplication = await NestFactory.create(
+        await core.DynamicModule.mount(
+            {"include":["src/controllers"],"exclude":[]},
+        ),
+    );
+    await server.listen(37_000);
+
+    const report: DynamicExecutor.IReport = await DynamicExecutor.validate({
+        extension: __filename.substring(__filename.length - 2),
+        prefix: "test",
+        parameters: () => [
+            {
+                host: "http://127.0.0.1:37000",
+            },
+        ],
+    })(`${__dirname}/features`);
+    await server.close();
+
+    const exceptions: Error[] = report.executions
+        .filter((exec) => exec.error !== null)
+        .map((exec) => exec.error!);
+    if (exceptions.length === 0) {
+        console.log("Success");
+        console.log("Elapsed time", report.time.toLocaleString(), `ms`);
+    } else {
+        for (const exp of exceptions) console.log(exp);
+        console.log("Failed");
+        console.log("Elapsed time", report.time.toLocaleString(), `ms`);
+        process.exit(-1);
+    }
+}
+main().catch((exp) => {
+    console.log(exp);
+    process.exit(-1);
+});

--- a/test/features/implicit-error/swagger.json
+++ b/test/features/implicit-error/swagger.json
@@ -1,0 +1,768 @@
+{
+  "openapi": "3.0.1",
+  "servers": [
+    {
+      "url": "https://github.com/samchon/nestia",
+      "description": "insert your server url"
+    }
+  ],
+  "info": {
+    "version": "0.0.0",
+    "title": "@nestia/test",
+    "description": "Test program of Nestia"
+  },
+  "paths": {
+    "/implicit/number": {
+      "get": {
+        "tags": [],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "number"
+                }
+              }
+            },
+            "x-nestia-encrypted": false
+          }
+        },
+        "x-nestia-namespace": "implicit.number.number",
+        "x-nestia-jsDocTags": []
+      }
+    },
+    "/implicit/object1": {
+      "get": {
+        "tags": [],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/__object"
+                }
+              }
+            },
+            "x-nestia-encrypted": false
+          }
+        },
+        "x-nestia-namespace": "implicit.object1.object1",
+        "x-nestia-jsDocTags": []
+      }
+    },
+    "/implicit/object2": {
+      "get": {
+        "tags": [],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/__object.o1"
+                }
+              }
+            },
+            "x-nestia-encrypted": false
+          }
+        },
+        "x-nestia-namespace": "implicit.object2.object2",
+        "x-nestia-jsDocTags": []
+      }
+    },
+    "/implicit/objectConstant": {
+      "get": {
+        "tags": [],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/__object.o2"
+                }
+              }
+            },
+            "x-nestia-encrypted": false
+          }
+        },
+        "x-nestia-namespace": "implicit.objectConstant.objectConstant",
+        "x-nestia-jsDocTags": []
+      }
+    },
+    "/implicit/array": {
+      "get": {
+        "tags": [],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/__object.o3"
+                  }
+                }
+              }
+            },
+            "x-nestia-encrypted": false
+          }
+        },
+        "x-nestia-namespace": "implicit.array.array",
+        "x-nestia-jsDocTags": []
+      }
+    },
+    "/implicit/arrayUnion": {
+      "get": {
+        "tags": [],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/__object.o4"
+                      },
+                      {
+                        "$ref": "#/components/schemas/__object.o5"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "x-nestia-encrypted": false
+          }
+        },
+        "x-nestia-namespace": "implicit.arrayUnion.arrayUnion",
+        "x-nestia-jsDocTags": []
+      }
+    },
+    "/implicit/matrix": {
+      "get": {
+        "tags": [],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/__object.o6"
+                    }
+                  }
+                }
+              }
+            },
+            "x-nestia-encrypted": false
+          }
+        },
+        "x-nestia-namespace": "implicit.matrix.matrix",
+        "x-nestia-jsDocTags": []
+      }
+    },
+    "/implicit/matrixUnion": {
+      "get": {
+        "tags": [],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "oneOf": [
+                        {
+                          "$ref": "#/components/schemas/__object.o7"
+                        },
+                        {
+                          "$ref": "#/components/schemas/__object.o8"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "x-nestia-encrypted": false
+          }
+        },
+        "x-nestia-namespace": "implicit.matrixUnion.matrixUnion",
+        "x-nestia-jsDocTags": []
+      }
+    },
+    "/implicit/tuple": {
+      "get": {
+        "tags": [],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/__object.o9"
+                      },
+                      {
+                        "$ref": "#/components/schemas/__object.o10"
+                      }
+                    ]
+                  },
+                  "x-typia-tuple": {
+                    "type": "array",
+                    "items": [
+                      {
+                        "$ref": "#/components/schemas/__object.o9"
+                      },
+                      {
+                        "$ref": "#/components/schemas/__object.o10"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "x-nestia-encrypted": false
+          }
+        },
+        "x-nestia-namespace": "implicit.tuple.tuple",
+        "x-nestia-jsDocTags": []
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "__object": {
+        "type": "object",
+        "properties": {
+          "cpu": {
+            "$ref": "#/components/schemas/_singlequote_process_singlequote_.global.NodeJS.CpuUsage"
+          },
+          "memory": {
+            "$ref": "#/components/schemas/_singlequote_process_singlequote_.global.NodeJS.MemoryUsage"
+          },
+          "resource": {
+            "$ref": "#/components/schemas/_singlequote_process_singlequote_.global.NodeJS.ResourceUsage"
+          }
+        },
+        "nullable": false,
+        "required": [
+          "cpu",
+          "memory",
+          "resource"
+        ],
+        "x-typia-jsDocTags": []
+      },
+      "_singlequote_process_singlequote_.global.NodeJS.CpuUsage": {
+        "type": "object",
+        "properties": {
+          "user": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "number"
+          },
+          "system": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "number"
+          }
+        },
+        "nullable": false,
+        "required": [
+          "user",
+          "system"
+        ],
+        "x-typia-jsDocTags": []
+      },
+      "_singlequote_process_singlequote_.global.NodeJS.MemoryUsage": {
+        "type": "object",
+        "properties": {
+          "rss": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "number"
+          },
+          "heapTotal": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "number"
+          },
+          "heapUsed": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "number"
+          },
+          "external": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "number"
+          },
+          "arrayBuffers": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "number"
+          }
+        },
+        "nullable": false,
+        "required": [
+          "rss",
+          "heapTotal",
+          "heapUsed",
+          "external",
+          "arrayBuffers"
+        ],
+        "x-typia-jsDocTags": []
+      },
+      "_singlequote_process_singlequote_.global.NodeJS.ResourceUsage": {
+        "type": "object",
+        "properties": {
+          "fsRead": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "number"
+          },
+          "fsWrite": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "number"
+          },
+          "involuntaryContextSwitches": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "number"
+          },
+          "ipcReceived": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "number"
+          },
+          "ipcSent": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "number"
+          },
+          "majorPageFault": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "number"
+          },
+          "maxRSS": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "number"
+          },
+          "minorPageFault": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "number"
+          },
+          "sharedMemorySize": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "number"
+          },
+          "signalsCount": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "number"
+          },
+          "swappedOut": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "number"
+          },
+          "systemCPUTime": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "number"
+          },
+          "unsharedDataSize": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "number"
+          },
+          "unsharedStackSize": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "number"
+          },
+          "userCPUTime": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "number"
+          },
+          "voluntaryContextSwitches": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "number"
+          }
+        },
+        "nullable": false,
+        "required": [
+          "fsRead",
+          "fsWrite",
+          "involuntaryContextSwitches",
+          "ipcReceived",
+          "ipcSent",
+          "majorPageFault",
+          "maxRSS",
+          "minorPageFault",
+          "sharedMemorySize",
+          "signalsCount",
+          "swappedOut",
+          "systemCPUTime",
+          "unsharedDataSize",
+          "unsharedStackSize",
+          "userCPUTime",
+          "voluntaryContextSwitches"
+        ],
+        "x-typia-jsDocTags": []
+      },
+      "__object.o1": {
+        "type": "object",
+        "properties": {
+          "arch": {
+            "$ref": "#/components/schemas/_singlequote_process_singlequote_.global.NodeJS.Architecture"
+          },
+          "platform": {
+            "$ref": "#/components/schemas/_singlequote_process_singlequote_.global.NodeJS.Platform"
+          },
+          "versions": {
+            "$ref": "#/components/schemas/_singlequote_process_singlequote_.global.NodeJS.ProcessVersions"
+          }
+        },
+        "nullable": false,
+        "required": [
+          "arch",
+          "platform",
+          "versions"
+        ],
+        "x-typia-jsDocTags": []
+      },
+      "_singlequote_process_singlequote_.global.NodeJS.Architecture": {
+        "type": "string",
+        "enum": [
+          "arm",
+          "arm64",
+          "ia32",
+          "mips",
+          "mipsel",
+          "ppc",
+          "ppc64",
+          "s390",
+          "s390x",
+          "x64"
+        ]
+      },
+      "_singlequote_process_singlequote_.global.NodeJS.Platform": {
+        "type": "string",
+        "enum": [
+          "aix",
+          "android",
+          "darwin",
+          "freebsd",
+          "haiku",
+          "linux",
+          "openbsd",
+          "sunos",
+          "win32",
+          "cygwin",
+          "netbsd"
+        ]
+      },
+      "_singlequote_process_singlequote_.global.NodeJS.ProcessVersions": {
+        "type": "object",
+        "properties": {
+          "http_parser": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "string"
+          },
+          "node": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "string"
+          },
+          "v8": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "string"
+          },
+          "ares": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "string"
+          },
+          "uv": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "string"
+          },
+          "zlib": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "string"
+          },
+          "modules": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "string"
+          },
+          "openssl": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "string"
+          }
+        },
+        "nullable": false,
+        "required": [
+          "http_parser",
+          "node",
+          "v8",
+          "ares",
+          "uv",
+          "zlib",
+          "modules",
+          "openssl"
+        ],
+        "x-typia-jsDocTags": [],
+        "x-typia-additionalProperties": {
+          "x-typia-required": false,
+          "x-typia-optional": false,
+          "type": "string"
+        },
+        "additionalProperties": {
+          "x-typia-required": false,
+          "x-typia-optional": false,
+          "type": "string"
+        }
+      },
+      "__object.o2": {
+        "type": "object",
+        "properties": {
+          "cpu": {
+            "$ref": "#/components/schemas/_singlequote_process_singlequote_.global.NodeJS.CpuUsage"
+          },
+          "memory": {
+            "$ref": "#/components/schemas/_singlequote_process_singlequote_.global.NodeJS.MemoryUsage"
+          },
+          "resource": {
+            "$ref": "#/components/schemas/_singlequote_process_singlequote_.global.NodeJS.ResourceUsage"
+          }
+        },
+        "nullable": false,
+        "required": [
+          "cpu",
+          "memory",
+          "resource"
+        ],
+        "x-typia-jsDocTags": []
+      },
+      "__object.o3": {
+        "type": "object",
+        "properties": {
+          "cpu": {
+            "$ref": "#/components/schemas/_singlequote_process_singlequote_.global.NodeJS.CpuUsage"
+          },
+          "memory": {
+            "$ref": "#/components/schemas/_singlequote_process_singlequote_.global.NodeJS.MemoryUsage"
+          },
+          "resource": {
+            "$ref": "#/components/schemas/_singlequote_process_singlequote_.global.NodeJS.ResourceUsage"
+          }
+        },
+        "nullable": false,
+        "required": [
+          "cpu",
+          "memory",
+          "resource"
+        ],
+        "x-typia-jsDocTags": []
+      },
+      "__object.o4": {
+        "type": "object",
+        "properties": {
+          "cpu": {
+            "$ref": "#/components/schemas/_singlequote_process_singlequote_.global.NodeJS.CpuUsage"
+          },
+          "memory": {
+            "$ref": "#/components/schemas/_singlequote_process_singlequote_.global.NodeJS.MemoryUsage"
+          },
+          "resource": {
+            "$ref": "#/components/schemas/_singlequote_process_singlequote_.global.NodeJS.ResourceUsage"
+          }
+        },
+        "nullable": false,
+        "required": [
+          "cpu",
+          "memory",
+          "resource"
+        ],
+        "x-typia-jsDocTags": []
+      },
+      "__object.o5": {
+        "type": "object",
+        "properties": {
+          "arch": {
+            "$ref": "#/components/schemas/_singlequote_process_singlequote_.global.NodeJS.Architecture"
+          },
+          "platform": {
+            "$ref": "#/components/schemas/_singlequote_process_singlequote_.global.NodeJS.Platform"
+          },
+          "versions": {
+            "$ref": "#/components/schemas/_singlequote_process_singlequote_.global.NodeJS.ProcessVersions"
+          }
+        },
+        "nullable": false,
+        "required": [
+          "arch",
+          "platform",
+          "versions"
+        ],
+        "x-typia-jsDocTags": []
+      },
+      "__object.o6": {
+        "type": "object",
+        "properties": {
+          "cpu": {
+            "$ref": "#/components/schemas/_singlequote_process_singlequote_.global.NodeJS.CpuUsage"
+          },
+          "memory": {
+            "$ref": "#/components/schemas/_singlequote_process_singlequote_.global.NodeJS.MemoryUsage"
+          },
+          "resource": {
+            "$ref": "#/components/schemas/_singlequote_process_singlequote_.global.NodeJS.ResourceUsage"
+          }
+        },
+        "nullable": false,
+        "required": [
+          "cpu",
+          "memory",
+          "resource"
+        ],
+        "x-typia-jsDocTags": []
+      },
+      "__object.o7": {
+        "type": "object",
+        "properties": {
+          "cpu": {
+            "$ref": "#/components/schemas/_singlequote_process_singlequote_.global.NodeJS.CpuUsage"
+          },
+          "memory": {
+            "$ref": "#/components/schemas/_singlequote_process_singlequote_.global.NodeJS.MemoryUsage"
+          },
+          "resource": {
+            "$ref": "#/components/schemas/_singlequote_process_singlequote_.global.NodeJS.ResourceUsage"
+          }
+        },
+        "nullable": false,
+        "required": [
+          "cpu",
+          "memory",
+          "resource"
+        ],
+        "x-typia-jsDocTags": []
+      },
+      "__object.o8": {
+        "type": "object",
+        "properties": {
+          "arch": {
+            "$ref": "#/components/schemas/_singlequote_process_singlequote_.global.NodeJS.Architecture"
+          },
+          "platform": {
+            "$ref": "#/components/schemas/_singlequote_process_singlequote_.global.NodeJS.Platform"
+          },
+          "versions": {
+            "$ref": "#/components/schemas/_singlequote_process_singlequote_.global.NodeJS.ProcessVersions"
+          }
+        },
+        "nullable": false,
+        "required": [
+          "arch",
+          "platform",
+          "versions"
+        ],
+        "x-typia-jsDocTags": []
+      },
+      "__object.o9": {
+        "type": "object",
+        "properties": {
+          "cpu": {
+            "$ref": "#/components/schemas/_singlequote_process_singlequote_.global.NodeJS.CpuUsage"
+          },
+          "memory": {
+            "$ref": "#/components/schemas/_singlequote_process_singlequote_.global.NodeJS.MemoryUsage"
+          },
+          "resource": {
+            "$ref": "#/components/schemas/_singlequote_process_singlequote_.global.NodeJS.ResourceUsage"
+          }
+        },
+        "nullable": false,
+        "required": [
+          "cpu",
+          "memory",
+          "resource"
+        ],
+        "x-typia-jsDocTags": []
+      },
+      "__object.o10": {
+        "type": "object",
+        "properties": {
+          "arch": {
+            "$ref": "#/components/schemas/_singlequote_process_singlequote_.global.NodeJS.Architecture"
+          },
+          "platform": {
+            "$ref": "#/components/schemas/_singlequote_process_singlequote_.global.NodeJS.Platform"
+          },
+          "versions": {
+            "$ref": "#/components/schemas/_singlequote_process_singlequote_.global.NodeJS.ProcessVersions"
+          }
+        },
+        "nullable": false,
+        "required": [
+          "arch",
+          "platform",
+          "versions"
+        ],
+        "x-typia-jsDocTags": []
+      }
+    },
+    "securitySchemes": {
+      "bearer": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "Authorization"
+      }
+    }
+  },
+  "security": [
+    {
+      "bearer": []
+    }
+  ]
+}

--- a/test/features/implicit-error/tsconfig.json
+++ b/test/features/implicit-error/tsconfig.json
@@ -1,0 +1,98 @@
+{
+    "compilerOptions": {
+      /* Visit https://aka.ms/tsconfig to read more about this file */
+      /* Projects */
+      // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
+      // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+      // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
+      // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
+      // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+      // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+      /* Language and Environment */
+      "target": "es2016", /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */// "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+      // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+      "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
+      "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+      // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
+      // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+      // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
+      // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
+      // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+      // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+      // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
+      /* Modules */
+      "module": "commonjs", /* Specify what module code is generated. */// "rootDir": "./",                                  /* Specify the root folder within your source files. */
+      // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
+      // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+      "paths": {
+        "@api": ["./src/api"],
+        "@api/lib/*": ["./src/api/*"],
+      },                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+      // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+      // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+      // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+      // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+      // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
+      // "resolveJsonModule": true,                        /* Enable importing .json files. */
+      // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
+      /* JavaScript Support */
+      // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+      // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+      // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
+      /* Emit */
+      // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+      // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+      // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+      // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+      // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
+      // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+      // "removeComments": true,                           /* Disable emitting comments. */
+      "noEmit": true,                                   /* Disable emitting files from a compilation. */
+      // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+      // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
+      // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+      // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+      // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+      // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+      // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+      // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+      // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+      // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
+      // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
+      // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+      // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
+      // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+      // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
+      /* Interop Constraints */
+      // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+      // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+      "esModuleInterop": true, /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */// "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+      "forceConsistentCasingInFileNames": true, /* Ensure that casing is correct in imports. *//* Type Checking */
+      "strict": true, /* Enable all strict type-checking options. */// "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+      // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
+      // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+      // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
+      // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+      // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
+      // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+      // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+      // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
+      // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
+      // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+      // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+      // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+      // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+      // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+      // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
+      // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+      // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+      /* Completeness */
+      // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+      "skipLibCheck": true, /* Skip type checking all .d.ts files. */
+      "plugins": [
+        { "transform": "typescript-transform-paths" },
+        { "transform": "typia/lib/transform" },
+        { "transform": "@nestia/core/lib/transform" },
+      ],
+    }
+  }

--- a/test/features/non-strict-error/nestia.config.ts
+++ b/test/features/non-strict-error/nestia.config.ts
@@ -1,0 +1,15 @@
+import { INestiaConfig } from "@nestia/sdk";
+
+export const NESTIA_CONFIG: INestiaConfig = {
+    input: ["src/controllers"],
+    output: "src/api",
+    swagger: {
+        output: "swagger.json",
+        security: {
+            bearer: {
+                type: "apiKey",
+            },
+        },
+    },
+};
+export default NESTIA_CONFIG;

--- a/test/features/non-strict-error/src/controllers/HealthController.ts
+++ b/test/features/non-strict-error/src/controllers/HealthController.ts
@@ -1,0 +1,9 @@
+import { Controller } from "@nestjs/common";
+
+import core from "@nestia/core";
+
+@Controller("health")
+export class HealthController {
+    @core.TypedRoute.Get()
+    public get(): void {}
+}

--- a/test/features/non-strict-error/tsconfig.json
+++ b/test/features/non-strict-error/tsconfig.json
@@ -1,0 +1,95 @@
+{
+    "compilerOptions": {
+      /* Visit https://aka.ms/tsconfig to read more about this file */
+      /* Projects */
+      // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
+      // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+      // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
+      // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
+      // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+      // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+      /* Language and Environment */
+      "target": "es2016", /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */// "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+      // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+      "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
+      "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+      // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
+      // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+      // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
+      // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
+      // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+      // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+      // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
+      /* Modules */
+      "module": "commonjs", /* Specify what module code is generated. */// "rootDir": "./",                                  /* Specify the root folder within your source files. */
+      // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
+      // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+      // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+      // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+      // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+      // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+      // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+      // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
+      // "resolveJsonModule": true,                        /* Enable importing .json files. */
+      // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
+      /* JavaScript Support */
+      // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+      // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+      // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
+      /* Emit */
+      // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+      // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+      // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+      // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+      // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
+      // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+      // "removeComments": true,                           /* Disable emitting comments. */
+      "noEmit": true,                                   /* Disable emitting files from a compilation. */
+      // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+      // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
+      // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+      // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+      // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+      // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+      // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+      // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+      // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+      // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
+      // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
+      // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+      // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
+      // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+      // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
+      /* Interop Constraints */
+      // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+      // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+      "esModuleInterop": true, /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */// "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+      "forceConsistentCasingInFileNames": true, /* Ensure that casing is correct in imports. *//* Type Checking */
+      // "strict": true, /* Enable all strict type-checking options. */// "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+      // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
+      // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+      // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
+      // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+      // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
+      // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+      // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+      // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
+      // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
+      // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+      // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+      // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+      // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+      // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+      // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
+      // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+      // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+      /* Completeness */
+      // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+      "skipLibCheck": true, /* Skip type checking all .d.ts files. */
+      "plugins": [
+        { "transform": "typescript-transform-paths" },
+        { "transform": "typia/lib/transform" },
+        { "transform": "@nestia/core/lib/transform" },
+      ],
+    }
+  }

--- a/test/features/non-strictNullChecks-but-strict-error/nestia.config.ts
+++ b/test/features/non-strictNullChecks-but-strict-error/nestia.config.ts
@@ -1,0 +1,15 @@
+import { INestiaConfig } from "@nestia/sdk";
+
+export const NESTIA_CONFIG: INestiaConfig = {
+    input: ["src/controllers"],
+    output: "src/api",
+    swagger: {
+        output: "swagger.json",
+        security: {
+            bearer: {
+                type: "apiKey",
+            },
+        },
+    },
+};
+export default NESTIA_CONFIG;

--- a/test/features/non-strictNullChecks-but-strict-error/src/controllers/HealthController.ts
+++ b/test/features/non-strictNullChecks-but-strict-error/src/controllers/HealthController.ts
@@ -1,0 +1,9 @@
+import { Controller } from "@nestjs/common";
+
+import core from "@nestia/core";
+
+@Controller("health")
+export class HealthController {
+    @core.TypedRoute.Get()
+    public get(): void {}
+}

--- a/test/features/non-strictNullChecks-but-strict-error/tsconfig.json
+++ b/test/features/non-strictNullChecks-but-strict-error/tsconfig.json
@@ -1,0 +1,95 @@
+{
+    "compilerOptions": {
+      /* Visit https://aka.ms/tsconfig to read more about this file */
+      /* Projects */
+      // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
+      // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+      // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
+      // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
+      // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+      // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+      /* Language and Environment */
+      "target": "es2016", /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */// "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+      // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+      "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
+      "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+      // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
+      // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+      // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
+      // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
+      // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+      // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+      // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
+      /* Modules */
+      "module": "commonjs", /* Specify what module code is generated. */// "rootDir": "./",                                  /* Specify the root folder within your source files. */
+      // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
+      // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+      // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+      // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+      // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+      // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+      // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+      // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
+      // "resolveJsonModule": true,                        /* Enable importing .json files. */
+      // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
+      /* JavaScript Support */
+      // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+      // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+      // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
+      /* Emit */
+      // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+      // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+      // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+      // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+      // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
+      // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+      // "removeComments": true,                           /* Disable emitting comments. */
+      "noEmit": true,                                   /* Disable emitting files from a compilation. */
+      // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+      // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
+      // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+      // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+      // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+      // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+      // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+      // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+      // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+      // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
+      // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
+      // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+      // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
+      // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+      // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
+      /* Interop Constraints */
+      // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+      // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+      "esModuleInterop": true, /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */// "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+      "forceConsistentCasingInFileNames": true, /* Ensure that casing is correct in imports. *//* Type Checking */
+      "strict": true, /* Enable all strict type-checking options. */// "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+      "strictNullChecks": false,                         /* When type checking, take into account 'null' and 'undefined'. */
+      // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+      // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
+      // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+      // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
+      // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+      // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+      // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
+      // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
+      // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+      // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+      // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+      // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+      // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+      // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
+      // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+      // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+      /* Completeness */
+      // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+      "skipLibCheck": true, /* Skip type checking all .d.ts files. */
+      "plugins": [
+        { "transform": "typescript-transform-paths" },
+        { "transform": "typia/lib/transform" },
+        { "transform": "@nestia/core/lib/transform" },
+      ],
+    }
+  }

--- a/test/features/non-strictNullChecks-error/nestia.config.ts
+++ b/test/features/non-strictNullChecks-error/nestia.config.ts
@@ -1,0 +1,15 @@
+import { INestiaConfig } from "@nestia/sdk";
+
+export const NESTIA_CONFIG: INestiaConfig = {
+    input: ["src/controllers"],
+    output: "src/api",
+    swagger: {
+        output: "swagger.json",
+        security: {
+            bearer: {
+                type: "apiKey",
+            },
+        },
+    },
+};
+export default NESTIA_CONFIG;

--- a/test/features/non-strictNullChecks-error/src/controllers/HealthController.ts
+++ b/test/features/non-strictNullChecks-error/src/controllers/HealthController.ts
@@ -1,0 +1,9 @@
+import { Controller } from "@nestjs/common";
+
+import core from "@nestia/core";
+
+@Controller("health")
+export class HealthController {
+    @core.TypedRoute.Get()
+    public get(): void {}
+}

--- a/test/features/non-strictNullChecks-error/tsconfig.json
+++ b/test/features/non-strictNullChecks-error/tsconfig.json
@@ -1,0 +1,95 @@
+{
+    "compilerOptions": {
+      /* Visit https://aka.ms/tsconfig to read more about this file */
+      /* Projects */
+      // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
+      // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+      // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
+      // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
+      // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+      // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+      /* Language and Environment */
+      "target": "es2016", /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */// "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+      // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+      "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
+      "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+      // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
+      // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+      // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
+      // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
+      // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+      // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+      // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
+      /* Modules */
+      "module": "commonjs", /* Specify what module code is generated. */// "rootDir": "./",                                  /* Specify the root folder within your source files. */
+      // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
+      // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+      // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+      // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+      // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+      // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+      // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+      // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
+      // "resolveJsonModule": true,                        /* Enable importing .json files. */
+      // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
+      /* JavaScript Support */
+      // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+      // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+      // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
+      /* Emit */
+      // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+      // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+      // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+      // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+      // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
+      // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+      // "removeComments": true,                           /* Disable emitting comments. */
+      "noEmit": true,                                   /* Disable emitting files from a compilation. */
+      // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+      // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
+      // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+      // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+      // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+      // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+      // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+      // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+      // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+      // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
+      // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
+      // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+      // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
+      // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+      // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
+      /* Interop Constraints */
+      // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+      // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+      "esModuleInterop": true, /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */// "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+      "forceConsistentCasingInFileNames": true, /* Ensure that casing is correct in imports. *//* Type Checking */
+      // "strict": true, /* Enable all strict type-checking options. */// "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+      "strictNullChecks": false,                         /* When type checking, take into account 'null' and 'undefined'. */
+      // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+      // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
+      // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+      // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
+      // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+      // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+      // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
+      // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
+      // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+      // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+      // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+      // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+      // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+      // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
+      // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+      // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+      /* Completeness */
+      // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+      "skipLibCheck": true, /* Skip type checking all .d.ts files. */
+      "plugins": [
+        { "transform": "typescript-transform-paths" },
+        { "transform": "typia/lib/transform" },
+        { "transform": "@nestia/core/lib/transform" },
+      ],
+    }
+  }

--- a/test/package.json
+++ b/test/package.json
@@ -39,9 +39,9 @@
     "typia": "^4.0.2",
     "uuid": "^9.0.0",
     "nestia": "../packages/cli/nestia-4.2.1.tgz",
-    "@nestia/core": "../packages/core/nestia-core-1.3.3.tgz",
+    "@nestia/core": "../packages/core/nestia-core-1.3.4.tgz",
     "@nestia/e2e": "../packages/e2e/nestia-e2e-0.3.2.tgz",
     "@nestia/fetcher": "../packages/fetcher/nestia-fetcher-1.3.1.tgz",
-    "@nestia/sdk": "../packages/sdk/nestia-sdk-1.3.9.tgz"
+    "@nestia/sdk": "../packages/sdk/nestia-sdk-1.3.10.tgz"
   }
 }


### PR DESCRIPTION
Too many `nestia` users are confusing by legacy projects that had configured `strictNullChecks: false`, and mis-report to my repo saying "nestia seems broken". 

I think it would better to entirely prohibit `strictNullChecks: false` option in compliation level. Therefore, since v4.0.4 update, `strictNullChecks: false` would be compilation error in every nestia utilizing projects.

Also, made SDK generator to prohibit implicit return in controller method without any type definition. It's because if SDK allows object literal expression without type definition, client developers utilizing the SDK library would be crazy due to they have to read backend server code.