### PR TITLE
Fix `decompose` option's bug on swagger generator with comment tags.

### DIFF
--- a/packages/sdk/src/structures/ISwaggerLazyProperty.ts
+++ b/packages/sdk/src/structures/ISwaggerLazyProperty.ts
@@ -1,0 +1,7 @@
+import { IJsonSchema } from "typia";
+
+export interface ISwaggerLazyProperty {
+    schema: IJsonSchema;
+    object: string;
+    property: string;
+}

--- a/packages/sdk/src/structures/ISwaggerLazySchema.ts
+++ b/packages/sdk/src/structures/ISwaggerLazySchema.ts
@@ -1,7 +1,7 @@
 import { IJsonSchema } from "typia";
 import { Metadata } from "typia/lib/schemas/metadata/Metadata";
 
-export interface ISwaggerSchemaTuple {
+export interface ISwaggerLazySchema {
     metadata: Metadata;
     schema: IJsonSchema;
 }

--- a/test/features/headers-decompose/swagger.json
+++ b/test/features/headers-decompose/swagger.json
@@ -23,6 +23,8 @@
             "name": "x-category",
             "in": "header",
             "schema": {
+              "x-typia-required": true,
+              "x-typia-optional": false,
               "type": "string",
               "enum": [
                 "x",
@@ -36,6 +38,8 @@
             "name": "x-memo",
             "in": "header",
             "schema": {
+              "x-typia-required": false,
+              "x-typia-optional": true,
               "type": "string"
             },
             "required": false
@@ -44,7 +48,21 @@
             "name": "x-name",
             "in": "header",
             "schema": {
-              "type": "string"
+              "x-typia-jsDocTags": [
+                {
+                  "name": "default",
+                  "text": [
+                    {
+                      "text": "Samchon",
+                      "kind": "text"
+                    }
+                  ]
+                }
+              ],
+              "x-typia-required": false,
+              "x-typia-optional": true,
+              "type": "string",
+              "default": "Samchon"
             },
             "required": false
           },
@@ -52,8 +70,12 @@
             "name": "x-values",
             "in": "header",
             "schema": {
+              "x-typia-required": true,
+              "x-typia-optional": false,
               "type": "array",
               "items": {
+                "x-typia-required": true,
+                "x-typia-optional": false,
                 "type": "number"
               }
             },
@@ -63,20 +85,13 @@
             "name": "x-flags",
             "in": "header",
             "schema": {
+              "x-typia-required": true,
+              "x-typia-optional": false,
               "type": "array",
               "items": {
+                "x-typia-required": true,
+                "x-typia-optional": false,
                 "type": "boolean"
-              }
-            },
-            "required": true
-          },
-          {
-            "name": "X-descriptions",
-            "in": "header",
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
               }
             },
             "required": true
@@ -115,6 +130,8 @@
             "name": "x-category",
             "in": "header",
             "schema": {
+              "x-typia-required": true,
+              "x-typia-optional": false,
               "type": "string",
               "enum": [
                 "x",
@@ -128,6 +145,8 @@
             "name": "x-memo",
             "in": "header",
             "schema": {
+              "x-typia-required": false,
+              "x-typia-optional": true,
               "type": "string"
             },
             "required": false
@@ -136,7 +155,21 @@
             "name": "x-name",
             "in": "header",
             "schema": {
-              "type": "string"
+              "x-typia-jsDocTags": [
+                {
+                  "name": "default",
+                  "text": [
+                    {
+                      "text": "Samchon",
+                      "kind": "text"
+                    }
+                  ]
+                }
+              ],
+              "x-typia-required": false,
+              "x-typia-optional": true,
+              "type": "string",
+              "default": "Samchon"
             },
             "required": false
           },
@@ -144,8 +177,12 @@
             "name": "x-values",
             "in": "header",
             "schema": {
+              "x-typia-required": true,
+              "x-typia-optional": false,
               "type": "array",
               "items": {
+                "x-typia-required": true,
+                "x-typia-optional": false,
                 "type": "number"
               }
             },
@@ -155,20 +192,13 @@
             "name": "x-flags",
             "in": "header",
             "schema": {
+              "x-typia-required": true,
+              "x-typia-optional": false,
               "type": "array",
               "items": {
+                "x-typia-required": true,
+                "x-typia-optional": false,
                 "type": "boolean"
-              }
-            },
-            "required": true
-          },
-          {
-            "name": "X-descriptions",
-            "in": "header",
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
               }
             },
             "required": true

--- a/test/features/query-decompose/swagger.json
+++ b/test/features/query-decompose/swagger.json
@@ -23,6 +23,8 @@
             "name": "limit",
             "in": "query",
             "schema": {
+              "x-typia-required": false,
+              "x-typia-optional": true,
               "type": "number"
             },
             "required": false
@@ -31,6 +33,8 @@
             "name": "enforce",
             "in": "query",
             "schema": {
+              "x-typia-required": true,
+              "x-typia-optional": false,
               "type": "boolean"
             },
             "required": true
@@ -39,8 +43,12 @@
             "name": "values",
             "in": "query",
             "schema": {
+              "x-typia-required": true,
+              "x-typia-optional": false,
               "type": "array",
               "items": {
+                "x-typia-required": true,
+                "x-typia-optional": false,
                 "type": "string"
               }
             },
@@ -50,6 +58,8 @@
             "name": "atomic",
             "in": "query",
             "schema": {
+              "x-typia-required": true,
+              "x-typia-optional": false,
               "type": "string",
               "nullable": true
             },
@@ -83,6 +93,8 @@
             "in": "query",
             "schema": {
               "type": "string",
+              "x-typia-required": false,
+              "x-typia-optional": true,
               "pattern": "^([+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?)$"
             },
             "required": false
@@ -91,6 +103,8 @@
             "name": "enforce",
             "in": "query",
             "schema": {
+              "x-typia-required": true,
+              "x-typia-optional": false,
               "type": "string",
               "enum": [
                 "false",
@@ -103,6 +117,8 @@
             "name": "atomic",
             "in": "query",
             "schema": {
+              "x-typia-required": true,
+              "x-typia-optional": false,
               "type": "string"
             },
             "required": true
@@ -111,8 +127,12 @@
             "name": "values",
             "in": "query",
             "schema": {
+              "x-typia-required": true,
+              "x-typia-optional": false,
               "type": "array",
               "items": {
+                "x-typia-required": true,
+                "x-typia-optional": false,
                 "type": "string"
               }
             },
@@ -186,6 +206,8 @@
             "name": "limit",
             "in": "query",
             "schema": {
+              "x-typia-required": false,
+              "x-typia-optional": true,
               "type": "number"
             },
             "required": false
@@ -194,6 +216,8 @@
             "name": "enforce",
             "in": "query",
             "schema": {
+              "x-typia-required": true,
+              "x-typia-optional": false,
               "type": "boolean"
             },
             "required": true
@@ -202,8 +226,12 @@
             "name": "values",
             "in": "query",
             "schema": {
+              "x-typia-required": true,
+              "x-typia-optional": false,
               "type": "array",
               "items": {
+                "x-typia-required": true,
+                "x-typia-optional": false,
                 "type": "string"
               }
             },
@@ -266,6 +294,79 @@
           "enforce",
           "values",
           "atomic"
+        ],
+        "x-typia-jsDocTags": []
+      },
+      "INestQuery": {
+        "type": "object",
+        "properties": {
+          "limit": {
+            "type": "string",
+            "x-typia-required": false,
+            "x-typia-optional": true,
+            "pattern": "^([+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?)$"
+          },
+          "enforce": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "string",
+            "enum": [
+              "false",
+              "true"
+            ]
+          },
+          "atomic": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "string"
+          },
+          "values": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "array",
+            "items": {
+              "x-typia-required": true,
+              "x-typia-optional": false,
+              "type": "string"
+            }
+          }
+        },
+        "nullable": false,
+        "required": [
+          "enforce",
+          "atomic",
+          "values"
+        ],
+        "x-typia-jsDocTags": []
+      },
+      "Omit<IQuery, \"atomic\">": {
+        "type": "object",
+        "properties": {
+          "limit": {
+            "x-typia-required": false,
+            "x-typia-optional": true,
+            "type": "number"
+          },
+          "enforce": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "boolean"
+          },
+          "values": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "array",
+            "items": {
+              "x-typia-required": true,
+              "x-typia-optional": false,
+              "type": "string"
+            }
+          }
+        },
+        "nullable": false,
+        "required": [
+          "enforce",
+          "values"
         ],
         "x-typia-jsDocTags": []
       }


### PR DESCRIPTION
When `decompose` option being used in swagger generator, comment tags written on property had been ignored.

```typescript
export interface IHeaders {
    "x-category": "x" | "y" | "z";
    "x-memo"?: string;

    /**
     * @default Samchon
     */
    "x-name"?: string;
    "x-values": number[];
    "x-flags": boolean[];

    /**
     * @hidden
     */
    "X-descriptions": string[];
}
```
