### PR TITLE
Upgrade peerDependencies of TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,18 @@ Nestia is a set of helper libraries for NestJS, supporting below features:
     - SDK generator for clients
     - Swagger generator evolved than ever
     - Automatic E2E test functions generator
+    - Backend Simulator for client applications
   - `nestia`: just CLI (command line interface) tool
 
 > **Note**
 > 
 > - **Only one line** required, with pure TypeScript type
-> - Runtime validator is **20,000x faster** than `class-validator`
-> - JSON serialization is **200x faster** than `class-transformer`
-> - SDK is similar with [tRPC](https://trpc.io), but much advanced
+> - Enhance performance **30x** up
+>   - Runtime validator is **20,000x faster** than `class-validator`
+>   - JSON serialization is **200x faster** than `class-transformer`
+> - Software Development Kit
+>   - SDK is similar with [tRPC](https://trpc.io), but much advanced
+>   - Simulator is similar with [msw](https://mswjs.io/), but fully automated
 
 ![nestia-sdk-demo](https://user-images.githubusercontent.com/13158709/215004990-368c589d-7101-404e-b81b-fbc936382f05.gif)
 
@@ -58,3 +62,4 @@ Check out the document in the [website](https://nestia.io/docs/):
     - [Swagger Documents](https://nestia.io/docs/sdk/swagger/)
     - [SDK Library](https://nestia.io/docs/sdk/sdk/)
     - [E2E Functions](https://nestia.io/docs/sdk/e2e/)
+    - [Simulation Mode](https://nestia.io/docs/sdk/simulation/)

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -14,14 +14,18 @@ Nestia is a set of helper libraries for NestJS, supporting below features:
     - SDK generator for clients
     - Swagger generator evolved than ever
     - Automatic E2E test functions generator
+    - Backend Simulator for client applications
   - `nestia`: just CLI (command line interface) tool
 
 > **Note**
 > 
 > - **Only one line** required, with pure TypeScript type
-> - Runtime validator is **20,000x faster** than `class-validator`
-> - JSON serialization is **200x faster** than `class-transformer`
-> - SDK is similar with [tRPC](https://trpc.io), but much advanced
+> - Enhance performance **30x** up
+>   - Runtime validator is **20,000x faster** than `class-validator`
+>   - JSON serialization is **200x faster** than `class-transformer`
+> - Software Development Kit
+>   - SDK is similar with [tRPC](https://trpc.io), but much advanced
+>   - Simulator is similar with [msw](https://mswjs.io/), but fully automated
 
 ![nestia-sdk-demo](https://user-images.githubusercontent.com/13158709/215004990-368c589d-7101-404e-b81b-fbc936382f05.gif)
 
@@ -46,9 +50,9 @@ Check out the document in the [website](https://nestia.io/docs/):
 ### 🏠 Home
   - [Introduction](https://nestia.io/docs/)
   - [Setup](https://nestia.io/docs/setup/)
+  - [Pure TypeScript](https://nestia.io/docs/pure)
 
 ### 📖 Features
-  - [Pure TypeScript](https://nestia.io/docs/pure)
   - Core Library
     - [TypedRoute](https://nestia.io/docs/core/TypedRoute/)
     - [TypedBody](https://nestia.io/docs/core/TypedBody/)
@@ -58,3 +62,4 @@ Check out the document in the [website](https://nestia.io/docs/):
     - [Swagger Documents](https://nestia.io/docs/sdk/swagger/)
     - [SDK Library](https://nestia.io/docs/sdk/sdk/)
     - [E2E Functions](https://nestia.io/docs/sdk/e2e/)
+    - [Simulation Mode](https://nestia.io/docs/sdk/simulation/)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/core",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Super-fast validation decorators of NestJS",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -34,7 +34,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^1.2.1",
+    "@nestia/fetcher": "^1.3.3",
     "@nestjs/common": ">= 7.0.1",
     "@nestjs/core": ">= 7.0.1",
     "@nestjs/platform-express": ">= 7.0.1",
@@ -44,10 +44,10 @@
     "raw-body": ">= 2.0.0",
     "reflect-metadata": ">= 0.1.12",
     "rxjs": ">= 6.0.0",
-    "typia": "^4.0.4"
+    "typia": "^4.0.6"
   },
   "peerDependencies": {
-    "@nestia/fetcher": "^1.2.1",
+    "@nestia/fetcher": ">= 1.3.3",
     "@nestjs/common": ">= 7.0.1",
     "@nestjs/core": ">= 7.0.1",
     "@nestjs/platform-express": ">= 7.0.1",
@@ -55,8 +55,8 @@
     "raw-body": ">= 2.0.0",
     "reflect-metadata": ">= 0.1.12",
     "rxjs": ">= 6.0.0",
-    "typescript": ">= 4.5.2",
-    "typia": ">= 4.0.3"
+    "typescript": ">= 4.7.4",
+    "typia": ">= 4.0.6"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.0.0",

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -14,14 +14,18 @@ Nestia is a set of helper libraries for NestJS, supporting below features:
     - SDK generator for clients
     - Swagger generator evolved than ever
     - Automatic E2E test functions generator
+    - Backend Simulator for client applications
   - `nestia`: just CLI (command line interface) tool
 
 > **Note**
 > 
 > - **Only one line** required, with pure TypeScript type
-> - Runtime validator is **20,000x faster** than `class-validator`
-> - JSON serialization is **200x faster** than `class-transformer`
-> - SDK is similar with [tRPC](https://trpc.io), but much advanced
+> - Enhance performance **30x** up
+>   - Runtime validator is **20,000x faster** than `class-validator`
+>   - JSON serialization is **200x faster** than `class-transformer`
+> - Software Development Kit
+>   - SDK is similar with [tRPC](https://trpc.io), but much advanced
+>   - Simulator is similar with [msw](https://mswjs.io/), but fully automated
 
 ![nestia-sdk-demo](https://user-images.githubusercontent.com/13158709/215004990-368c589d-7101-404e-b81b-fbc936382f05.gif)
 
@@ -46,9 +50,9 @@ Check out the document in the [website](https://nestia.io/docs/):
 ### 🏠 Home
   - [Introduction](https://nestia.io/docs/)
   - [Setup](https://nestia.io/docs/setup/)
+  - [Pure TypeScript](https://nestia.io/docs/pure)
 
 ### 📖 Features
-  - [Pure TypeScript](https://nestia.io/docs/pure)
   - Core Library
     - [TypedRoute](https://nestia.io/docs/core/TypedRoute/)
     - [TypedBody](https://nestia.io/docs/core/TypedBody/)
@@ -58,3 +62,4 @@ Check out the document in the [website](https://nestia.io/docs/):
     - [Swagger Documents](https://nestia.io/docs/sdk/swagger/)
     - [SDK Library](https://nestia.io/docs/sdk/sdk/)
     - [E2E Functions](https://nestia.io/docs/sdk/e2e/)
+    - [Simulation Mode](https://nestia.io/docs/sdk/simulation/)

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^1.3.2",
+    "@nestia/fetcher": "^1.3.3",
     "cli": "^1.0.1",
     "glob": "^7.2.0",
     "path-to-regexp": "^6.2.1",
@@ -43,16 +43,16 @@
     "tsconfck": "^2.0.1",
     "tsconfig-paths": "^4.1.1",
     "tstl": "^2.5.13",
-    "typia": "^4.0.4"
+    "typia": "^4.0.6"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">= 1.3.2",
+    "@nestia/fetcher": ">= 1.3.3",
     "@nestjs/common": ">= 7.0.1",
     "@nestjs/core": ">= 7.0.1",
     "reflect-metadata": ">= 0.1.12",
     "ts-node": ">= 10.6.0",
-    "typescript": ">= 4.5.2",
-    "typia": ">= 4.0.3"
+    "typescript": ">= 4.7.4",
+    "typia": ">= 4.0.6"
   },
   "devDependencies": {
     "@nestjs/common": ">= 7.0.1",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/sdk",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "description": "Nestia SDK and Swagger generator",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/test/package.json
+++ b/test/package.json
@@ -36,10 +36,10 @@
     "ts-patch": "v2.1.0",
     "typescript": "^4.9.5",
     "typescript-transform-paths": "^3.4.4",
-    "typia": "^4.0.2",
+    "typia": "^4.0.6",
     "uuid": "^9.0.0",
     "nestia": "../packages/cli/nestia-4.3.0.tgz",
-    "@nestia/core": "../packages/core/nestia-core-1.3.4.tgz",
+    "@nestia/core": "../packages/core/nestia-core-1.3.5.tgz",
     "@nestia/e2e": "../packages/e2e/nestia-e2e-0.3.2.tgz",
     "@nestia/fetcher": "../packages/fetcher/nestia-fetcher-1.3.3.tgz",
     "@nestia/sdk": "../packages/sdk/nestia-sdk-1.3.11.tgz"

--- a/website/pages/docs/index.mdx
+++ b/website/pages/docs/index.mdx
@@ -46,6 +46,7 @@ Nestia is a set of helper libraries for [NestJS](https://docs.nestjs.com), suppo
     - SDK generator for clients
     - Swagger generator evolved than ever
     - Automatic E2E test functions generator
+    - Backend Simulator for client developers
   - `nestia`: just CLI (command line interface) tool
 
 <br/>
@@ -54,13 +55,14 @@ Nestia is a set of helper libraries for [NestJS](https://docs.nestjs.com), suppo
         Only **one line** required, with pure TypeScript type
     </Alert>
     <Alert severity="success">
-        Runtime validator is **20,000x** faster than `class-validator`
+        Enhance performance **30x** up
+        - Runtime validator is **20,000x** faster than `class-validator`
+        - JSON serialization is **200x faster** than `class-transformer`
     </Alert>
-    <Alert severity="info">
-        JSON serialization is **200x faster** than `class-transformer`
-    </Alert>
-    <Alert severity="error">
-        SDK is similar with [tRPC](https://trpc.io), but much advanced
+    <Alert severity="info"> 
+        Software Development Kit
+        - SDK is similar with [tRPC](https://trpc.io), but much advanced
+        - Simulator is similar with [msw](https://mswjs.io/), but fully automated
     </Alert>
 </Stack>
 

--- a/website/pages/index.mdx
+++ b/website/pages/index.mdx
@@ -1,8 +1,6 @@
 import Alert from '@mui/material/Alert';
 import Stack from '@mui/material/Stack';
 
-<meta http-equiv="refresh" content="0; url=/docs" />
-
 ## Outline
 
 ![Nestia Logo](/logo.png)
@@ -44,10 +42,11 @@ import Stack from '@mui/material/Stack';
 Nestia is a set of helper libraries for [NestJS](https://docs.nestjs.com), supporting below features:
 
   - `@nestia/core`: super-fast decorators
-  - `@nestia/sdk`: 
+  - `@nestia/sdk`:
     - SDK generator for clients
     - Swagger generator evolved than ever
     - Automatic E2E test functions generator
+    - Backend Simulator for client developers
   - `nestia`: just CLI (command line interface) tool
 
 <br/>
@@ -56,15 +55,20 @@ Nestia is a set of helper libraries for [NestJS](https://docs.nestjs.com), suppo
         Only **one line** required, with pure TypeScript type
     </Alert>
     <Alert severity="success">
-        Runtime validator is **20,000x** faster than `class-validator`
+        Enhance performance **30x** up
+        - Runtime validator is **20,000x** faster than `class-validator`
+        - JSON serialization is **200x faster** than `class-transformer`
     </Alert>
-    <Alert severity="info">
-        JSON serialization is **200x faster** than `class-transformer`
-    </Alert>
-    <Alert severity="error">
-        SDK is similar with [tRPC](https://trpc.io), but much advanced
+    <Alert severity="info"> 
+        Software Development Kit
+        - SDK is similar with [tRPC](https://trpc.io), but much advanced
+        - Simulator is similar with [msw](https://mswjs.io/), but fully automated
     </Alert>
 </Stack>
+
+![SDK](https://user-images.githubusercontent.com/13158709/215004990-368c589d-7101-404e-b81b-fbc936382f05.gif)
+
+> Left is server code, and right is client (frontend) code
 
 
 


### PR DESCRIPTION
@kakasoo and @8471919 had contributed to enhance `Primitive` type. By the way, the new `Primitive` type requires at least TS 4.7.

Therefore, change `peerDependencies` config.