### PR TITLE
Enhance #473 - `IConnection.Headerify` to be much stronger

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/core",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Super-fast validation decorators of NestJS",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -34,7 +34,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^1.5.0",
+    "@nestia/fetcher": "^1.5.1",
     "@nestjs/common": ">= 7.0.1",
     "@nestjs/core": ">= 7.0.1",
     "@nestjs/platform-express": ">= 7.0.1",
@@ -47,7 +47,7 @@
     "typia": "^4.1.13"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">= 1.5.0",
+    "@nestia/fetcher": ">= 1.5.1",
     "@nestjs/common": ">= 7.0.1",
     "@nestjs/core": ">= 7.0.1",
     "@nestjs/platform-express": ">= 7.0.1",
@@ -55,7 +55,7 @@
     "raw-body": ">= 2.0.0",
     "reflect-metadata": ">= 0.1.12",
     "rxjs": ">= 6.0.0",
-    "typescript": ">= 4.7.4",
+    "typescript": ">= 4.8.0",
     "typia": ">= 4.1.13"
   },
   "devDependencies": {

--- a/packages/core/src/decorators/TypedRoute.ts
+++ b/packages/core/src/decorators/TypedRoute.ts
@@ -107,10 +107,10 @@ export namespace TypedRoute {
     }
 }
 for (const method of [
+    stringify,
     isStringify,
     assertStringify,
     validateStringify,
-    stringify,
 ])
     for (const [key, value] of Object.entries(method))
         for (const deco of [

--- a/packages/core/src/programmers/TypedHeadersProgrammer.ts
+++ b/packages/core/src/programmers/TypedHeadersProgrammer.ts
@@ -199,13 +199,7 @@ export namespace TypedHeadersProgrammer {
                           ? [meta.atomics[0], true]
                           : [meta.constants[0]!.type, true];
                   })();
-            if (key.toLowerCase() !== key)
-                throw new Error(
-                    ErrorMessages.property(object)(key)(
-                        `property "${key}" must be lower case.`,
-                    ),
-                );
-            else if (isArray && SINGULAR.has(key))
+            if (isArray && SINGULAR.has(key))
                 throw new Error(
                     ErrorMessages.property(object)(key)(
                         `property "${key}" cannot be array.`,
@@ -220,7 +214,7 @@ export namespace TypedHeadersProgrammer {
 
             const accessor = IdentifierFactory.access(
                 ts.factory.createIdentifier("input"),
-            )(key);
+            )(key.toLowerCase());
 
             return ts.factory.createPropertyAssignment(
                 Escaper.variable(key)

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -40,7 +40,7 @@
     "ts-node": "^10.9.1",
     "ts-patch": "^3.0.0",
     "typescript": "^5.1.3",
-    "typia": "^4.1.8"
+    "typia": "^4.1.13"
   },
   "dependencies": {
     "chalk": "^4.1.2",

--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/fetcher",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Fetcher library of Nestia SDK",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -35,7 +35,7 @@
     "typescript": "^5.1.3"
   },
   "peerDependencies": {
-    "typescript": ">= 4.7.4"
+    "typescript": ">= 4.8.0"
   },
   "dependencies": {
     "import2": "^1.0.3",

--- a/packages/fetcher/src/IConnection.ts
+++ b/packages/fetcher/src/IConnection.ts
@@ -136,6 +136,11 @@ export namespace IConnection {
             | "unsafe-url";
     }
 
+    /**
+     * Type of allowed header values.
+     *
+     * Only atomic or array of atomic values are allowed.
+     */
     export type HeaderValue =
         | string
         | boolean
@@ -148,9 +153,67 @@ export namespace IConnection {
         | Array<number>
         | Array<string>;
 
+    /**
+     * Type of headers
+     *
+     * `Headerify` removes every properties that are not allowed in the
+     * HTTP headers type.
+     *
+     * Below are list of prohibited in HTTP headers.
+     *
+     * 1. Value type one of {@link HeaderValue}
+     * 2. Key is "set-cookie", but value is not an Array type
+     * 3. Key is one of them, but value is Array type
+     *   - "age"
+     *   - "authorization"
+     *   - "content-length"
+     *   - "content-type"
+     *   - "etag"
+     *   - "expires"
+     *   - "from"
+     *   - "host"
+     *   - "if-modified-since"
+     *   - "if-unmodified-since"
+     *   - "last-modified"
+     *   - "location"
+     *   - "max-forwards"
+     *   - "proxy-authorization"
+     *   - "referer"
+     *   - "retry-after"
+     *   - "server"
+     *   - "user-agent"
+     */
     export type Headerify<T extends object> = {
         [P in keyof T]?: T[P] extends HeaderValue | undefined
-            ? T[P] | undefined
+            ? P extends string
+                ? Lowercase<P> extends "set-cookie"
+                    ? T[P] extends Array<HeaderValue>
+                        ? T[P] | undefined
+                        : never
+                    : Lowercase<P> extends
+                          | "age"
+                          | "authorization"
+                          | "content-length"
+                          | "content-type"
+                          | "etag"
+                          | "expires"
+                          | "from"
+                          | "host"
+                          | "if-modified-since"
+                          | "if-unmodified-since"
+                          | "last-modified"
+                          | "location"
+                          | "max-forwards"
+                          | "proxy-authorization"
+                          | "referer"
+                          | "retry-after"
+                          | "server"
+                          | "user-agent"
+                    ? T[P] extends Array<HeaderValue>
+                        ? never
+                        : T[P] | undefined
+                    : T[P] | undefined
+                : never
             : never;
     };
 }

--- a/packages/fetcher/src/IEncryptionPassword.ts
+++ b/packages/fetcher/src/IEncryptionPassword.ts
@@ -15,7 +15,7 @@ export interface IEncryptionPassword {
     key: string;
 
     /**
-     * Initialization vector.
+     * Initialization Vector.
      */
     iv: string;
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/sdk",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Nestia SDK and Swagger generator",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -35,7 +35,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^1.5.0",
+    "@nestia/fetcher": "^1.5.1",
     "cli": "^1.0.1",
     "glob": "^7.2.0",
     "path-to-regexp": "^6.2.1",
@@ -47,12 +47,12 @@
     "typia": "^4.1.13"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">= 1.5.0",
+    "@nestia/fetcher": ">= 1.5.1",
     "@nestjs/common": ">= 7.0.1",
     "@nestjs/core": ">= 7.0.1",
     "reflect-metadata": ">= 0.1.12",
     "ts-node": ">= 10.6.0",
-    "typescript": ">= 4.7.4",
+    "typescript": ">= 4.8.0",
     "typia": ">= 4.1.13"
   },
   "devDependencies": {

--- a/packages/sdk/src/analyses/ReflectAnalyzer.ts
+++ b/packages/sdk/src/analyses/ReflectAnalyzer.ts
@@ -160,6 +160,9 @@ export namespace ReflectAnalyzer {
         // CONSTRUCTION
         //----
         // BASIC INFO
+        const encrypted: boolean =
+            Reflect.getMetadata(Constants.INTERCEPTORS_METADATA, proto)?.[0]
+                ?.constructor?.name === "EncryptedRouteInterceptor";
         const meta: IController.IFunction = {
             name,
             method: METHODS[
@@ -169,17 +172,16 @@ export namespace ReflectAnalyzer {
                 Reflect.getMetadata(Constants.PATH_METADATA, proto),
             ),
             parameters: [],
-            encrypted:
-                Reflect.getMetadata(Constants.INTERCEPTORS_METADATA, proto)?.[0]
-                    ?.constructor?.name === "EncryptedRouteInterceptor",
             status: Reflect.getMetadata(Constants.HTTP_CODE_METADATA, proto),
-            contentType:
-                Reflect.getMetadata(Constants.HEADERS_METADATA, proto)?.find(
-                    (h: Record<string, string>) =>
-                        typeof h?.name === "string" &&
-                        typeof h?.value === "string" &&
-                        h.name.toLowerCase() === "content-type",
-                )?.value ?? "application/json",
+            encrypted,
+            contentType: encrypted
+                ? "text/plain"
+                : Reflect.getMetadata(Constants.HEADERS_METADATA, proto)?.find(
+                      (h: Record<string, string>) =>
+                          typeof h?.name === "string" &&
+                          typeof h?.value === "string" &&
+                          h.name.toLowerCase() === "content-type",
+                  )?.value ?? "application/json",
             security: _Get_security(proto),
         };
 

--- a/packages/sdk/src/structures/ISwaggerRoute.ts
+++ b/packages/sdk/src/structures/ISwaggerRoute.ts
@@ -12,7 +12,7 @@ export interface ISwaggerRoute {
     description?: string;
     "x-nestia-method": string;
     "x-nestia-namespace": string;
-    "x-nestia-jsDocTags": IJsDocTagInfo[];
+    "x-nestia-jsDocTags"?: IJsDocTagInfo[];
 }
 export namespace ISwaggerRoute {
     export interface IParameter {

--- a/test/features/distribute-assert/packages/api/package.json
+++ b/test/features/distribute-assert/packages/api/package.json
@@ -8,7 +8,8 @@
     "build": "npm run build:sdk && npm run compile",
     "build:sdk": "rimraf ../../src/api/functional && cd ../.. && npx nestia sdk && cd packages/api",
     "compile": "rimraf lib && tsc",
-    "deploy": "npm run build && npm publish"
+    "deploy": "npm run build && npm publish",
+    "prepare": "ts-patch install"
   },
   "repository": {
     "type": "git",
@@ -26,9 +27,13 @@
     "README.md"
   ],
   "devDependencies": {
-    "rimraf": "^5.0.1"
+    "rimraf": "^5.0.1",
+    "ts-node": "^10.9.1",
+    "ts-patch": "^3.0.2",
+    "typescript": "^5.1.6"
   },
   "dependencies": {
-    "@nestia/fetcher": "^1.5.0"
+    "@nestia/fetcher": "^1.5.0",
+    "typia": "^4.1.13"
   }
 }

--- a/test/features/distribute-assert/packages/api/tsconfig.json
+++ b/test/features/distribute-assert/packages/api/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig to read more about this file */
-
     /* Projects */
     // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
     // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
@@ -9,14 +8,12 @@
     // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
     // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
-
     /* Language and Environment */
-    "target": "ES5",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "ES5", /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     "lib": [
       "DOM",
       "ES2015"
-    ],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
-    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+    ], /* Specify a set of bundled library declaration files that describe the target runtime environment. */// "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
     // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
     // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
@@ -26,10 +23,8 @@
     // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
     // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
-
     /* Modules */
-    "module": "commonjs",                                /* Specify what module code is generated. */
-    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    "module": "commonjs", /* Specify what module code is generated. */// "rootDir": "./",                                  /* Specify the root folder within your source files. */
     // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
@@ -40,47 +35,35 @@
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
     // "resolveJsonModule": true,                        /* Enable importing .json files. */
     // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
-
     /* JavaScript Support */
     // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
     // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
     // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
-
     /* Emit */
-    "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
-    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    "declaration": true, /* Generate .d.ts files from TypeScript and JavaScript files in your project. */// "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
-    "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
-    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    "outDir": "./lib",                                   /* Specify an output folder for all emitted files. */
-    // "removeComments": true,                           /* Disable emitting comments. */
+    "sourceMap": true, /* Create source map files for emitted JavaScript files. */// "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
+    "outDir": "./lib", /* Specify an output folder for all emitted files. */// "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
     // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
-    "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
-    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+    "downlevelIteration": true, /* Emit more compliant, but verbose and less performant JavaScript for iteration. */// "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
     // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
     // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
-    "newLine": "lf",                                /* Set the newline character for emitting files. */
-    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
+    "newLine": "lf", /* Set the newline character for emitting files. */// "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
     // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
     // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
     // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
     // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
     // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
-
     /* Interop Constraints */
     // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
     // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
-    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
-    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
-    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
-
-    /* Type Checking */
-    "strict": true,                                      /* Enable all strict type-checking options. */
-    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+    "esModuleInterop": true, /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */// "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+    "forceConsistentCasingInFileNames": true, /* Ensure that casing is correct in imports. *//* Type Checking */
+    "strict": true, /* Enable all strict type-checking options. */// "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
     // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
     // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
@@ -98,10 +81,15 @@
     // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
     // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
     // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
-
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": true,                                 /* Skip type checking all .d.ts files. */
+    "skipLibCheck": true, /* Skip type checking all .d.ts files. */
+    "plugins": [
+      {
+        "transform": "typia/lib/transform"
+      }
+    ],
+    "strictNullChecks": true
   },
   "include": [
     "../../src/api"

--- a/test/features/encrypted/swagger.json
+++ b/test/features/encrypted/swagger.json
@@ -72,7 +72,7 @@
           "201": {
             "description": "## Warning\nResponse data have been encrypted.\n\nThe response body data would be encrypted as \"AES-128(256) / CBC mode / PKCS#5 Padding / Base64 Encoding\", through the [EncryptedRoute.P.ost](https://github.com/samchon/@nestia/core#encryptedroute) component.\n\nTherefore, just utilize this swagger editor only for referencing. If you need to call the real API, using [SDK](https://github.com/samchon/nestia#software-development-kit) would be much better.\n\n-----------------\n\nInformation of newly joined seller",
             "content": {
-              "application/json": {
+              "text/plain": {
                 "schema": {
                   "$ref": "#/components/schemas/ISeller.IAuthorized"
                 }
@@ -144,7 +144,7 @@
           "201": {
             "description": "## Warning\nResponse data have been encrypted.\n\nThe response body data would be encrypted as \"AES-128(256) / CBC mode / PKCS#5 Padding / Base64 Encoding\", through the [EncryptedRoute.P.ost](https://github.com/samchon/@nestia/core#encryptedroute) component.\n\nTherefore, just utilize this swagger editor only for referencing. If you need to call the real API, using [SDK](https://github.com/samchon/nestia#software-development-kit) would be much better.\n\n-----------------\n\nInformation of the seller",
             "content": {
-              "application/json": {
+              "text/plain": {
                 "schema": {
                   "$ref": "#/components/schemas/ISeller.IAuthorized"
                 }

--- a/test/features/fastify/swagger.json
+++ b/test/features/fastify/swagger.json
@@ -351,7 +351,7 @@
           "201": {
             "description": "## Warning\nResponse data have been encrypted.\n\nThe response body data would be encrypted as \"AES-128(256) / CBC mode / PKCS#5 Padding / Base64 Encoding\", through the [EncryptedRoute.P.ost](https://github.com/samchon/@nestia/core#encryptedroute) component.\n\nTherefore, just utilize this swagger editor only for referencing. If you need to call the real API, using [SDK](https://github.com/samchon/nestia#software-development-kit) would be much better.\n\n-----------------\n\nInformation of newly joined seller",
             "content": {
-              "application/json": {
+              "text/plain": {
                 "schema": {
                   "$ref": "#/components/schemas/ISeller.IAuthorized"
                 }
@@ -423,7 +423,7 @@
           "201": {
             "description": "## Warning\nResponse data have been encrypted.\n\nThe response body data would be encrypted as \"AES-128(256) / CBC mode / PKCS#5 Padding / Base64 Encoding\", through the [EncryptedRoute.P.ost](https://github.com/samchon/@nestia/core#encryptedroute) component.\n\nTherefore, just utilize this swagger editor only for referencing. If you need to call the real API, using [SDK](https://github.com/samchon/nestia#software-development-kit) would be much better.\n\n-----------------\n\nInformation of the seller",
             "content": {
-              "application/json": {
+              "text/plain": {
                 "schema": {
                   "$ref": "#/components/schemas/ISeller.IAuthorized"
                 }

--- a/test/features/headers-decompose/src/api/structures/IHeaders.ts
+++ b/test/features/headers-decompose/src/api/structures/IHeaders.ts
@@ -4,5 +4,5 @@ export interface IHeaders {
     "x-name"?: string;
     "x-values": number[];
     "x-flags": boolean[];
-    "x-descriptions": string[];
+    "X-Descriptions": string[];
 }

--- a/test/features/headers-decompose/src/test/features/api/test_api_headers.ts
+++ b/test/features/headers-decompose/src/test/features/api/test_api_headers.ts
@@ -12,7 +12,7 @@ export const test_api_headers = async (
         ...typia.random<Required<IHeaders>>(),
         "x-values": [1, 2, 3],
         "x-flags": [true, false, true],
-        "x-descriptions": ["a", "b", "c"],
+        "X-Descriptions": ["a", "b", "c"],
     };
     const output: IHeaders = await api.functional.headers.emplace(
         {

--- a/test/features/headers-decompose/swagger.json
+++ b/test/features/headers-decompose/swagger.json
@@ -85,7 +85,7 @@
             "required": true
           },
           {
-            "name": "x-descriptions",
+            "name": "X-Descriptions",
             "in": "header",
             "schema": {
               "x-typia-required": true,
@@ -195,7 +195,7 @@
             "required": true
           },
           {
-            "name": "x-descriptions",
+            "name": "X-Descriptions",
             "in": "header",
             "schema": {
               "x-typia-required": true,
@@ -388,7 +388,7 @@
               "type": "boolean"
             }
           },
-          "x-descriptions": {
+          "X-Descriptions": {
             "x-typia-required": true,
             "x-typia-optional": false,
             "type": "array",
@@ -404,7 +404,7 @@
           "x-category",
           "x-values",
           "x-flags",
-          "x-descriptions"
+          "X-Descriptions"
         ],
         "x-typia-jsDocTags": []
       },

--- a/test/features/headers/src/api/structures/IHeaders.ts
+++ b/test/features/headers/src/api/structures/IHeaders.ts
@@ -4,5 +4,5 @@ export interface IHeaders {
     "x-name"?: string;
     "x-values": number[];
     "x-flags": boolean[];
-    "x-descriptions": string[];
+    "X-Descriptions": string[];
 }

--- a/test/features/headers/src/test/features/api/test_api_headers.ts
+++ b/test/features/headers/src/test/features/api/test_api_headers.ts
@@ -12,7 +12,7 @@ export const test_api_headers = async (
         ...typia.random<Required<IHeaders>>(),
         "x-values": [1, 2, 3],
         "x-flags": [true, false, true],
-        "x-descriptions": ["a", "b", "c"],
+        "X-Descriptions": ["a", "b", "c"],
     };
     const output: IHeaders = await api.functional.headers.emplace(
         {

--- a/test/features/headers/swagger.json
+++ b/test/features/headers/swagger.json
@@ -396,7 +396,7 @@
               "type": "boolean"
             }
           },
-          "x-descriptions": {
+          "X-Descriptions": {
             "x-typia-required": true,
             "x-typia-optional": false,
             "type": "array",
@@ -412,7 +412,7 @@
           "x-category",
           "x-values",
           "x-flags",
-          "x-descriptions"
+          "X-Descriptions"
         ],
         "x-typia-jsDocTags": []
       },

--- a/test/features/simulate/swagger.json
+++ b/test/features/simulate/swagger.json
@@ -628,7 +628,7 @@
           "201": {
             "description": "## Warning\nResponse data have been encrypted.\n\nThe response body data would be encrypted as \"AES-128(256) / CBC mode / PKCS#5 Padding / Base64 Encoding\", through the [EncryptedRoute.P.ost](https://github.com/samchon/@nestia/core#encryptedroute) component.\n\nTherefore, just utilize this swagger editor only for referencing. If you need to call the real API, using [SDK](https://github.com/samchon/nestia#software-development-kit) would be much better.\n\n-----------------\n\nInformation of newly joined seller",
             "content": {
-              "application/json": {
+              "text/plain": {
                 "schema": {
                   "$ref": "#/components/schemas/ISeller.IAuthorized"
                 }
@@ -700,7 +700,7 @@
           "201": {
             "description": "## Warning\nResponse data have been encrypted.\n\nThe response body data would be encrypted as \"AES-128(256) / CBC mode / PKCS#5 Padding / Base64 Encoding\", through the [EncryptedRoute.P.ost](https://github.com/samchon/@nestia/core#encryptedroute) component.\n\nTherefore, just utilize this swagger editor only for referencing. If you need to call the real API, using [SDK](https://github.com/samchon/nestia#software-development-kit) would be much better.\n\n-----------------\n\nInformation of the seller",
             "content": {
-              "application/json": {
+              "text/plain": {
                 "schema": {
                   "$ref": "#/components/schemas/ISeller.IAuthorized"
                 }

--- a/test/features/tags/src/api/functional/bbs/articles/index.ts
+++ b/test/features/tags/src/api/functional/bbs/articles/index.ts
@@ -28,7 +28,13 @@ export async function store(
     input: store.Input,
 ): Promise<store.Output> {
     return Fetcher.fetch(
-        connection,
+        {
+            ...connection,
+            headers: {
+                ...(connection.headers ?? {}),
+                "Content-Type": "application/json",
+            },
+        },
         store.ENCRYPTED,
         store.METHOD,
         store.path(section),
@@ -75,7 +81,13 @@ export async function update(
     input: update.Input,
 ): Promise<update.Output> {
     return Fetcher.fetch(
-        connection,
+        {
+            ...connection,
+            headers: {
+                ...(connection.headers ?? {}),
+                "Content-Type": "application/json",
+            },
+        },
         update.ENCRYPTED,
         update.METHOD,
         update.path(section, id),

--- a/test/features/variable/src/api/functional/bbs/$package/articles/index.ts
+++ b/test/features/variable/src/api/functional/bbs/$package/articles/index.ts
@@ -27,7 +27,13 @@ export async function index(
     input: index.Input,
 ): Promise<index.Output> {
     return Fetcher.fetch(
-        connection,
+        {
+            ...connection,
+            headers: {
+                ...(connection.headers ?? {}),
+                "Content-Type": "application/json",
+            },
+        },
         index.ENCRYPTED,
         index.METHOD,
         index.path(section),
@@ -191,7 +197,13 @@ export async function store(
     input: store.Input,
 ): Promise<store.Output> {
     return Fetcher.fetch(
-        connection,
+        {
+            ...connection,
+            headers: {
+                ...(connection.headers ?? {}),
+                "Content-Type": "application/json",
+            },
+        },
         store.ENCRYPTED,
         store.METHOD,
         store.path(section),
@@ -233,7 +245,13 @@ export async function update(
     input: update.Input,
 ): Promise<update.Output> {
     return Fetcher.fetch(
-        connection,
+        {
+            ...connection,
+            headers: {
+                ...(connection.headers ?? {}),
+                "Content-Type": "application/json",
+            },
+        },
         update.ENCRYPTED,
         update.METHOD,
         update.path(section, id),

--- a/test/package.json
+++ b/test/package.json
@@ -41,9 +41,9 @@
     "typia": "^4.1.8",
     "uuid": "^9.0.0",
     "nestia": "../packages/cli/nestia-4.3.2.tgz",
-    "@nestia/core": "../packages/core/nestia-core-1.5.0.tgz",
+    "@nestia/core": "../packages/core/nestia-core-1.5.1.tgz",
     "@nestia/e2e": "../packages/e2e/nestia-e2e-0.3.6.tgz",
-    "@nestia/fetcher": "../packages/fetcher/nestia-fetcher-1.5.0.tgz",
-    "@nestia/sdk": "../packages/sdk/nestia-sdk-1.5.0.tgz"
+    "@nestia/fetcher": "../packages/fetcher/nestia-fetcher-1.5.1.tgz",
+    "@nestia/sdk": "../packages/sdk/nestia-sdk-1.5.1.tgz"
   }
 }


### PR DESCRIPTION
Enhanced `IConnection.Headerify` type of `@nestia/fetcher` to be much stronger. It will validate special cases whether each property allows Array type or not through their key name. For example, "set-cookie" type must be Array type, and `Authorization` must be atomic type.

```typescript
export namespace IConnection {
    export type Headerify<T extends object> = {
        [P in keyof T]?: T[P] extends HeaderValue | undefined
            ? P extends string
                ? Lowercase<P> extends "set-cookie"
                    ? T[P] extends Array<HeaderValue>
                        ? T[P] | undefined
                        : never
                    : Lowercase<P> extends
                          | "age"
                          | "authorization"
                          | "content-length"
                          | "content-type"
                          | "etag"
                          | "expires"
                          | "from"
                          | "host"
                          | "if-modified-since"
                          | "if-unmodified-since"
                          | "last-modified"
                          | "location"
                          | "max-forwards"
                          | "proxy-authorization"
                          | "referer"
                          | "retry-after"
                          | "server"
                          | "user-agent"
                    ? T[P] extends Array<HeaderValue>
                        ? never
                        : T[P] | undefined
                    : T[P] | undefined
                : never
            : never;
}
```