### PR TITLE
Fix #606 and Fix #607 - DTO clone mode with comment tags.

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -24,8 +24,8 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/core": "^2.0.2",
-    "typia": "^5.0.3"
+    "@nestia/core": "^2.0.3-dev.20230916",
+    "typia": "^5.0.4"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.1.1",

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/core": "^2.0.3-dev.20230916",
+    "@nestia/core": "^2.0.3",
     "typia": "^5.0.4"
   },
   "devDependencies": {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -3,7 +3,7 @@
 
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/samchon/nestia/blob/master/LICENSE)
 [![npm version](https://img.shields.io/npm/v/@nestia/core.svg)](https://www.npmjs.com/package/@nestia/core)
-[![Downloads](https://img.shields.io/npm/dm/nestia.svg)](https://www.npmjs.com/package/nestia)
+[![Downloads](https://img.shields.io/npm/dm/@nestia/core.svg)](https://www.npmjs.com/package/@nestia/core)
 [![Build Status](https://github.com/samchon/nestia/workflows/build/badge.svg)](https://github.com/samchon/nestia/actions?query=workflow%3Abuild)
 [![Guide Documents](https://img.shields.io/badge/guide-documents-forestgreen)](https://nestia.io/docs/)
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -3,7 +3,7 @@
 
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/samchon/nestia/blob/master/LICENSE)
 [![npm version](https://img.shields.io/npm/v/@nestia/core.svg)](https://www.npmjs.com/package/@nestia/core)
-[![Downloads](https://img.shields.io/npm/dm/nestia.svg)](https://www.npmjs.com/package/nestia)
+[![Downloads](https://img.shields.io/npm/dm/@nestia/core.svg)](https://www.npmjs.com/package/@nestia/core)
 [![Build Status](https://github.com/samchon/nestia/workflows/build/badge.svg)](https://github.com/samchon/nestia/actions?query=workflow%3Abuild)
 [![Guide Documents](https://img.shields.io/badge/guide-documents-forestgreen)](https://nestia.io/docs/)
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/core",
-  "version": "2.0.2",
+  "version": "2.0.3-dev.20230916",
   "description": "Super-fast validation decorators of NestJS",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -34,7 +34,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^2.0.2",
+    "@nestia/fetcher": "^2.0.3-dev.20230916",
     "@nestjs/common": ">= 7.0.1",
     "@nestjs/core": ">= 7.0.1",
     "@nestjs/platform-express": ">= 7.0.1",
@@ -44,10 +44,10 @@
     "raw-body": ">= 2.0.0",
     "reflect-metadata": ">= 0.1.12",
     "rxjs": ">= 6.0.0",
-    "typia": "^5.0.3"
+    "typia": "^5.0.4"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">=2.0.2",
+    "@nestia/fetcher": ">=2.0.3-dev.20230916",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "@nestjs/platform-express": ">=7.0.1",
@@ -56,7 +56,7 @@
     "reflect-metadata": ">=0.1.12",
     "rxjs": ">=6.0.0",
     "typescript": ">=4.8.0",
-    "typia": ">=5.0.3 <6.0.0"
+    "typia": ">=5.0.4 <6.0.0"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/core",
-  "version": "2.0.3-dev.20230916",
+  "version": "2.0.3",
   "description": "Super-fast validation decorators of NestJS",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -34,7 +34,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^2.0.3-dev.20230916",
+    "@nestia/fetcher": "^2.0.3",
     "@nestjs/common": ">= 7.0.1",
     "@nestjs/core": ">= 7.0.1",
     "@nestjs/platform-express": ">= 7.0.1",
@@ -47,7 +47,7 @@
     "typia": "^5.0.4"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">=2.0.3-dev.20230916",
+    "@nestia/fetcher": ">=2.0.3",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "@nestjs/platform-express": ">=7.0.1",

--- a/packages/e2e/README.md
+++ b/packages/e2e/README.md
@@ -3,7 +3,7 @@
 
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/samchon/nestia/blob/master/LICENSE)
 [![npm version](https://img.shields.io/npm/v/@nestia/core.svg)](https://www.npmjs.com/package/@nestia/core)
-[![Downloads](https://img.shields.io/npm/dm/nestia.svg)](https://www.npmjs.com/package/nestia)
+[![Downloads](https://img.shields.io/npm/dm/@nestia/core.svg)](https://www.npmjs.com/package/@nestia/core)
 [![Build Status](https://github.com/samchon/nestia/workflows/build/badge.svg)](https://github.com/samchon/nestia/actions?query=workflow%3Abuild)
 [![Guide Documents](https://img.shields.io/badge/guide-documents-forestgreen)](https://nestia.io/docs/)
 

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -40,7 +40,7 @@
     "ts-node": "^10.9.1",
     "ts-patch": "^3.0.2",
     "typescript": "^5.2.2",
-    "typia": "^5.0.3"
+    "typia": "^5.0.4"
   },
   "dependencies": {
     "chalk": "^4.1.2",

--- a/packages/fetcher/README.md
+++ b/packages/fetcher/README.md
@@ -3,7 +3,7 @@
 
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/samchon/nestia/blob/master/LICENSE)
 [![npm version](https://img.shields.io/npm/v/@nestia/core.svg)](https://www.npmjs.com/package/@nestia/core)
-[![Downloads](https://img.shields.io/npm/dm/nestia.svg)](https://www.npmjs.com/package/nestia)
+[![Downloads](https://img.shields.io/npm/dm/@nestia/core.svg)](https://www.npmjs.com/package/@nestia/core)
 [![Build Status](https://github.com/samchon/nestia/workflows/build/badge.svg)](https://github.com/samchon/nestia/actions?query=workflow%3Abuild)
 [![Guide Documents](https://img.shields.io/badge/guide-documents-forestgreen)](https://nestia.io/docs/)
 

--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/fetcher",
-  "version": "2.0.3-dev.20230916",
+  "version": "2.0.3",
   "description": "Fetcher library of Nestia SDK",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/fetcher",
-  "version": "2.0.2",
+  "version": "2.0.3-dev.20230916",
   "description": "Fetcher library of Nestia SDK",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/migrate/README.md
+++ b/packages/migrate/README.md
@@ -3,7 +3,7 @@
 
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/samchon/nestia/blob/master/LICENSE)
 [![npm version](https://img.shields.io/npm/v/@nestia/core.svg)](https://www.npmjs.com/package/@nestia/core)
-[![Downloads](https://img.shields.io/npm/dm/nestia.svg)](https://www.npmjs.com/package/nestia)
+[![Downloads](https://img.shields.io/npm/dm/@nestia/core.svg)](https://www.npmjs.com/package/@nestia/core)
 [![Build Status](https://github.com/samchon/nestia/workflows/build/badge.svg)](https://github.com/samchon/nestia/actions?query=workflow%3Abuild)
 [![Guide Documents](https://img.shields.io/badge/guide-documents-forestgreen)](https://nestia.io/docs/)
 

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -30,8 +30,8 @@
   },
   "homepage": "https://github.com/samchon/nestia#readme",
   "devDependencies": {
-    "@nestia/core": "^2.0.3-dev.20230916",
-    "@nestia/fetcher": "^2.0.3-dev.20230916",
+    "@nestia/core": "^2.0.3",
+    "@nestia/fetcher": "^2.0.3",
     "@trivago/prettier-plugin-sort-imports": "^4.1.1",
     "@types/node": "^20.3.3",
     "prettier": "^2.8.8",

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -30,8 +30,8 @@
   },
   "homepage": "https://github.com/samchon/nestia#readme",
   "devDependencies": {
-    "@nestia/core": "^2.0.2",
-    "@nestia/fetcher": "^2.0.2",
+    "@nestia/core": "^2.0.3-dev.20230916",
+    "@nestia/fetcher": "^2.0.3-dev.20230916",
     "@trivago/prettier-plugin-sort-imports": "^4.1.1",
     "@types/node": "^20.3.3",
     "prettier": "^2.8.8",
@@ -45,7 +45,7 @@
     "typescript-transform-paths": "^3.4.6"
   },
   "dependencies": {
-    "typia": "^5.0.3"
+    "typia": "^5.0.4"
   },
   "files": [
     "lib",

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -3,7 +3,7 @@
 
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/samchon/nestia/blob/master/LICENSE)
 [![npm version](https://img.shields.io/npm/v/@nestia/core.svg)](https://www.npmjs.com/package/@nestia/core)
-[![Downloads](https://img.shields.io/npm/dm/nestia.svg)](https://www.npmjs.com/package/nestia)
+[![Downloads](https://img.shields.io/npm/dm/@nestia/core.svg)](https://www.npmjs.com/package/@nestia/core)
 [![Build Status](https://github.com/samchon/nestia/workflows/build/badge.svg)](https://github.com/samchon/nestia/actions?query=workflow%3Abuild)
 [![Guide Documents](https://img.shields.io/badge/guide-documents-forestgreen)](https://nestia.io/docs/)
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/sdk",
-  "version": "2.0.2",
+  "version": "2.0.3-dev.20230916",
   "description": "Nestia SDK and Swagger generator",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -35,7 +35,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^2.0.2",
+    "@nestia/fetcher": "^2.0.3-dev.20230916",
     "cli": "^1.0.1",
     "glob": "^7.2.0",
     "path-to-regexp": "^6.2.1",
@@ -44,16 +44,16 @@
     "tsconfck": "^2.0.1",
     "tsconfig-paths": "^4.1.1",
     "tstl": "^2.5.13",
-    "typia": "^5.0.3"
+    "typia": "^5.0.4"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">=2.0.2",
+    "@nestia/fetcher": ">=2.0.3-dev.20230916",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "reflect-metadata": ">=0.1.12",
     "ts-node": ">=10.6.0",
     "typescript": ">=4.8.0",
-    "typia": ">=5.0.3 <6.0.0"
+    "typia": ">=5.0.4 <6.0.0"
   },
   "devDependencies": {
     "@nestjs/common": ">= 7.0.1",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/sdk",
-  "version": "2.0.3-dev.20230916",
+  "version": "2.0.3",
   "description": "Nestia SDK and Swagger generator",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -35,7 +35,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^2.0.3-dev.20230916",
+    "@nestia/fetcher": "^2.0.3",
     "cli": "^1.0.1",
     "glob": "^7.2.0",
     "path-to-regexp": "^6.2.1",
@@ -47,7 +47,7 @@
     "typia": "^5.0.4"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">=2.0.3-dev.20230916",
+    "@nestia/fetcher": ">=2.0.3",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "reflect-metadata": ">=0.1.12",

--- a/test/features/all/swagger.json
+++ b/test/features/all/swagger.json
@@ -327,7 +327,7 @@
             "format": "url",
             "x-typia-typeTags": [
               {
-                "name": "Format<url>",
+                "name": "Format<\"url\">",
                 "target": "string",
                 "kind": "format",
                 "value": "url",
@@ -366,7 +366,7 @@
             "format": "uuid",
             "x-typia-typeTags": [
               {
-                "name": "Format<uuid>",
+                "name": "Format<\"uuid\">",
                 "target": "string",
                 "kind": "format",
                 "value": "uuid",
@@ -393,7 +393,7 @@
             "format": "date-time",
             "x-typia-typeTags": [
               {
-                "name": "Format<date-time>",
+                "name": "Format<\"date-time\">",
                 "target": "string",
                 "kind": "format",
                 "value": "date-time",

--- a/test/features/body-manual-assert/swagger.json
+++ b/test/features/body-manual-assert/swagger.json
@@ -459,7 +459,7 @@
             "format": "url",
             "x-typia-typeTags": [
               {
-                "name": "Format<url>",
+                "name": "Format<\"url\">",
                 "target": "string",
                 "kind": "format",
                 "value": "url",
@@ -498,7 +498,7 @@
             "format": "uuid",
             "x-typia-typeTags": [
               {
-                "name": "Format<uuid>",
+                "name": "Format<\"uuid\">",
                 "target": "string",
                 "kind": "format",
                 "value": "uuid",
@@ -525,7 +525,7 @@
             "format": "date-time",
             "x-typia-typeTags": [
               {
-                "name": "Format<date-time>",
+                "name": "Format<\"date-time\">",
                 "target": "string",
                 "kind": "format",
                 "value": "date-time",

--- a/test/features/body-manual-is/swagger.json
+++ b/test/features/body-manual-is/swagger.json
@@ -459,7 +459,7 @@
             "format": "url",
             "x-typia-typeTags": [
               {
-                "name": "Format<url>",
+                "name": "Format<\"url\">",
                 "target": "string",
                 "kind": "format",
                 "value": "url",
@@ -498,7 +498,7 @@
             "format": "uuid",
             "x-typia-typeTags": [
               {
-                "name": "Format<uuid>",
+                "name": "Format<\"uuid\">",
                 "target": "string",
                 "kind": "format",
                 "value": "uuid",
@@ -525,7 +525,7 @@
             "format": "date-time",
             "x-typia-typeTags": [
               {
-                "name": "Format<date-time>",
+                "name": "Format<\"date-time\">",
                 "target": "string",
                 "kind": "format",
                 "value": "date-time",

--- a/test/features/body-manual-validate/swagger.json
+++ b/test/features/body-manual-validate/swagger.json
@@ -459,7 +459,7 @@
             "format": "url",
             "x-typia-typeTags": [
               {
-                "name": "Format<url>",
+                "name": "Format<\"url\">",
                 "target": "string",
                 "kind": "format",
                 "value": "url",
@@ -498,7 +498,7 @@
             "format": "uuid",
             "x-typia-typeTags": [
               {
-                "name": "Format<uuid>",
+                "name": "Format<\"uuid\">",
                 "target": "string",
                 "kind": "format",
                 "value": "uuid",
@@ -525,7 +525,7 @@
             "format": "date-time",
             "x-typia-typeTags": [
               {
-                "name": "Format<date-time>",
+                "name": "Format<\"date-time\">",
                 "target": "string",
                 "kind": "format",
                 "value": "date-time",

--- a/test/features/body/swagger.json
+++ b/test/features/body/swagger.json
@@ -617,7 +617,7 @@
             "format": "url",
             "x-typia-typeTags": [
               {
-                "name": "Format<url>",
+                "name": "Format<\"url\">",
                 "target": "string",
                 "kind": "format",
                 "value": "url",
@@ -656,7 +656,7 @@
             "format": "uuid",
             "x-typia-typeTags": [
               {
-                "name": "Format<uuid>",
+                "name": "Format<\"uuid\">",
                 "target": "string",
                 "kind": "format",
                 "value": "uuid",
@@ -683,7 +683,7 @@
             "format": "date-time",
             "x-typia-typeTags": [
               {
-                "name": "Format<date-time>",
+                "name": "Format<\"date-time\">",
                 "target": "string",
                 "kind": "format",
                 "value": "date-time",

--- a/test/features/clone/src/api/structures/IBbsArticle.ts
+++ b/test/features/clone/src/api/structures/IBbsArticle.ts
@@ -11,6 +11,7 @@ export type IBbsArticle = {
     id: (string & Format<"uuid">);
     section: string;
     created_at: (string & Format<"date-time">);
+    updated_at: (string & Format<"date-time">);
     title: (string & MinLength<3> & MaxLength<50>);
     body: string;
     files: Array<IAttachmentFile>;
@@ -22,6 +23,7 @@ export namespace IBbsArticle {
         writer: string;
         title: (string & MinLength<3> & MaxLength<50>);
         created_at: (string & Format<"date-time">);
+        updated_at: (string & Format<"date-time">);
     }
     export type IStore = {
         title: (string & MinLength<3> & MaxLength<50>);

--- a/test/features/clone/src/controllers/BbsArticlesController.ts
+++ b/test/features/clone/src/controllers/BbsArticlesController.ts
@@ -107,6 +107,10 @@ interface IBbsArticle extends IBbsArticle.IStore {
     id: string & tags.Format<"uuid">;
     section: string;
     created_at: string & tags.Format<"date-time">;
+    /**
+     * @format date-time
+     */
+    updated_at: string;
 }
 namespace IBbsArticle {
     export interface IStore {
@@ -121,6 +125,10 @@ namespace IBbsArticle {
         writer: string;
         title: string & tags.MinLength<3> & tags.MaxLength<50>;
         created_at: string & tags.Format<"date-time">;
+        /**
+         * @format date-time
+         */
+        updated_at: string;
     }
 }
 

--- a/test/features/clone/swagger.json
+++ b/test/features/clone/swagger.json
@@ -344,7 +344,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/_singlequote_process_singlequote_.global.NodeJS.CpuUsage"
+                  "$ref": "#/components/schemas/_singlequote_node:process_singlequote_.global.NodeJS.CpuUsage"
                 }
               }
             },
@@ -366,7 +366,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/_singlequote_process_singlequote_.global.NodeJS.MemoryUsage"
+                  "$ref": "#/components/schemas/_singlequote_node:process_singlequote_.global.NodeJS.MemoryUsage"
                 }
               }
             },
@@ -388,7 +388,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/_singlequote_process_singlequote_.global.NodeJS.ResourceUsage"
+                  "$ref": "#/components/schemas/_singlequote_node:process_singlequote_.global.NodeJS.ResourceUsage"
                 }
               }
             },
@@ -1125,7 +1125,7 @@
         "description": "Article info.",
         "x-typia-jsDocTags": []
       },
-      "_singlequote_process_singlequote_.global.NodeJS.CpuUsage": {
+      "_singlequote_node:process_singlequote_.global.NodeJS.CpuUsage": {
         "type": "object",
         "properties": {
           "user": {
@@ -1146,7 +1146,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "_singlequote_process_singlequote_.global.NodeJS.MemoryUsage": {
+      "_singlequote_node:process_singlequote_.global.NodeJS.MemoryUsage": {
         "type": "object",
         "properties": {
           "rss": {
@@ -1185,7 +1185,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "_singlequote_process_singlequote_.global.NodeJS.ResourceUsage": {
+      "_singlequote_node:process_singlequote_.global.NodeJS.ResourceUsage": {
         "type": "object",
         "properties": {
           "fsRead": {

--- a/test/features/clone/swagger.json
+++ b/test/features/clone/swagger.json
@@ -755,6 +755,33 @@
                 ]
               }
             ]
+          },
+          "updated_at": {
+            "x-typia-jsDocTags": [
+              {
+                "name": "format",
+                "text": [
+                  {
+                    "text": "date-time",
+                    "kind": "text"
+                  }
+                ]
+              }
+            ],
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "string",
+            "format": "date-time",
+            "x-typia-typeTags": [
+              {
+                "name": "Format<\"date-time\">",
+                "target": "string",
+                "kind": "format",
+                "value": "date-time",
+                "validate": "!isNaN(new Date($input).getTime())",
+                "exclusive": true
+              }
+            ]
           }
         },
         "nullable": false,
@@ -763,7 +790,8 @@
           "section",
           "writer",
           "title",
-          "created_at"
+          "created_at",
+          "updated_at"
         ],
         "x-typia-jsDocTags": []
       },
@@ -1018,6 +1046,33 @@
               }
             ]
           },
+          "updated_at": {
+            "x-typia-jsDocTags": [
+              {
+                "name": "format",
+                "text": [
+                  {
+                    "text": "date-time",
+                    "kind": "text"
+                  }
+                ]
+              }
+            ],
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "string",
+            "format": "date-time",
+            "x-typia-typeTags": [
+              {
+                "name": "Format<\"date-time\">",
+                "target": "string",
+                "kind": "format",
+                "value": "date-time",
+                "validate": "!isNaN(new Date($input).getTime())",
+                "exclusive": true
+              }
+            ]
+          },
           "title": {
             "x-typia-required": true,
             "x-typia-optional": false,
@@ -1062,6 +1117,7 @@
           "id",
           "section",
           "created_at",
+          "updated_at",
           "title",
           "body",
           "files"

--- a/test/features/distribute-assert/packages/api/package.json
+++ b/test/features/distribute-assert/packages/api/package.json
@@ -33,7 +33,7 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "@nestia/fetcher": "^2.0.2",
-    "typia": "^5.0.3"
+    "@nestia/fetcher": "^2.0.3-dev.20230916",
+    "typia": "^5.0.4"
   }
 }

--- a/test/features/distribute-assert/packages/api/package.json
+++ b/test/features/distribute-assert/packages/api/package.json
@@ -33,7 +33,7 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "@nestia/fetcher": "^2.0.3-dev.20230916",
+    "@nestia/fetcher": "^2.0.3",
     "typia": "^5.0.4"
   }
 }

--- a/test/features/distribute-assert/swagger.json
+++ b/test/features/distribute-assert/swagger.json
@@ -448,7 +448,7 @@
             "format": "url",
             "x-typia-typeTags": [
               {
-                "name": "Format<url>",
+                "name": "Format<\"url\">",
                 "target": "string",
                 "kind": "format",
                 "value": "url",
@@ -487,7 +487,7 @@
             "format": "uuid",
             "x-typia-typeTags": [
               {
-                "name": "Format<uuid>",
+                "name": "Format<\"uuid\">",
                 "target": "string",
                 "kind": "format",
                 "value": "uuid",
@@ -519,7 +519,7 @@
             "format": "date-time",
             "x-typia-typeTags": [
               {
-                "name": "Format<date-time>",
+                "name": "Format<\"date-time\">",
                 "target": "string",
                 "kind": "format",
                 "value": "date-time",

--- a/test/features/distribute-json/packages/api/package.json
+++ b/test/features/distribute-json/packages/api/package.json
@@ -33,7 +33,7 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "@nestia/fetcher": "^2.0.2",
-    "typia": "^5.0.3"
+    "@nestia/fetcher": "^2.0.3-dev.20230916",
+    "typia": "^5.0.4"
   }
 }

--- a/test/features/distribute-json/packages/api/package.json
+++ b/test/features/distribute-json/packages/api/package.json
@@ -33,7 +33,7 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "@nestia/fetcher": "^2.0.3-dev.20230916",
+    "@nestia/fetcher": "^2.0.3",
     "typia": "^5.0.4"
   }
 }

--- a/test/features/distribute-json/swagger.json
+++ b/test/features/distribute-json/swagger.json
@@ -448,7 +448,7 @@
             "format": "url",
             "x-typia-typeTags": [
               {
-                "name": "Format<url>",
+                "name": "Format<\"url\">",
                 "target": "string",
                 "kind": "format",
                 "value": "url",
@@ -487,7 +487,7 @@
             "format": "uuid",
             "x-typia-typeTags": [
               {
-                "name": "Format<uuid>",
+                "name": "Format<\"uuid\">",
                 "target": "string",
                 "kind": "format",
                 "value": "uuid",
@@ -519,7 +519,7 @@
             "format": "date-time",
             "x-typia-typeTags": [
               {
-                "name": "Format<date-time>",
+                "name": "Format<\"date-time\">",
                 "target": "string",
                 "kind": "format",
                 "value": "date-time",

--- a/test/features/distribute/packages/api/package.json
+++ b/test/features/distribute/packages/api/package.json
@@ -33,7 +33,7 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "@nestia/fetcher": "^2.0.2",
-    "typia": "^5.0.3"
+    "@nestia/fetcher": "^2.0.3-dev.20230916",
+    "typia": "^5.0.4"
   }
 }

--- a/test/features/distribute/packages/api/package.json
+++ b/test/features/distribute/packages/api/package.json
@@ -33,7 +33,7 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "@nestia/fetcher": "^2.0.3-dev.20230916",
+    "@nestia/fetcher": "^2.0.3",
     "typia": "^5.0.4"
   }
 }

--- a/test/features/distribute/swagger.json
+++ b/test/features/distribute/swagger.json
@@ -448,7 +448,7 @@
             "format": "url",
             "x-typia-typeTags": [
               {
-                "name": "Format<url>",
+                "name": "Format<\"url\">",
                 "target": "string",
                 "kind": "format",
                 "value": "url",
@@ -487,7 +487,7 @@
             "format": "uuid",
             "x-typia-typeTags": [
               {
-                "name": "Format<uuid>",
+                "name": "Format<\"uuid\">",
                 "target": "string",
                 "kind": "format",
                 "value": "uuid",
@@ -519,7 +519,7 @@
             "format": "date-time",
             "x-typia-typeTags": [
               {
-                "name": "Format<date-time>",
+                "name": "Format<\"date-time\">",
                 "target": "string",
                 "kind": "format",
                 "value": "date-time",

--- a/test/features/duplicated/swagger.json
+++ b/test/features/duplicated/swagger.json
@@ -120,7 +120,7 @@
             "format": "uuid",
             "x-typia-typeTags": [
               {
-                "name": "Format<uuid>",
+                "name": "Format<\"uuid\">",
                 "target": "string",
                 "kind": "format",
                 "value": "uuid",
@@ -205,7 +205,7 @@
             "format": "date-time",
             "x-typia-typeTags": [
               {
-                "name": "Format<date-time>",
+                "name": "Format<\"date-time\">",
                 "target": "string",
                 "kind": "format",
                 "value": "date-time",
@@ -329,7 +329,7 @@
             "format": "url",
             "x-typia-typeTags": [
               {
-                "name": "Format<url>",
+                "name": "Format<\"url\">",
                 "target": "string",
                 "kind": "format",
                 "value": "url",

--- a/test/features/e2e/swagger.json
+++ b/test/features/e2e/swagger.json
@@ -448,7 +448,7 @@
             "format": "url",
             "x-typia-typeTags": [
               {
-                "name": "Format<url>",
+                "name": "Format<\"url\">",
                 "target": "string",
                 "kind": "format",
                 "value": "url",
@@ -487,7 +487,7 @@
             "format": "uuid",
             "x-typia-typeTags": [
               {
-                "name": "Format<uuid>",
+                "name": "Format<\"uuid\">",
                 "target": "string",
                 "kind": "format",
                 "value": "uuid",
@@ -519,7 +519,7 @@
             "format": "date-time",
             "x-typia-typeTags": [
               {
-                "name": "Format<date-time>",
+                "name": "Format<\"date-time\">",
                 "target": "string",
                 "kind": "format",
                 "value": "date-time",

--- a/test/features/exception-filter/swagger.json
+++ b/test/features/exception-filter/swagger.json
@@ -362,7 +362,7 @@
             "format": "url",
             "x-typia-typeTags": [
               {
-                "name": "Format<url>",
+                "name": "Format<\"url\">",
                 "target": "string",
                 "kind": "format",
                 "value": "url",
@@ -401,7 +401,7 @@
             "format": "uuid",
             "x-typia-typeTags": [
               {
-                "name": "Format<uuid>",
+                "name": "Format<\"uuid\">",
                 "target": "string",
                 "kind": "format",
                 "value": "uuid",
@@ -428,7 +428,7 @@
             "format": "date-time",
             "x-typia-typeTags": [
               {
-                "name": "Format<date-time>",
+                "name": "Format<\"date-time\">",
                 "target": "string",
                 "kind": "format",
                 "value": "date-time",

--- a/test/features/exception/swagger.json
+++ b/test/features/exception/swagger.json
@@ -544,7 +544,7 @@
             "format": "url",
             "x-typia-typeTags": [
               {
-                "name": "Format<url>",
+                "name": "Format<\"url\">",
                 "target": "string",
                 "kind": "format",
                 "value": "url",
@@ -705,7 +705,7 @@
             "format": "uuid",
             "x-typia-typeTags": [
               {
-                "name": "Format<uuid>",
+                "name": "Format<\"uuid\">",
                 "target": "string",
                 "kind": "format",
                 "value": "uuid",
@@ -732,7 +732,7 @@
             "format": "date-time",
             "x-typia-typeTags": [
               {
-                "name": "Format<date-time>",
+                "name": "Format<\"date-time\">",
                 "target": "string",
                 "kind": "format",
                 "value": "date-time",

--- a/test/features/fastify/swagger.json
+++ b/test/features/fastify/swagger.json
@@ -755,7 +755,7 @@
             "type": "integer",
             "x-typia-typeTags": [
               {
-                "name": "Type<uint32>",
+                "name": "Type<\"uint32\">",
                 "target": "number",
                 "kind": "type",
                 "value": "uint32",
@@ -782,7 +782,7 @@
             "type": "integer",
             "x-typia-typeTags": [
               {
-                "name": "Type<uint32>",
+                "name": "Type<\"uint32\">",
                 "target": "number",
                 "kind": "type",
                 "value": "uint32",
@@ -840,7 +840,7 @@
             "format": "uuid",
             "x-typia-typeTags": [
               {
-                "name": "Format<uuid>",
+                "name": "Format<\"uuid\">",
                 "target": "string",
                 "kind": "format",
                 "value": "uuid",
@@ -922,7 +922,7 @@
             "format": "date-time",
             "x-typia-typeTags": [
               {
-                "name": "Format<date-time>",
+                "name": "Format<\"date-time\">",
                 "target": "string",
                 "kind": "format",
                 "value": "date-time",
@@ -962,7 +962,7 @@
             "type": "integer",
             "x-typia-typeTags": [
               {
-                "name": "Type<uint32>",
+                "name": "Type<\"uint32\">",
                 "target": "number",
                 "kind": "type",
                 "value": "uint32",
@@ -988,7 +988,7 @@
             "type": "integer",
             "x-typia-typeTags": [
               {
-                "name": "Type<uint32>",
+                "name": "Type<\"uint32\">",
                 "target": "number",
                 "kind": "type",
                 "value": "uint32",
@@ -1014,7 +1014,7 @@
             "type": "integer",
             "x-typia-typeTags": [
               {
-                "name": "Type<uint32>",
+                "name": "Type<\"uint32\">",
                 "target": "number",
                 "kind": "type",
                 "value": "uint32",
@@ -1040,7 +1040,7 @@
             "type": "integer",
             "x-typia-typeTags": [
               {
-                "name": "Type<uint32>",
+                "name": "Type<\"uint32\">",
                 "target": "number",
                 "kind": "type",
                 "value": "uint32",
@@ -1234,7 +1234,7 @@
             "format": "url",
             "x-typia-typeTags": [
               {
-                "name": "Format<url>",
+                "name": "Format<\"url\">",
                 "target": "string",
                 "kind": "format",
                 "value": "url",
@@ -1273,7 +1273,7 @@
             "format": "uuid",
             "x-typia-typeTags": [
               {
-                "name": "Format<uuid>",
+                "name": "Format<\"uuid\">",
                 "target": "string",
                 "kind": "format",
                 "value": "uuid",
@@ -1305,7 +1305,7 @@
             "format": "date-time",
             "x-typia-typeTags": [
               {
-                "name": "Format<date-time>",
+                "name": "Format<\"date-time\">",
                 "target": "string",
                 "kind": "format",
                 "value": "date-time",

--- a/test/features/headers-decompose/swagger.json
+++ b/test/features/headers-decompose/swagger.json
@@ -556,7 +556,7 @@
             "format": "url",
             "x-typia-typeTags": [
               {
-                "name": "Format<url>",
+                "name": "Format<\"url\">",
                 "target": "string",
                 "kind": "format",
                 "value": "url",
@@ -595,7 +595,7 @@
             "format": "uuid",
             "x-typia-typeTags": [
               {
-                "name": "Format<uuid>",
+                "name": "Format<\"uuid\">",
                 "target": "string",
                 "kind": "format",
                 "value": "uuid",
@@ -622,7 +622,7 @@
             "format": "date-time",
             "x-typia-typeTags": [
               {
-                "name": "Format<date-time>",
+                "name": "Format<\"date-time\">",
                 "target": "string",
                 "kind": "format",
                 "value": "date-time",

--- a/test/features/headers/swagger.json
+++ b/test/features/headers/swagger.json
@@ -603,7 +603,7 @@
             "format": "url",
             "x-typia-typeTags": [
               {
-                "name": "Format<url>",
+                "name": "Format<\"url\">",
                 "target": "string",
                 "kind": "format",
                 "value": "url",
@@ -642,7 +642,7 @@
             "format": "uuid",
             "x-typia-typeTags": [
               {
-                "name": "Format<uuid>",
+                "name": "Format<\"uuid\">",
                 "target": "string",
                 "kind": "format",
                 "value": "uuid",
@@ -669,7 +669,7 @@
             "format": "date-time",
             "x-typia-typeTags": [
               {
-                "name": "Format<date-time>",
+                "name": "Format<\"date-time\">",
                 "target": "string",
                 "kind": "format",
                 "value": "date-time",

--- a/test/features/kebab/swagger.json
+++ b/test/features/kebab/swagger.json
@@ -327,7 +327,7 @@
             "format": "url",
             "x-typia-typeTags": [
               {
-                "name": "Format<url>",
+                "name": "Format<\"url\">",
                 "target": "string",
                 "kind": "format",
                 "value": "url",
@@ -366,7 +366,7 @@
             "format": "uuid",
             "x-typia-typeTags": [
               {
-                "name": "Format<uuid>",
+                "name": "Format<\"uuid\">",
                 "target": "string",
                 "kind": "format",
                 "value": "uuid",
@@ -393,7 +393,7 @@
             "format": "date-time",
             "x-typia-typeTags": [
               {
-                "name": "Format<date-time>",
+                "name": "Format<\"date-time\">",
                 "target": "string",
                 "kind": "format",
                 "value": "date-time",

--- a/test/features/route-manual-assert/swagger.json
+++ b/test/features/route-manual-assert/swagger.json
@@ -295,7 +295,7 @@
             "format": "uuid",
             "x-typia-typeTags": [
               {
-                "name": "Format<uuid>",
+                "name": "Format<\"uuid\">",
                 "target": "string",
                 "kind": "format",
                 "value": "uuid",
@@ -380,7 +380,7 @@
             "format": "date-time",
             "x-typia-typeTags": [
               {
-                "name": "Format<date-time>",
+                "name": "Format<\"date-time\">",
                 "target": "string",
                 "kind": "format",
                 "value": "date-time",
@@ -504,7 +504,7 @@
             "format": "url",
             "x-typia-typeTags": [
               {
-                "name": "Format<url>",
+                "name": "Format<\"url\">",
                 "target": "string",
                 "kind": "format",
                 "value": "url",

--- a/test/features/route-manual-is/swagger.json
+++ b/test/features/route-manual-is/swagger.json
@@ -295,7 +295,7 @@
             "format": "uuid",
             "x-typia-typeTags": [
               {
-                "name": "Format<uuid>",
+                "name": "Format<\"uuid\">",
                 "target": "string",
                 "kind": "format",
                 "value": "uuid",
@@ -380,7 +380,7 @@
             "format": "date-time",
             "x-typia-typeTags": [
               {
-                "name": "Format<date-time>",
+                "name": "Format<\"date-time\">",
                 "target": "string",
                 "kind": "format",
                 "value": "date-time",
@@ -504,7 +504,7 @@
             "format": "url",
             "x-typia-typeTags": [
               {
-                "name": "Format<url>",
+                "name": "Format<\"url\">",
                 "target": "string",
                 "kind": "format",
                 "value": "url",

--- a/test/features/route-manual-stringify/swagger.json
+++ b/test/features/route-manual-stringify/swagger.json
@@ -295,7 +295,7 @@
             "format": "uuid",
             "x-typia-typeTags": [
               {
-                "name": "Format<uuid>",
+                "name": "Format<\"uuid\">",
                 "target": "string",
                 "kind": "format",
                 "value": "uuid",
@@ -380,7 +380,7 @@
             "format": "date-time",
             "x-typia-typeTags": [
               {
-                "name": "Format<date-time>",
+                "name": "Format<\"date-time\">",
                 "target": "string",
                 "kind": "format",
                 "value": "date-time",
@@ -504,7 +504,7 @@
             "format": "url",
             "x-typia-typeTags": [
               {
-                "name": "Format<url>",
+                "name": "Format<\"url\">",
                 "target": "string",
                 "kind": "format",
                 "value": "url",

--- a/test/features/route-manual-validate/swagger.json
+++ b/test/features/route-manual-validate/swagger.json
@@ -295,7 +295,7 @@
             "format": "uuid",
             "x-typia-typeTags": [
               {
-                "name": "Format<uuid>",
+                "name": "Format<\"uuid\">",
                 "target": "string",
                 "kind": "format",
                 "value": "uuid",
@@ -380,7 +380,7 @@
             "format": "date-time",
             "x-typia-typeTags": [
               {
-                "name": "Format<date-time>",
+                "name": "Format<\"date-time\">",
                 "target": "string",
                 "kind": "format",
                 "value": "date-time",
@@ -504,7 +504,7 @@
             "format": "url",
             "x-typia-typeTags": [
               {
-                "name": "Format<url>",
+                "name": "Format<\"url\">",
                 "target": "string",
                 "kind": "format",
                 "value": "url",

--- a/test/features/route/swagger.json
+++ b/test/features/route/swagger.json
@@ -295,7 +295,7 @@
             "format": "uuid",
             "x-typia-typeTags": [
               {
-                "name": "Format<uuid>",
+                "name": "Format<\"uuid\">",
                 "target": "string",
                 "kind": "format",
                 "value": "uuid",
@@ -380,7 +380,7 @@
             "format": "date-time",
             "x-typia-typeTags": [
               {
-                "name": "Format<date-time>",
+                "name": "Format<\"date-time\">",
                 "target": "string",
                 "kind": "format",
                 "value": "date-time",
@@ -504,7 +504,7 @@
             "format": "url",
             "x-typia-typeTags": [
               {
-                "name": "Format<url>",
+                "name": "Format<\"url\">",
                 "target": "string",
                 "kind": "format",
                 "value": "url",

--- a/test/features/simulate/swagger.json
+++ b/test/features/simulate/swagger.json
@@ -885,7 +885,7 @@
             "type": "integer",
             "x-typia-typeTags": [
               {
-                "name": "Type<uint32>",
+                "name": "Type<\"uint32\">",
                 "target": "number",
                 "kind": "type",
                 "value": "uint32",
@@ -912,7 +912,7 @@
             "type": "integer",
             "x-typia-typeTags": [
               {
-                "name": "Type<uint32>",
+                "name": "Type<\"uint32\">",
                 "target": "number",
                 "kind": "type",
                 "value": "uint32",
@@ -970,7 +970,7 @@
             "format": "uuid",
             "x-typia-typeTags": [
               {
-                "name": "Format<uuid>",
+                "name": "Format<\"uuid\">",
                 "target": "string",
                 "kind": "format",
                 "value": "uuid",
@@ -1052,7 +1052,7 @@
             "format": "date-time",
             "x-typia-typeTags": [
               {
-                "name": "Format<date-time>",
+                "name": "Format<\"date-time\">",
                 "target": "string",
                 "kind": "format",
                 "value": "date-time",
@@ -1092,7 +1092,7 @@
             "type": "integer",
             "x-typia-typeTags": [
               {
-                "name": "Type<uint32>",
+                "name": "Type<\"uint32\">",
                 "target": "number",
                 "kind": "type",
                 "value": "uint32",
@@ -1118,7 +1118,7 @@
             "type": "integer",
             "x-typia-typeTags": [
               {
-                "name": "Type<uint32>",
+                "name": "Type<\"uint32\">",
                 "target": "number",
                 "kind": "type",
                 "value": "uint32",
@@ -1144,7 +1144,7 @@
             "type": "integer",
             "x-typia-typeTags": [
               {
-                "name": "Type<uint32>",
+                "name": "Type<\"uint32\">",
                 "target": "number",
                 "kind": "type",
                 "value": "uint32",
@@ -1170,7 +1170,7 @@
             "type": "integer",
             "x-typia-typeTags": [
               {
-                "name": "Type<uint32>",
+                "name": "Type<\"uint32\">",
                 "target": "number",
                 "kind": "type",
                 "value": "uint32",
@@ -1211,7 +1211,7 @@
             "format": "uuid",
             "x-typia-typeTags": [
               {
-                "name": "Format<uuid>",
+                "name": "Format<\"uuid\">",
                 "target": "string",
                 "kind": "format",
                 "value": "uuid",
@@ -1243,7 +1243,7 @@
             "format": "date-time",
             "x-typia-typeTags": [
               {
-                "name": "Format<date-time>",
+                "name": "Format<\"date-time\">",
                 "target": "string",
                 "kind": "format",
                 "value": "date-time",
@@ -1426,7 +1426,7 @@
             "format": "url",
             "x-typia-typeTags": [
               {
-                "name": "Format<url>",
+                "name": "Format<\"url\">",
                 "target": "string",
                 "kind": "format",
                 "value": "url",

--- a/test/features/status/swagger.json
+++ b/test/features/status/swagger.json
@@ -295,7 +295,7 @@
             "format": "uuid",
             "x-typia-typeTags": [
               {
-                "name": "Format<uuid>",
+                "name": "Format<\"uuid\">",
                 "target": "string",
                 "kind": "format",
                 "value": "uuid",
@@ -380,7 +380,7 @@
             "format": "date-time",
             "x-typia-typeTags": [
               {
-                "name": "Format<date-time>",
+                "name": "Format<\"date-time\">",
                 "target": "string",
                 "kind": "format",
                 "value": "date-time",
@@ -504,7 +504,7 @@
             "format": "url",
             "x-typia-typeTags": [
               {
-                "name": "Format<url>",
+                "name": "Format<\"url\">",
                 "target": "string",
                 "kind": "format",
                 "value": "url",

--- a/test/features/tags/swagger.json
+++ b/test/features/tags/swagger.json
@@ -439,7 +439,7 @@
             "format": "url",
             "x-typia-typeTags": [
               {
-                "name": "Format<url>",
+                "name": "Format<\"url\">",
                 "target": "string",
                 "kind": "format",
                 "value": "url",
@@ -478,7 +478,7 @@
             "format": "uuid",
             "x-typia-typeTags": [
               {
-                "name": "Format<uuid>",
+                "name": "Format<\"uuid\">",
                 "target": "string",
                 "kind": "format",
                 "value": "uuid",
@@ -510,7 +510,7 @@
             "format": "date-time",
             "x-typia-typeTags": [
               {
-                "name": "Format<date-time>",
+                "name": "Format<\"date-time\">",
                 "target": "string",
                 "kind": "format",
                 "value": "date-time",

--- a/test/features/variable/swagger.json
+++ b/test/features/variable/swagger.json
@@ -750,7 +750,7 @@
             "type": "integer",
             "x-typia-typeTags": [
               {
-                "name": "Type<uint32>",
+                "name": "Type<\"uint32\">",
                 "target": "number",
                 "kind": "type",
                 "value": "uint32",
@@ -777,7 +777,7 @@
             "type": "integer",
             "x-typia-typeTags": [
               {
-                "name": "Type<uint32>",
+                "name": "Type<\"uint32\">",
                 "target": "number",
                 "kind": "type",
                 "value": "uint32",
@@ -835,7 +835,7 @@
             "format": "uuid",
             "x-typia-typeTags": [
               {
-                "name": "Format<uuid>",
+                "name": "Format<\"uuid\">",
                 "target": "string",
                 "kind": "format",
                 "value": "uuid",
@@ -917,7 +917,7 @@
             "format": "date-time",
             "x-typia-typeTags": [
               {
-                "name": "Format<date-time>",
+                "name": "Format<\"date-time\">",
                 "target": "string",
                 "kind": "format",
                 "value": "date-time",
@@ -957,7 +957,7 @@
             "type": "integer",
             "x-typia-typeTags": [
               {
-                "name": "Type<uint32>",
+                "name": "Type<\"uint32\">",
                 "target": "number",
                 "kind": "type",
                 "value": "uint32",
@@ -983,7 +983,7 @@
             "type": "integer",
             "x-typia-typeTags": [
               {
-                "name": "Type<uint32>",
+                "name": "Type<\"uint32\">",
                 "target": "number",
                 "kind": "type",
                 "value": "uint32",
@@ -1009,7 +1009,7 @@
             "type": "integer",
             "x-typia-typeTags": [
               {
-                "name": "Type<uint32>",
+                "name": "Type<\"uint32\">",
                 "target": "number",
                 "kind": "type",
                 "value": "uint32",
@@ -1035,7 +1035,7 @@
             "type": "integer",
             "x-typia-typeTags": [
               {
-                "name": "Type<uint32>",
+                "name": "Type<\"uint32\">",
                 "target": "number",
                 "kind": "type",
                 "value": "uint32",
@@ -1076,7 +1076,7 @@
             "format": "uuid",
             "x-typia-typeTags": [
               {
-                "name": "Format<uuid>",
+                "name": "Format<\"uuid\">",
                 "target": "string",
                 "kind": "format",
                 "value": "uuid",
@@ -1108,7 +1108,7 @@
             "format": "date-time",
             "x-typia-typeTags": [
               {
-                "name": "Format<date-time>",
+                "name": "Format<\"date-time\">",
                 "target": "string",
                 "kind": "format",
                 "value": "date-time",
@@ -1291,7 +1291,7 @@
             "format": "url",
             "x-typia-typeTags": [
               {
-                "name": "Format<url>",
+                "name": "Format<\"url\">",
                 "target": "string",
                 "kind": "format",
                 "value": "url",

--- a/test/package.json
+++ b/test/package.json
@@ -34,12 +34,12 @@
     "ts-patch": "v3.0.2",
     "typescript": "^5.1.6",
     "typescript-transform-paths": "^3.4.4",
-    "typia": "^5.0.3",
+    "typia": "^5.0.4",
     "uuid": "^9.0.0",
     "nestia": "../packages/cli/nestia-4.5.0.tgz",
-    "@nestia/core": "../packages/core/nestia-core-2.0.2.tgz",
+    "@nestia/core": "../packages/core/nestia-core-2.0.3-dev.20230916.tgz",
     "@nestia/e2e": "../packages/e2e/nestia-e2e-0.3.6.tgz",
-    "@nestia/fetcher": "../packages/fetcher/nestia-fetcher-2.0.2.tgz",
-    "@nestia/sdk": "../packages/sdk/nestia-sdk-2.0.2.tgz"
+    "@nestia/fetcher": "../packages/fetcher/nestia-fetcher-2.0.3-dev.20230916.tgz",
+    "@nestia/sdk": "../packages/sdk/nestia-sdk-2.0.3-dev.20230916.tgz"
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -28,7 +28,7 @@
     "@nestia/migrate": "../packages/migrate/nestia-migrate-0.3.0.tgz",
     "@nestjs/swagger": "^7.1.2",
     "@types/express": "^4.17.17",
-    "@types/node": "^18.11.15",
+    "@types/node": "18.11.15",
     "@types/uuid": "^9.0.0",
     "ts-node": "^10.9.1",
     "ts-patch": "v3.0.2",

--- a/test/package.json
+++ b/test/package.json
@@ -37,9 +37,9 @@
     "typia": "^5.0.4",
     "uuid": "^9.0.0",
     "nestia": "../packages/cli/nestia-4.5.0.tgz",
-    "@nestia/core": "../packages/core/nestia-core-2.0.3-dev.20230916.tgz",
+    "@nestia/core": "../packages/core/nestia-core-2.0.3.tgz",
     "@nestia/e2e": "../packages/e2e/nestia-e2e-0.3.6.tgz",
-    "@nestia/fetcher": "../packages/fetcher/nestia-fetcher-2.0.3-dev.20230916.tgz",
-    "@nestia/sdk": "../packages/sdk/nestia-sdk-2.0.3-dev.20230916.tgz"
+    "@nestia/fetcher": "../packages/fetcher/nestia-fetcher-2.0.3.tgz",
+    "@nestia/sdk": "../packages/sdk/nestia-sdk-2.0.3.tgz"
   }
 }


### PR DESCRIPTION
When DTO clone mode be turned on and comment tags being used, `@nestia/sdk`'s DTO cloner defined both type tags and comment tags at the same time, and it caused compile time error of `typia`.

Therefore, fixed the bug.