### PR TITLE
Fix(typo): Update setup.mdx

### DIFF
--- a/website/pages/docs/setup.mdx
+++ b/website/pages/docs/setup.mdx
@@ -42,7 +42,7 @@ yarn nestia setup --manager yarn
     </Tab>
 </Tabs>
 
-When you want to setup `nestia` in exiting project, just run above `npx nestia setup` command.
+When you want to setup `nestia` in existing project, just run above `npx nestia setup` command.
 
 Setup Wizard will install and configure everything automatically.
 


### PR DESCRIPTION
In the setup.mdx , it said 
`When you want to set up nestia in exiting project ....` it should say 
`existing` rather than `exiting`


