### PR TITLE
Allow optional typed Array in `@TypedQuery()`

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/core",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "Super-fast validation decorators of NestJS",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/core/src/programmers/TypedQueryProgrammer.ts
+++ b/packages/core/src/programmers/TypedQueryProgrammer.ts
@@ -91,12 +91,6 @@ export namespace TypedQueryProgrammer {
                             "union type is not allowed",
                         ),
                     );
-                else if (value.isRequired() === false)
-                    throw new Error(
-                        ErrorMessages.property(obj)(key)(
-                            "array type cannot be optional",
-                        ),
-                    );
                 for (const array of value.arrays)
                     atom.push(...validate(obj)(key)(array.value, depth + 1));
                 for (const tuple of value.tuples)

--- a/test/features/query/src/api/structures/IQuery.ts
+++ b/test/features/query/src/api/structures/IQuery.ts
@@ -1,6 +1,6 @@
 export interface IQuery {
     limit?: number;
     enforce: boolean;
-    values: string[];
+    values?: string[];
     atomic: string | null;
 }

--- a/test/features/query/src/test/features/api/test_api_query_nest.ts
+++ b/test/features/query/src/test/features/api/test_api_query_nest.ts
@@ -15,10 +15,10 @@ export const test_api_query_nest = async (
         values: ["a", "b", "c"],
     };
     const result: IQuery = await api.functional.query.nest(connection, {
-        ...input,
         limit: input.limit ? `${input.limit}` : undefined,
         enforce: input.enforce ? "true" : "false",
         atomic: input.atomic ? input.atomic : "null",
+        values: input.values ?? [],
     });
     typia.assertEquals(result);
     TestValidator.equals("nest")(input)(result);

--- a/test/features/query/swagger.json
+++ b/test/features/query/swagger.json
@@ -166,12 +166,12 @@
             "type": "boolean"
           },
           "values": {
-            "x-typia-required": true,
-            "x-typia-optional": false,
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
-              "x-typia-required": true,
-              "x-typia-optional": false,
+              "x-typia-required": false,
+              "x-typia-optional": true,
               "type": "string"
             }
           },
@@ -185,7 +185,6 @@
         "nullable": false,
         "required": [
           "enforce",
-          "values",
           "atomic"
         ],
         "x-typia-jsDocTags": []
@@ -246,20 +245,19 @@
             "type": "boolean"
           },
           "values": {
-            "x-typia-required": true,
-            "x-typia-optional": false,
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
-              "x-typia-required": true,
-              "x-typia-optional": false,
+              "x-typia-required": false,
+              "x-typia-optional": true,
               "type": "string"
             }
           }
         },
         "nullable": false,
         "required": [
-          "enforce",
-          "values"
+          "enforce"
         ],
         "x-typia-jsDocTags": []
       }

--- a/test/package.json
+++ b/test/package.json
@@ -42,7 +42,7 @@
     "typia": "^4.1.8",
     "uuid": "^9.0.0",
     "nestia": "../packages/cli/nestia-4.3.2.tgz",
-    "@nestia/core": "../packages/core/nestia-core-1.4.4.tgz",
+    "@nestia/core": "../packages/core/nestia-core-1.4.5.tgz",
     "@nestia/e2e": "../packages/e2e/nestia-e2e-0.3.6.tgz",
     "@nestia/fetcher": "../packages/fetcher/nestia-fetcher-1.4.0.tgz",
     "@nestia/sdk": "../packages/sdk/nestia-sdk-1.4.17.tgz"


### PR DESCRIPTION
In [fireblocks](https://www.fireblocks.com/) case, its swagger API has an optional typed Array in query parameter. It seems nonsensible, but it is actually used in that way.

  - https://docs.fireblocks.com/api/v1/swagger.yaml

Therefore, allow optional typed Array in `@TypedQuery()`, and assign `undefined` value when the target property key never being used in the query string.

```typescript
export namespace IApiNftsOwnershipCollections {
    export type GetQuery = {
        /**
         * Search owned collections. Possible criteria for search: collection name, collection contract address.
         * 
         */
        search?: string;
        /**
         * Page cursor to fetch
         * 
         */
        pageCursor?: string;
        /**
         * Items per page (max 100)
         * 
         * @minimum 1
         * @maximum 100
         */
        pageSize?: number;
        /**
         * Sort by param, it can be one param or a list of params separated by comma
         * 
         */
        sort?: Array<"name">;
        /**
         * Order direction, it can be `ASC` for ascending or `DESC` for descending
         * 
         * @default ASC
         */
        order?: "DESC" | "ASC";
    }
}
```