### PR TITLE
Complement #417 - update instead of replace

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/sdk",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Nestia SDK and Swagger generator",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/test/package.json
+++ b/test/package.json
@@ -42,6 +42,6 @@
     "@nestia/core": "../packages/core/nestia-core-1.4.1.tgz",
     "@nestia/e2e": "../packages/e2e/nestia-e2e-0.3.4.tgz",
     "@nestia/fetcher": "../packages/fetcher/nestia-fetcher-1.4.0.tgz",
-    "@nestia/sdk": "../packages/sdk/nestia-sdk-1.4.1.tgz"
+    "@nestia/sdk": "../packages/sdk/nestia-sdk-1.4.2.tgz"
   }
 }


### PR DESCRIPTION
To support `verbatimModuleSyntax` option of `tsconfig.json`, I'd changed bundled files generated by `@nestia/sdk`, and replaced those files when running `npx nestia sdk` command.

By the way, there have been someone that modifying those bundled files for customizations. For them, I've complemented the SDK generator to update specific import statements suitable for `verbatimModuleSyntax`, to keep their customizations.