### PR TITLE
Update typia version

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/core",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "Super-fast validation decorators of NestJS",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -44,7 +44,7 @@
     "raw-body": ">= 2.0.0",
     "reflect-metadata": ">= 0.1.12",
     "rxjs": ">= 6.0.0",
-    "typia": "^4.0.10"
+    "typia": "^4.0.12"
   },
   "peerDependencies": {
     "@nestia/fetcher": ">= 1.3.4",
@@ -56,7 +56,7 @@
     "reflect-metadata": ">= 0.1.12",
     "rxjs": ">= 6.0.0",
     "typescript": ">= 4.7.4",
-    "typia": ">= 4.0.10"
+    "typia": ">= 4.0.12"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.0.0",

--- a/test/features/distribute-assert/packages/api/package.json
+++ b/test/features/distribute-assert/packages/api/package.json
@@ -34,6 +34,6 @@
   },
   "dependencies": {
     "@nestia/fetcher": "^1.3.4",
-    "typia": "^4.0.11"
+    "typia": "^4.0.12"
   }
 }

--- a/test/features/distribute-json/packages/api/package.json
+++ b/test/features/distribute-json/packages/api/package.json
@@ -34,6 +34,6 @@
   },
   "dependencies": {
     "@nestia/fetcher": "^1.3.4",
-    "typia": "^4.0.11"
+    "typia": "^4.0.12"
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -39,7 +39,7 @@
     "typia": "^4.0.11",
     "uuid": "^9.0.0",
     "nestia": "../packages/cli/nestia-4.3.2.tgz",
-    "@nestia/core": "../packages/core/nestia-core-1.3.8.tgz",
+    "@nestia/core": "../packages/core/nestia-core-1.3.9.tgz",
     "@nestia/e2e": "../packages/e2e/nestia-e2e-0.3.2.tgz",
     "@nestia/fetcher": "../packages/fetcher/nestia-fetcher-1.3.4.tgz",
     "@nestia/sdk": "../packages/sdk/nestia-sdk-1.3.16.tgz"


### PR DESCRIPTION
`typia@4.0.12` has optimized validation by function inlining. Threfore, `@nestia/core` also follows the update.