### PR TITLE
Fix `@TypedHeaders()` bug when zero length array comes

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/core": "^1.5.7",
+    "@nestia/core": "^1.5.8",
     "typia": "^4.1.16"
   },
   "devDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/core",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "description": "Super-fast validation decorators of NestJS",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -34,7 +34,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^1.5.7",
+    "@nestia/fetcher": "^1.5.8",
     "@nestjs/common": ">= 7.0.1",
     "@nestjs/core": ">= 7.0.1",
     "@nestjs/platform-express": ">= 7.0.1",
@@ -47,7 +47,7 @@
     "typia": "^4.1.16"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">= 1.5.7",
+    "@nestia/fetcher": ">= 1.5.8",
     "@nestjs/common": ">= 7.0.1",
     "@nestjs/core": ">= 7.0.1",
     "@nestjs/platform-express": ">= 7.0.1",

--- a/packages/core/src/programmers/TypedHeadersProgrammer.ts
+++ b/packages/core/src/programmers/TypedHeadersProgrammer.ts
@@ -223,33 +223,7 @@ export namespace TypedHeadersProgrammer {
                 isArray
                     ? key === "set-cookie"
                         ? accessor
-                        : ts.factory.createCallChain(
-                              ts.factory.createPropertyAccessChain(
-                                  ts.factory.createCallChain(
-                                      ts.factory.createPropertyAccessChain(
-                                          accessor,
-                                          ts.factory.createToken(
-                                              ts.SyntaxKind.QuestionDotToken,
-                                          ),
-                                          ts.factory.createIdentifier("split"),
-                                      ),
-                                      undefined,
-                                      undefined,
-                                      [
-                                          ts.factory.createStringLiteral(
-                                              key === "cookie" ? "; " : ", ",
-                                          ),
-                                      ],
-                                  ),
-                                  ts.factory.createToken(
-                                      ts.SyntaxKind.QuestionDotToken,
-                                  ),
-                                  ts.factory.createIdentifier("map"),
-                              ),
-                              undefined,
-                              undefined,
-                              [importer.use(type)],
-                          )
+                        : decode_array(importer)(type)(key)(value)(accessor)
                     : decode_value(importer)(type)(accessor),
             );
         };
@@ -265,6 +239,45 @@ export namespace TypedHeadersProgrammer {
                       undefined,
                       [value],
                   );
+
+    const decode_array =
+        (importer: FunctionImporter) =>
+        (type: Atomic.Literal) =>
+        (key: string) =>
+        (value: Metadata) =>
+        (accessor: ts.Expression) => {
+            const expression = ts.factory.createCallChain(
+                ts.factory.createPropertyAccessChain(
+                    ts.factory.createCallChain(
+                        ts.factory.createPropertyAccessChain(
+                            accessor,
+                            ts.factory.createToken(
+                                ts.SyntaxKind.QuestionDotToken,
+                            ),
+                            ts.factory.createIdentifier("split"),
+                        ),
+                        undefined,
+                        undefined,
+                        [
+                            ts.factory.createStringLiteral(
+                                key === "cookie" ? "; " : ", ",
+                            ),
+                        ],
+                    ),
+                    ts.factory.createToken(ts.SyntaxKind.QuestionDotToken),
+                    ts.factory.createIdentifier("map"),
+                ),
+                undefined,
+                undefined,
+                [importer.use(type)],
+            );
+            if (value.isRequired() === false) return expression;
+            return ts.factory.createBinaryExpression(
+                expression,
+                ts.factory.createToken(ts.SyntaxKind.QuestionQuestionToken),
+                ts.factory.createArrayLiteralExpression([], false),
+            );
+        };
 }
 
 namespace ErrorMessages {

--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/fetcher",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "description": "Fetcher library of Nestia SDK",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/migrate",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Migration program from swagger to NestJS",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -30,8 +30,8 @@
   },
   "homepage": "https://github.com/samchon/nestia#readme",
   "devDependencies": {
-    "@nestia/core": "^1.5.7",
-    "@nestia/fetcher": "^1.5.7",
+    "@nestia/core": "^1.5.8",
+    "@nestia/fetcher": "^1.5.8",
     "@trivago/prettier-plugin-sort-imports": "^4.1.1",
     "@types/node": "^20.3.3",
     "prettier": "^2.8.8",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/sdk",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "description": "Nestia SDK and Swagger generator",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -35,7 +35,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^1.5.7",
+    "@nestia/fetcher": "^1.5.8",
     "cli": "^1.0.1",
     "glob": "^7.2.0",
     "path-to-regexp": "^6.2.1",
@@ -47,7 +47,7 @@
     "typia": "^4.1.16"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">= 1.5.7",
+    "@nestia/fetcher": ">= 1.5.8",
     "@nestjs/common": ">= 7.0.1",
     "@nestjs/core": ">= 7.0.1",
     "reflect-metadata": ">= 0.1.12",

--- a/test/features/distribute-assert/packages/api/package.json
+++ b/test/features/distribute-assert/packages/api/package.json
@@ -33,7 +33,7 @@
     "typescript": "^5.1.6"
   },
   "dependencies": {
-    "@nestia/fetcher": "^1.5.7",
+    "@nestia/fetcher": "^1.5.8",
     "typia": "^4.1.16"
   }
 }

--- a/test/features/distribute-json/packages/api/package.json
+++ b/test/features/distribute-json/packages/api/package.json
@@ -33,7 +33,7 @@
     "typescript": "^5.1.6"
   },
   "dependencies": {
-    "@nestia/fetcher": "^1.5.7",
+    "@nestia/fetcher": "^1.5.8",
     "typia": "^4.1.16"
   }
 }

--- a/test/features/distribute/packages/api/package.json
+++ b/test/features/distribute/packages/api/package.json
@@ -30,6 +30,6 @@
     "typescript": "^5.1.6"
   },
   "dependencies": {
-    "@nestia/fetcher": "^1.5.7"
+    "@nestia/fetcher": "^1.5.8"
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -42,9 +42,9 @@
     "typia": "^4.1.16",
     "uuid": "^9.0.0",
     "nestia": "../packages/cli/nestia-4.3.2.tgz",
-    "@nestia/core": "../packages/core/nestia-core-1.5.7.tgz",
+    "@nestia/core": "../packages/core/nestia-core-1.5.8.tgz",
     "@nestia/e2e": "../packages/e2e/nestia-e2e-0.3.6.tgz",
-    "@nestia/fetcher": "../packages/fetcher/nestia-fetcher-1.5.7.tgz",
-    "@nestia/sdk": "../packages/sdk/nestia-sdk-1.5.7.tgz"
+    "@nestia/fetcher": "../packages/fetcher/nestia-fetcher-1.5.8.tgz",
+    "@nestia/sdk": "../packages/sdk/nestia-sdk-1.5.8.tgz"
   }
 }


### PR DESCRIPTION
When an object type has an array typed property not undefindable, and being used in `@TypedHeaders()`, embeded validator function in the `@TypedHeaders()` had thrown a type error due to `undefined` value. To fix this bug, I've changed `@TypedHeaders()` to generate empty Array when target property value does not exist in the raw headers.

```typescript
expoort interface ISomeHeadersDto {
    someArray: number[];
}

await api.functional.someApi({
      host: "http://127.0.0.1",
      headers: {
          someArray: [],
      }
});
```