### PR TITLE
Fix `npx nestia start <directory> --manager <manager>`

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestia",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "Nestia CLI tool",
   "main": "bin/index.js",
   "bin": {

--- a/packages/cli/src/NestiaStarter.ts
+++ b/packages/cli/src/NestiaStarter.ts
@@ -7,9 +7,17 @@ export namespace NestiaStarter {
         async (argv: string[]): Promise<void> => {
             // VALIDATION
             const dest: string | undefined = argv[0];
-            const manager: string = argv[1] ?? "npm";
-
+            const manager: string =
+                argv[1] === "--manager" && argv[2] ? argv[2] : "npm";
             if (dest === undefined) halter();
+            else if (
+                manager !== "npm" &&
+                manager !== "yarn" &&
+                manager !== "pnpm"
+            )
+                throw new Error(
+                    "Invalid package manager. Only npm, yarn, and pnpm are supported.",
+                );
             else if (fs.existsSync(dest) === true)
                 halter("The target directory already exists.");
 


### PR DESCRIPTION
In CLI manual, there had been manager specification option, but had not supported for a long time.

Therefore, updated to support the `npx nestia start <directory> --manager <manager>` command.