### PR TITLE
Fix #489 - stop casting `typia.TypeGuardError` to 400 status code.

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/core": "^1.6.2",
+    "@nestia/core": "^1.6.3",
     "typia": "^4.2.1"
   },
   "devDependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -36,8 +36,8 @@
     "inquirer": "^8.2.5"
   },
   "devDependencies": {
-    "@nestia/core": "^1.6.2",
-    "@nestia/sdk": "^1.6.2",
+    "@nestia/core": "^1.6.3",
+    "@nestia/sdk": "^1.6.3",
     "@trivago/prettier-plugin-sort-imports": "^4.1.1",
     "@types/inquirer": "^9.0.3",
     "@types/node": "^18.11.16",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/core",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "Super-fast validation decorators of NestJS",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -34,7 +34,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^1.6.2",
+    "@nestia/fetcher": "^1.6.3",
     "@nestjs/common": ">= 7.0.1",
     "@nestjs/core": ">= 7.0.1",
     "@nestjs/platform-express": ">= 7.0.1",
@@ -47,7 +47,7 @@
     "typia": "^4.2.1"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">= 1.6.2",
+    "@nestia/fetcher": ">= 1.6.3",
     "@nestjs/common": ">= 7.0.1",
     "@nestjs/core": ">= 7.0.1",
     "@nestjs/platform-express": ">= 7.0.1",

--- a/packages/core/src/utils/ExceptionManager.ts
+++ b/packages/core/src/utils/ExceptionManager.ts
@@ -1,6 +1,5 @@
 import { HttpError } from "@nestia/fetcher";
 import { HttpException } from "@nestjs/common";
-import { TypeGuardError } from "typia";
 
 import { Creator } from "../typings/Creator";
 
@@ -99,19 +98,6 @@ export namespace ExceptionManager {
      */
     export const listeners: Set<(error: any) => any> = new Set();
 }
-
-ExceptionManager.insert(
-    TypeGuardError,
-    (error) =>
-        new HttpException(
-            {
-                path: error.path,
-                reason: error.message,
-                message: "Request message is not following the promised type.",
-            },
-            400,
-        ),
-);
 
 ExceptionManager.insert(
     HttpError,

--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/fetcher",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "Fetcher library of Nestia SDK",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/migrate/assets/input/fireblocks.json
+++ b/packages/migrate/assets/input/fireblocks.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Fireblocks API",
-    "version": "1.6.2",
+    "version": "1.6.3",
     "contact": {
       "email": "support@fireblocks.com"
     }

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/migrate",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Migration program from swagger to NestJS",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -30,8 +30,8 @@
   },
   "homepage": "https://github.com/samchon/nestia#readme",
   "devDependencies": {
-    "@nestia/core": "^1.6.2",
-    "@nestia/fetcher": "^1.6.2",
+    "@nestia/core": "^1.6.3",
+    "@nestia/fetcher": "^1.6.3",
     "@trivago/prettier-plugin-sort-imports": "^4.1.1",
     "@types/node": "^20.3.3",
     "prettier": "^2.8.8",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/sdk",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "Nestia SDK and Swagger generator",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -35,7 +35,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^1.6.2",
+    "@nestia/fetcher": "^1.6.3",
     "cli": "^1.0.1",
     "glob": "^7.2.0",
     "path-to-regexp": "^6.2.1",
@@ -47,7 +47,7 @@
     "typia": "^4.2.1"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">= 1.6.2",
+    "@nestia/fetcher": ">= 1.6.3",
     "@nestjs/common": ">= 7.0.1",
     "@nestjs/core": ">= 7.0.1",
     "reflect-metadata": ">= 0.1.12",

--- a/test/package.json
+++ b/test/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://nestia.io",
   "devDependencies": {
-    "@nestia/migrate": "../packages/migrate/nestia-migrate-0.2.6.tgz",
+    "@nestia/migrate": "../packages/migrate/nestia-migrate-0.2.9.tgz",
     "@nestjs/swagger": "^7.1.2",
     "@trivago/prettier-plugin-sort-imports": "^4.0.0",
     "@types/express": "^4.17.17",
@@ -41,10 +41,10 @@
     "typescript-transform-paths": "^3.4.4",
     "typia": "^4.2.1",
     "uuid": "^9.0.0",
-    "nestia": "../packages/cli/nestia-4.3.2.tgz",
-    "@nestia/core": "../packages/core/nestia-core-1.6.2.tgz",
+    "nestia": "../packages/cli/nestia-4.4.0.tgz",
+    "@nestia/core": "../packages/core/nestia-core-1.6.3.tgz",
     "@nestia/e2e": "../packages/e2e/nestia-e2e-0.3.6.tgz",
-    "@nestia/fetcher": "../packages/fetcher/nestia-fetcher-1.6.2.tgz",
-    "@nestia/sdk": "../packages/sdk/nestia-sdk-1.6.2.tgz"
+    "@nestia/fetcher": "../packages/fetcher/nestia-fetcher-1.6.3.tgz",
+    "@nestia/sdk": "../packages/sdk/nestia-sdk-1.6.3.tgz"
   }
 }

--- a/website/public/sitemap-0.xml
+++ b/website/public/sitemap-0.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://nestia.io/</loc><lastmod>2023-08-07T10:55:49.108Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://nestia.io/docs/</loc><lastmod>2023-08-07T10:55:49.108Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://nestia.io/docs/core/TypedBody/</loc><lastmod>2023-08-07T10:55:49.108Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://nestia.io/docs/core/TypedHeaders/</loc><lastmod>2023-08-07T10:55:49.108Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://nestia.io/docs/core/TypedParam/</loc><lastmod>2023-08-07T10:55:49.108Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://nestia.io/docs/core/TypedQuery/</loc><lastmod>2023-08-07T10:55:49.108Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://nestia.io/docs/core/TypedRoute/</loc><lastmod>2023-08-07T10:55:49.108Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://nestia.io/docs/migrate/</loc><lastmod>2023-08-07T10:55:49.108Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://nestia.io/docs/pure/</loc><lastmod>2023-08-07T10:55:49.108Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://nestia.io/docs/sdk/e2e/</loc><lastmod>2023-08-07T10:55:49.108Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://nestia.io/docs/sdk/sdk/</loc><lastmod>2023-08-07T10:55:49.108Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://nestia.io/docs/sdk/simulator/</loc><lastmod>2023-08-07T10:55:49.108Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://nestia.io/docs/sdk/swagger/</loc><lastmod>2023-08-07T10:55:49.108Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://nestia.io/docs/setup/</loc><lastmod>2023-08-07T10:55:49.108Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://nestia.io/playground/</loc><lastmod>2023-08-07T10:55:49.108Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://nestia.io/</loc><lastmod>2023-08-09T17:48:49.371Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://nestia.io/docs/</loc><lastmod>2023-08-09T17:48:49.371Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://nestia.io/docs/core/TypedBody/</loc><lastmod>2023-08-09T17:48:49.371Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://nestia.io/docs/core/TypedHeaders/</loc><lastmod>2023-08-09T17:48:49.371Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://nestia.io/docs/core/TypedParam/</loc><lastmod>2023-08-09T17:48:49.371Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://nestia.io/docs/core/TypedQuery/</loc><lastmod>2023-08-09T17:48:49.371Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://nestia.io/docs/core/TypedRoute/</loc><lastmod>2023-08-09T17:48:49.371Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://nestia.io/docs/migrate/</loc><lastmod>2023-08-09T17:48:49.371Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://nestia.io/docs/pure/</loc><lastmod>2023-08-09T17:48:49.371Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://nestia.io/docs/sdk/e2e/</loc><lastmod>2023-08-09T17:48:49.371Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://nestia.io/docs/sdk/sdk/</loc><lastmod>2023-08-09T17:48:49.371Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://nestia.io/docs/sdk/simulator/</loc><lastmod>2023-08-09T17:48:49.371Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://nestia.io/docs/sdk/swagger/</loc><lastmod>2023-08-09T17:48:49.371Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://nestia.io/docs/setup/</loc><lastmod>2023-08-09T17:48:49.371Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://nestia.io/playground/</loc><lastmod>2023-08-09T17:48:49.371Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>


### PR DESCRIPTION
Very long time ago, `nestia` had designed to cast `typia.TypeGuardError` to `nest.BadRequestException` for request body validation. Such logic had to be deleted when `@nestia/core` be published, but had taken a mistake that forgetting the work.

Therefore, by this PR, I remove the logic.