### PR TITLE
Support non-standard swagger.json generated by SpringDoc

### DIFF
--- a/packages/migrate/assets/input/.gitignore
+++ b/packages/migrate/assets/input/.gitignore
@@ -1,0 +1,1 @@
+kim-java.json

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/migrate",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Migration program from swagger to NestJS",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/migrate/src/programmers/ControllerProgrammer.ts
+++ b/packages/migrate/src/programmers/ControllerProgrammer.ts
@@ -57,12 +57,12 @@ export namespace ControllerProgrammer {
                     routes.map((r) => r.path),
                 );
                 for (const r of routes)
-                    r.path = StringUtil.reJoinWithoutParameters(
+                    r.path = StringUtil.reJoinWithDecimalParameters(
                         r.path.replace(prefix, ""),
                     );
                 const controller: IMigrateController = {
                     name: StringUtil.pascal(location) + "Controller",
-                    path: StringUtil.reJoinWithoutParameters(prefix),
+                    path: StringUtil.reJoinWithDecimalParameters(prefix),
                     location: "src/controllers/" + location,
                     routes,
                 };

--- a/packages/migrate/src/programmers/SchemaProgrammer.ts
+++ b/packages/migrate/src/programmers/SchemaProgrammer.ts
@@ -118,7 +118,7 @@ export namespace SchemaProgrammer {
     const writeObject =
         (references: ISwaggerSchema.IReference[]) =>
         (schema: ISwaggerSchema.IObject): string => {
-            const entries = Object.entries(schema.properties);
+            const entries = Object.entries(schema.properties ?? {});
             return typeof schema.additionalProperties === "object"
                 ? entries.length
                     ? `${writeStaticObject(references)(
@@ -136,7 +136,7 @@ export namespace SchemaProgrammer {
         (schema: ISwaggerSchema.IObject): string =>
             [
                 "{",
-                ...Object.entries(schema.properties)
+                ...Object.entries(schema.properties ?? {})
                     .map(([key, value]) =>
                         writeProperty(references)(key)(
                             (schema.required ?? []).some((r) => r === key),

--- a/packages/migrate/src/structures/ISwaggeSchema.ts
+++ b/packages/migrate/src/structures/ISwaggeSchema.ts
@@ -61,7 +61,7 @@ export namespace ISwaggerSchema {
         items: ISwaggerSchema[];
     }
     export interface IObject extends ISignificant<"object"> {
-        properties: Record<string, ISwaggerSchema>;
+        properties?: Record<string, ISwaggerSchema>;
         required?: string[];
         additionalProperties?: ISwaggerSchema | boolean;
         "x-typia-patternProperties"?: Record<string, ISwaggerSchema>;

--- a/packages/migrate/src/structures/ISwaggerRoute.ts
+++ b/packages/migrate/src/structures/ISwaggerRoute.ts
@@ -1,32 +1,32 @@
 import { ISwaggerSchema } from "./ISwaggeSchema";
 
 export interface ISwaggerRoute {
-    parameters: ISwaggerRoute.IParameter[];
+    parameters?: ISwaggerRoute.IParameter[];
     requestBody?: ISwaggerRoute.IRequestBody;
-    responses: ISwaggerRoute.IResponseBody;
+    responses?: ISwaggerRoute.IResponseBody;
     summary?: string;
     description?: string;
     deprecated?: boolean;
-    tags: string[];
+    tags?: string[];
 }
 export namespace ISwaggerRoute {
     export interface IParameter {
         name: string;
         in: "path" | "query" | "header" | "cookie";
         schema: ISwaggerSchema;
-        required: boolean;
-        description: string;
+        required?: boolean;
+        description?: string;
     }
     export interface IRequestBody {
-        description: string;
+        description?: string;
         content: IContent;
-        required: true;
-        "x-nestia-encrypted": boolean;
+        required?: true;
+        "x-nestia-encrypted"?: boolean;
     }
     export type IResponseBody = Record<
         string,
         {
-            description: string;
+            description?: string;
             content?: IContent;
             "x-nestia-encrypted"?: boolean;
         }

--- a/packages/migrate/src/utils/StringUtil.ts
+++ b/packages/migrate/src/utils/StringUtil.ts
@@ -19,7 +19,7 @@ export namespace StringUtil {
             .map((str) => normalize(str.trim()))
             .filter((str) => !!str.length);
 
-    export const reJoinWithoutParameters = (path: string) =>
+    export const reJoinWithDecimalParameters = (path: string) =>
         split(path)
             .map((str) =>
                 str[0] === "{" && str[str.length - 1] === "}"


### PR DESCRIPTION
When build `swagger.json` file from SpringDoc, it is not following the OpenAPI standard.

  - Omits some essential properties
  - Content-Type is a little bit weird (contains charset)

Therefore, fixed `@nestia/migrate` to even support the SpringDoc case.

