### PR TITLE
Fix samchon/typia#744 - change setup wizard to deprecate yarn berry

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestia",
-  "version": "4.3.2",
+  "version": "4.4.0",
   "description": "Nestia CLI tool",
   "main": "bin/index.js",
   "bin": {
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "rimraf bin && tsc",
     "prettier": "prettier ./src/**/*.ts --write",
-    "package:next": "npm publish --access public --tag next"
+    "package:next": "npm run build && npm publish --access public --tag next"
   },
   "repository": {
     "type": "git",
@@ -36,14 +36,14 @@
     "inquirer": "^8.2.5"
   },
   "devDependencies": {
-    "@nestia/core": "^1.3.0",
-    "@nestia/sdk": "^1.3.0",
+    "@nestia/core": "^1.6.1",
+    "@nestia/sdk": "^1.6.1",
     "@trivago/prettier-plugin-sort-imports": "^4.1.1",
     "@types/inquirer": "^9.0.3",
     "@types/node": "^18.11.16",
     "prettier": "^2.8.7",
     "rimraf": "^3.0.2",
-    "typescript": "^5.1.3"
+    "typescript": "^5.1.6"
   },
   "files": [
     "bin",

--- a/packages/cli/src/internal/ArgumentParser.ts
+++ b/packages/cli/src/internal/ArgumentParser.ts
@@ -12,7 +12,7 @@ export namespace ArgumentParser {
 
     export async function parse(pack: PackageManager): Promise<IArguments> {
         // PREPARE ASSETS
-        commander.program.option("--manager [manager", "package manager");
+        commander.program.option("--manager [manager]", "package manager");
         commander.program.option(
             "--project [project]",
             "tsconfig.json file location",
@@ -39,6 +39,7 @@ export namespace ArgumentParser {
             (message: string) =>
             async <Choice extends string>(
                 choices: Choice[],
+                filter?: (value: string) => Choice,
             ): Promise<Choice> => {
                 questioned.value = true;
                 return (
@@ -47,6 +48,7 @@ export namespace ArgumentParser {
                         name: name,
                         message: message,
                         choices: choices,
+                        filter,
                     })
                 )[name];
             };
@@ -78,11 +80,14 @@ export namespace ArgumentParser {
 
         // DO CONSTRUCT
         return action(async (options) => {
-            options.manager ??= await select("manager")("Package Manager")([
-                "npm" as const,
-                "pnpm" as const,
-                "yarn" as const,
-            ]);
+            options.manager ??= await select("manager")("Package Manager")(
+                [
+                    "npm" as const,
+                    "pnpm" as const,
+                    "yarn (berry is not supported)" as "yarn",
+                ],
+                (value) => value.split(" ")[0] as "yarn",
+            );
             pack.manager = options.manager;
             options.project ??= await configure();
 


### PR DESCRIPTION
Same with with samchon/typia#744

  - Changed setup wizard
  - Introduce not to support `yarn berry`
  - Use `npm run postinstall` command instead

Unfortunately, `ts-patch` does not support `yarn berry`. Therefore, it is not possible to use transform mode of `typia` in the `yarn berry`. Therefore, to inform it and recommend not to use `yarn berry` in `typia`, I've changed setup wizard program. This change would be rolled back when `ts-patch` starts supporting the `yarn berry`.

Also, `yarn berry` does not support the `npm run prepare` command. I think this nonsensible story because the `npm run prepare` command is a standard feature of NPM, but this is the reality, so I can't help it. By the way, if `ts-patch` starts supporting `yarn berry`, configuring `npm run prepare` command by setup wizard can be a big problem. So, I've changed setup wizard to use `npm run postinstall` command instead of the previous `npm run prepare` command.