### PR TITLE
Evolve e2e test functions and swagger generators

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/sdk",
-  "version": "1.4.5",
+  "version": "1.4.8",
   "description": "Nestia SDK and Swagger generator",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/sdk/src/generates/SwaggerGenerator.ts
+++ b/packages/sdk/src/generates/SwaggerGenerator.ts
@@ -434,9 +434,13 @@ export namespace SwaggerGenerator {
         type: ts.Type,
     ): IJsonSchema | null {
         const metadata: Metadata = MetadataFactory.analyze(checker)({
-            resolve: false,
+            resolve: true,
             constant: true,
             absorb: false,
+            validate: (meta) => {
+                if (meta.atomics.find((str) => str === "bigint"))
+                    throw new Error(NO_BIGIT);
+            },
         })(collection)(type);
         if (metadata.empty() && metadata.nullable === false) return null;
 
@@ -514,3 +518,5 @@ interface ISchemaTuple {
     metadata: Metadata;
     schema: IJsonSchema;
 }
+
+const NO_BIGIT = "Error on typia.application(): does not allow bigint type.";

--- a/packages/sdk/src/generates/internal/E2eFileProgrammer.ts
+++ b/packages/sdk/src/generates/internal/E2eFileProgrammer.ts
@@ -18,12 +18,15 @@ export namespace E2eFileProgrammer {
                     importDict.emplace(tuple[0], false, instance);
 
             const additional: string[] = [];
-            for (const param of route.parameters)
-                if (param.category === "param")
-                    if (param.meta?.type === "uuid") additional.push(UUID);
-                    else if (param.meta?.type === "date") additional.push(DATE);
+            for (const param of route.parameters) {
+                const type = getAdditional(param);
+                if (type === "uuid") additional.push(UUID);
+                else if (type === "date") additional.push(DATE);
+            }
+
             const content: string = [
-                ...(route.parameters.length || route.output.name !== "void"
+                ...(!!route.parameters.filter((p) => getAdditional(p) === null)
+                    .length || route.output.name !== "void"
                     ? [
                           config.primitive === false
                               ? `import typia from "typia";`
@@ -120,6 +123,13 @@ export namespace E2eFileProgrammer {
         (config: INestiaConfig) =>
         (name: string): string =>
             config.primitive !== false ? `Primitive<${name}>` : name;
+
+    const getAdditional = (param: IRoute.IParameter): "uuid" | "date" | null =>
+        param.category === "param" && param.meta?.type === "uuid"
+            ? "uuid"
+            : param.category === "param" && param.meta?.type === "date"
+            ? "date"
+            : null;
 }
 
 const UUID = `const uuid = (): string =>


### PR DESCRIPTION
When running `npx nestia e2e` command, Nestia sometimes write unused import statements. 

Fixed that bug.

Also, fixed swagger generator bug that cannot escapse `toJSON()` function