### PR TITLE
Fix #521 - swagger query parameter type must have specific name

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -24,8 +24,8 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/core": "^1.4.4",
-    "typia": "^4.1.6"
+    "@nestia/core": "^1.5.7",
+    "typia": "^4.1.16"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.1.1",
@@ -45,8 +45,8 @@
     "rimraf": "^5.0.1",
     "tgrid": "^0.8.7",
     "ts-node": "^10.9.1",
-    "ts-patch": "^3.0.0",
+    "ts-patch": "^3.0.2",
     "tstl": "^2.5.13",
-    "typescript": "^5.1.3"
+    "typescript": "^5.1.6"
   }
 }

--- a/deploy/latest.sh
+++ b/deploy/latest.sh
@@ -1,0 +1,53 @@
+#--------------------------------------------------
+# PACKAGES
+#--------------------------------------------------
+cd ../packages/fetcher
+npm install
+npm run build
+npm publish --access public --tag latest
+
+cd ../core
+npm install
+npm run build
+npm publish --access public --tag latest
+
+cd ../sdk
+npm install
+npm run build
+npm publish --access public --tag latest
+
+#--------------------------------------------------
+# TEMPLATE REPOSITORY
+#--------------------------------------------------
+cd ../..
+cd ../nestia-template
+
+git checkout master
+git pull
+npm install
+npm install --save typia@latest
+npm install --save @nestia/core@latest
+npm install --save-dev @nestia/sdk@latest
+
+cd packages/api
+npm install
+npm install --save typia@latest
+npm install --save @nestia/fetcher@latest
+
+cd ../..
+npm run build
+npm run test
+git add .
+git commit -m "Update dependencies"
+git push
+
+#--------------------------------------------------
+# MIGRATE
+#--------------------------------------------------
+cd ../nestia/packages/migrate
+npm install
+npm install --save typia@latest
+npm install --save-dev @nestia/core@latest
+npm install --save-dev @nestia/fetcher@latest
+npm run build
+npm publish --access public --tag latest

--- a/deploy/next.sh
+++ b/deploy/next.sh
@@ -1,0 +1,14 @@
+cd ../packages/fetcher
+npm install
+npm run build
+npm publish --access public --tag next
+
+cd ../core
+npm install
+npm run build
+npm publish --access public --tag next
+
+cd ../sdk
+npm install
+npm run build
+npm publish --access public --tag next

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/core",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "description": "Super-fast validation decorators of NestJS",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -34,7 +34,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^1.5.6",
+    "@nestia/fetcher": "^1.5.7",
     "@nestjs/common": ">= 7.0.1",
     "@nestjs/core": ">= 7.0.1",
     "@nestjs/platform-express": ">= 7.0.1",
@@ -47,7 +47,7 @@
     "typia": "^4.1.16"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">= 1.5.6",
+    "@nestia/fetcher": ">= 1.5.7",
     "@nestjs/common": ">= 7.0.1",
     "@nestjs/core": ">= 7.0.1",
     "@nestjs/platform-express": ">= 7.0.1",
@@ -73,7 +73,7 @@
     "prettier": "^2.8.7",
     "rimraf": "^3.0.2",
     "ts-node": "^10.9.1",
-    "ts-patch": "^3.0.0",
+    "ts-patch": "^3.0.2",
     "tstl": "^2.5.13",
     "typescript": "^5.1.6",
     "typescript-transform-paths": "^3.4.6"

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -38,7 +38,7 @@
     "prettier": "^2.8.3",
     "rimraf": "^4.1.2",
     "ts-node": "^10.9.1",
-    "ts-patch": "^3.0.0",
+    "ts-patch": "^3.0.2",
     "typescript": "^5.1.3",
     "typia": "^4.1.16"
   },

--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/fetcher",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "description": "Fetcher library of Nestia SDK",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/migrate",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Migration program from swagger to NestJS",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -30,8 +30,8 @@
   },
   "homepage": "https://github.com/samchon/nestia#readme",
   "devDependencies": {
-    "@nestia/core": "^1.5.6",
-    "@nestia/fetcher": "^1.5.6",
+    "@nestia/core": "^1.5.7",
+    "@nestia/fetcher": "^1.5.7",
     "@trivago/prettier-plugin-sort-imports": "^4.1.1",
     "@types/node": "^20.3.3",
     "prettier": "^2.8.8",
@@ -39,7 +39,7 @@
     "serialize-error": "^4.1.0",
     "source-map-support": "^0.5.21",
     "ts-node": "^10.9.1",
-    "ts-patch": "^3.0.1",
+    "ts-patch": "^3.0.2",
     "tstl": "^2.5.13",
     "typescript": "^5.1.6",
     "typescript-transform-paths": "^3.4.6"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/sdk",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "description": "Nestia SDK and Swagger generator",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -35,7 +35,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^1.5.6",
+    "@nestia/fetcher": "^1.5.7",
     "cli": "^1.0.1",
     "glob": "^7.2.0",
     "path-to-regexp": "^6.2.1",
@@ -47,7 +47,7 @@
     "typia": "^4.1.16"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">= 1.5.6",
+    "@nestia/fetcher": ">= 1.5.7",
     "@nestjs/common": ">= 7.0.1",
     "@nestjs/core": ">= 7.0.1",
     "reflect-metadata": ">= 0.1.12",
@@ -72,7 +72,7 @@
     "prettier": "^2.8.1",
     "rimraf": "^3.0.2",
     "ts-node": "^10.9.1",
-    "ts-patch": "v3.0.0",
+    "ts-patch": "v3.0.2",
     "typescript": "^5.1.3",
     "typescript-transform-paths": "^3.4.4",
     "uuid": "^9.0.0"

--- a/packages/sdk/src/generates/SwaggerGenerator.ts
+++ b/packages/sdk/src/generates/SwaggerGenerator.ts
@@ -495,7 +495,7 @@ export namespace SwaggerGenerator {
 
         return [
             {
-                name: parameter.field,
+                name: parameter.field ?? parameter.name,
                 in:
                     parameter.category === "param"
                         ? "path"

--- a/packages/sdk/src/structures/ISwaggerRoute.ts
+++ b/packages/sdk/src/structures/ISwaggerRoute.ts
@@ -16,7 +16,7 @@ export interface ISwaggerRoute {
 }
 export namespace ISwaggerRoute {
     export interface IParameter {
-        name?: string;
+        name: string;
         in: string;
         schema: IJsonSchema;
         required: boolean;

--- a/test/executable/start.js
+++ b/test/executable/start.js
@@ -106,17 +106,13 @@ const feature = (name) => {
     // RUN TEST AUTOMATION PROGRAM
     if (fs.existsSync("src/test")) {
         const test = () => cp.execSync("npx ts-node src/test", { stdio: "ignore" });
-        try {
-            test();
-        }
-        catch {
+        for (let i = 0; i < 7; ++i)
             try {
                 test();
-            } catch {
-                test();
-            }
-        }
+                return;
+            } catch {}
     }
+    test();
 };
 
 // const migrate = (name) => {

--- a/test/executable/start.js
+++ b/test/executable/start.js
@@ -104,8 +104,8 @@ const feature = (name) => {
     cp.execSync("npx tsc", { stdio: "ignore" });
 
     // RUN TEST AUTOMATION PROGRAM
+    const test = () => cp.execSync("npx ts-node src/test", { stdio: "ignore" });
     if (fs.existsSync("src/test")) {
-        const test = () => cp.execSync("npx ts-node src/test", { stdio: "ignore" });
         for (let i = 0; i < 7; ++i)
             try {
                 test();

--- a/test/executable/start.js
+++ b/test/executable/start.js
@@ -106,7 +106,7 @@ const feature = (name) => {
     // RUN TEST AUTOMATION PROGRAM
     const test = () => cp.execSync("npx ts-node src/test", { stdio: "ignore" });
     if (fs.existsSync("src/test")) {
-        for (let i = 0; i < 7; ++i)
+        for (let i = 0; i < 10; ++i)
             try {
                 test();
                 return;

--- a/test/features/distribute-assert/packages/api/package.json
+++ b/test/features/distribute-assert/packages/api/package.json
@@ -33,7 +33,7 @@
     "typescript": "^5.1.6"
   },
   "dependencies": {
-    "@nestia/fetcher": "^1.5.6",
+    "@nestia/fetcher": "^1.5.7",
     "typia": "^4.1.16"
   }
 }

--- a/test/features/distribute-json/packages/api/package.json
+++ b/test/features/distribute-json/packages/api/package.json
@@ -33,7 +33,7 @@
     "typescript": "^5.1.6"
   },
   "dependencies": {
-    "@nestia/fetcher": "^1.5.6",
+    "@nestia/fetcher": "^1.5.7",
     "typia": "^4.1.16"
   }
 }

--- a/test/features/distribute/packages/api/package.json
+++ b/test/features/distribute/packages/api/package.json
@@ -30,6 +30,6 @@
     "typescript": "^5.1.6"
   },
   "dependencies": {
-    "@nestia/fetcher": "^1.5.6"
+    "@nestia/fetcher": "^1.5.7"
   }
 }

--- a/test/features/exception-filter/swagger.json
+++ b/test/features/exception-filter/swagger.json
@@ -95,6 +95,7 @@
         "tags": [],
         "parameters": [
           {
+            "name": "file",
             "in": "query",
             "description": "",
             "schema": {

--- a/test/features/fastify/swagger.json
+++ b/test/features/fastify/swagger.json
@@ -29,6 +29,7 @@
             "required": true
           },
           {
+            "name": "query",
             "in": "query",
             "description": "",
             "schema": {

--- a/test/features/headers/swagger.json
+++ b/test/features/headers/swagger.json
@@ -20,6 +20,7 @@
         "tags": [],
         "parameters": [
           {
+            "name": "headers",
             "in": "header",
             "description": "Headers for authentication",
             "schema": {
@@ -130,6 +131,7 @@
         "tags": [],
         "parameters": [
           {
+            "name": "headers",
             "in": "header",
             "description": "",
             "schema": {

--- a/test/features/query/swagger.json
+++ b/test/features/query/swagger.json
@@ -20,6 +20,7 @@
         "tags": [],
         "parameters": [
           {
+            "name": "query",
             "in": "query",
             "description": "",
             "schema": {
@@ -51,6 +52,7 @@
         "tags": [],
         "parameters": [
           {
+            "name": "query",
             "in": "query",
             "description": "",
             "schema": {
@@ -123,6 +125,7 @@
             "required": true
           },
           {
+            "name": "query",
             "in": "query",
             "description": "",
             "schema": {

--- a/test/features/simulate/swagger.json
+++ b/test/features/simulate/swagger.json
@@ -119,6 +119,7 @@
             "required": true
           },
           {
+            "name": "input",
             "in": "query",
             "description": "Page request info",
             "schema": {

--- a/test/features/variable/swagger.json
+++ b/test/features/variable/swagger.json
@@ -119,6 +119,7 @@
             "required": true
           },
           {
+            "name": "input",
             "in": "query",
             "description": "Page request info",
             "schema": {

--- a/test/package.json
+++ b/test/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://nestia.io",
   "devDependencies": {
-    "@nestia/migrate": "../packages/migrate/nestia-migrate-0.2.3.tgz",
+    "@nestia/migrate": "../packages/migrate/nestia-migrate-0.2.5.tgz",
     "@nestjs/swagger": "^7.1.2",
     "@trivago/prettier-plugin-sort-imports": "^4.0.0",
     "@types/express": "^4.17.17",
@@ -36,15 +36,15 @@
     "eslint": "^8.29.0",
     "eslint-plugin-deprecation": "^1.4.1",
     "ts-node": "^10.9.1",
-    "ts-patch": "v3.0.0",
-    "typescript": "^5.1.3",
+    "ts-patch": "v3.0.2",
+    "typescript": "^5.1.6",
     "typescript-transform-paths": "^3.4.4",
     "typia": "^4.1.16",
     "uuid": "^9.0.0",
     "nestia": "../packages/cli/nestia-4.3.2.tgz",
-    "@nestia/core": "../packages/core/nestia-core-1.5.6.tgz",
+    "@nestia/core": "../packages/core/nestia-core-1.5.7.tgz",
     "@nestia/e2e": "../packages/e2e/nestia-e2e-0.3.6.tgz",
-    "@nestia/fetcher": "../packages/fetcher/nestia-fetcher-1.5.6.tgz",
-    "@nestia/sdk": "../packages/sdk/nestia-sdk-1.5.6.tgz"
+    "@nestia/fetcher": "../packages/fetcher/nestia-fetcher-1.5.7.tgz",
+    "@nestia/sdk": "../packages/sdk/nestia-sdk-1.5.7.tgz"
   }
 }


### PR DESCRIPTION
Even when query parameter be defined just by one object type, it must have its specific name following the OpenAPI spec. 

Therefore, fix `@nestia/sdk` to always have parameter name, and the bug be fixed.