### PR TITLE
Enhance `@nestia/fetcher` for `@EncryptedRoute`

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/core",
-  "version": "1.5.4",
+  "version": "1.5.6",
   "description": "Super-fast validation decorators of NestJS",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -34,7 +34,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^1.5.4",
+    "@nestia/fetcher": "^1.5.6",
     "@nestjs/common": ">= 7.0.1",
     "@nestjs/core": ">= 7.0.1",
     "@nestjs/platform-express": ">= 7.0.1",
@@ -47,7 +47,7 @@
     "typia": "^4.1.16"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">= 1.5.4",
+    "@nestia/fetcher": ">= 1.5.6",
     "@nestjs/common": ">= 7.0.1",
     "@nestjs/core": ">= 7.0.1",
     "@nestjs/platform-express": ">= 7.0.1",

--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/fetcher",
-  "version": "1.5.4",
+  "version": "1.5.6",
   "description": "Fetcher library of Nestia SDK",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/fetcher/src/Fetcher.ts
+++ b/packages/fetcher/src/Fetcher.ts
@@ -168,7 +168,7 @@ export class Fetcher {
         if (method === "HEAD") return undefined!;
 
         // DECRYPT RESPONSE BODY
-        const content: string = !encrypted.response
+        const content: string = !encrypted.response || text.length === 0
             ? text
             : (() => {
                   const password:
@@ -198,7 +198,7 @@ export class Fetcher {
                     "application/json",
                 ) !== -1
             )
-                ret = JSON.parse(ret as any);
+                ret = content.length ? JSON.parse(content) : undefined!;
         } catch {}
 
         // RETURNS

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/sdk",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "Nestia SDK and Swagger generator",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -35,7 +35,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^1.5.4",
+    "@nestia/fetcher": "^1.5.6",
     "cli": "^1.0.1",
     "glob": "^7.2.0",
     "path-to-regexp": "^6.2.1",
@@ -47,7 +47,7 @@
     "typia": "^4.1.16"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">= 1.5.4",
+    "@nestia/fetcher": ">= 1.5.6",
     "@nestjs/common": ">= 7.0.1",
     "@nestjs/core": ">= 7.0.1",
     "reflect-metadata": ">= 0.1.12",

--- a/test/features/distribute-assert/packages/api/package.json
+++ b/test/features/distribute-assert/packages/api/package.json
@@ -33,7 +33,7 @@
     "typescript": "^5.1.6"
   },
   "dependencies": {
-    "@nestia/fetcher": "^1.5.2",
-    "typia": "^4.1.14"
+    "@nestia/fetcher": "^1.5.6",
+    "typia": "^4.1.16"
   }
 }

--- a/test/features/distribute-json/packages/api/package.json
+++ b/test/features/distribute-json/packages/api/package.json
@@ -33,7 +33,7 @@
     "typescript": "^5.1.6"
   },
   "dependencies": {
-    "@nestia/fetcher": "^1.5.2",
-    "typia": "^4.1.14"
+    "@nestia/fetcher": "^1.5.6",
+    "typia": "^4.1.16"
   }
 }

--- a/test/features/distribute/packages/api/package.json
+++ b/test/features/distribute/packages/api/package.json
@@ -30,6 +30,6 @@
     "typescript": "^5.1.6"
   },
   "dependencies": {
-    "@nestia/fetcher": "^1.5.2"
+    "@nestia/fetcher": "^1.5.6"
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://nestia.io",
   "devDependencies": {
-    "@nestia/migrate": "../packages/migrate/nestia-migrate-0.2.1.tgz",
+    "@nestia/migrate": "../packages/migrate/nestia-migrate-0.2.3.tgz",
     "@nestjs/swagger": "^7.1.2",
     "@trivago/prettier-plugin-sort-imports": "^4.0.0",
     "@types/express": "^4.17.17",
@@ -42,9 +42,9 @@
     "typia": "^4.1.16",
     "uuid": "^9.0.0",
     "nestia": "../packages/cli/nestia-4.3.2.tgz",
-    "@nestia/core": "../packages/core/nestia-core-1.5.3.tgz",
+    "@nestia/core": "../packages/core/nestia-core-1.5.6.tgz",
     "@nestia/e2e": "../packages/e2e/nestia-e2e-0.3.6.tgz",
-    "@nestia/fetcher": "../packages/fetcher/nestia-fetcher-1.5.3.tgz",
-    "@nestia/sdk": "../packages/sdk/nestia-sdk-1.5.3.tgz"
+    "@nestia/fetcher": "../packages/fetcher/nestia-fetcher-1.5.6.tgz",
+    "@nestia/sdk": "../packages/sdk/nestia-sdk-1.5.6.tgz"
   }
 }


### PR DESCRIPTION
When `@EncryptedRoute` defined controller method returns nothing (`void`), `@nestia/fetcher` had occured exception. Considering purpose of `@EncryptedRoute`, occuring exception from `@nestia/fetcher` can be considered as not a bug but a spec.

However, this is so unkind to users. Even though the exception is sensible to considering its principle, users may not think such deeply. So I've changed logic of `@nestia/fetcher` to support `void` return typed `@EncryptedRoute` method.