### PR TITLE
Prohibit manager arugment in `npx nestia start` command

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestia",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "Nestia CLI tool",
   "main": "bin/index.js",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestia",
-  "version": "4.2.3",
+  "version": "4.3.0",
   "description": "Nestia CLI tool",
   "main": "bin/index.js",
   "bin": {

--- a/packages/cli/src/NestiaStarter.ts
+++ b/packages/cli/src/NestiaStarter.ts
@@ -33,7 +33,7 @@ export namespace NestiaStarter {
             process.chdir(dest);
 
             // INSTALL DEPENDENCIES
-            execute(`${manager} install`);
+            execute(manager === "yarn" ? "yarn" : `${manager} install`);
 
             // BUILD TYPESCRIPT
             execute("npm run build");

--- a/packages/cli/src/NestiaStarter.ts
+++ b/packages/cli/src/NestiaStarter.ts
@@ -7,17 +7,7 @@ export namespace NestiaStarter {
         async (argv: string[]): Promise<void> => {
             // VALIDATION
             const dest: string | undefined = argv[0];
-            const manager: string =
-                argv[1] === "--manager" && argv[2] ? argv[2] : "npm";
             if (dest === undefined) halter();
-            else if (
-                manager !== "npm" &&
-                manager !== "yarn" &&
-                manager !== "pnpm"
-            )
-                throw new Error(
-                    "Invalid package manager. Only npm, yarn, and pnpm are supported.",
-                );
             else if (fs.existsSync(dest) === true)
                 halter("The target directory already exists.");
 
@@ -33,7 +23,7 @@ export namespace NestiaStarter {
             process.chdir(dest);
 
             // INSTALL DEPENDENCIES
-            execute(manager === "yarn" ? "yarn" : `${manager} install`);
+            execute("npm install");
 
             // BUILD TYPESCRIPT
             execute("npm run build");

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,9 +3,7 @@ const USAGE = `Wrong command has been detected. Use like below:
 
 npx nestia [command] [options?]
 
-  1. npx nestia start <directory> --manager (npm|pnpm|yarn)
-    - npx nestia start project
-    - npx nestia start project --manager pnpm
+  1. npx nestia start <directory>
   2. npx nestia setup
   3. npx nestia dependencies
   4. npx nestia init


### PR DESCRIPTION
In Windows, `npx` command from non-installed (both local and global) package does not allow `--` argument. Therefore, configuring package manager in `npx nestia start <diretory> --manager yarn` command was not possible.

Therefore, prohibit the `--manager` argument and just enforce only to use `npm` package manager in the `npx nestia start <directory>` command. There's no way at now.