### PR TITLE
`npx nestia setup` to install CLI too.

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestia",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "description": "Nestia CLI tool",
   "main": "bin/index.js",
   "bin": {

--- a/packages/cli/src/NestiaSetupWizard.ts
+++ b/packages/cli/src/NestiaSetupWizard.ts
@@ -58,6 +58,7 @@ export namespace NestiaSetupWizard {
         pack.install({ dev: false, modulo: "@nestia/core", version: "latest" });
         pack.install({ dev: true, modulo: "@nestia/e2e", version: "latest" });
         pack.install({ dev: true, modulo: "@nestia/sdk", version: "latest" });
+        pack.install({ dev: true, modulo: "nestia", version: "latest" });
         await PluginConfigurator.configure(args);
     }
 }


### PR DESCRIPTION
Some users are installing CLI as global mode like below:

  - `npm install -g nestia`

If do like that, unable to utilize any other command like `npx nestia sdk` and `npx nestia swagger`. It is not what I've guided, but changed `npx nestia setup` to install `nestia` in local forcibly for them.

Therefore, from now on, weirdo users setting up `nestia` as global mode also can enjoy Nestia.