### PR TITLE
Enhance error message of SDK/swagger generator

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/sdk",
-  "version": "1.4.14",
+  "version": "1.4.15",
   "description": "Nestia SDK and Swagger generator",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/sdk/src/analyses/ControllerAnalyzer.ts
+++ b/packages/sdk/src/analyses/ControllerAnalyzer.ts
@@ -1,3 +1,4 @@
+import path from "path";
 import { HashMap } from "tstl/container/HashMap";
 import ts from "typescript";
 
@@ -166,9 +167,15 @@ export namespace ControllerAnalyzer {
             status: func.status,
 
             symbol: `${controller.name}.${func.name}()`,
-            location: `${declaration.getSourceFile().fileName}:${
-                declaration.pos
-            }`,
+            location: (() => {
+                const file = declaration.getSourceFile();
+                const { line, character } = file.getLineAndCharacterOfPosition(
+                    declaration.pos,
+                );
+                return `${path.relative(process.cwd(), file.fileName)}:${
+                    line + 1
+                }:${character + 1}`;
+            })(),
             description: CommentFactory.description(symbol),
             tags,
             setHeaders: tags

--- a/test/package.json
+++ b/test/package.json
@@ -45,6 +45,6 @@
     "@nestia/core": "../packages/core/nestia-core-1.4.4.tgz",
     "@nestia/e2e": "../packages/e2e/nestia-e2e-0.3.6.tgz",
     "@nestia/fetcher": "../packages/fetcher/nestia-fetcher-1.4.0.tgz",
-    "@nestia/sdk": "../packages/sdk/nestia-sdk-1.4.14.tgz"
+    "@nestia/sdk": "../packages/sdk/nestia-sdk-1.4.15.tgz"
   }
 }


### PR DESCRIPTION
When error being detected when generating SDK or Swagger Documents, its message became a little bit detailed.

1. Location of file path became relative
2. Line and Column numbers are added