### PR TITLE
Deprecated property of `faastify`.

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/core",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Super-fast validation decorators of NestJS",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -34,7 +34,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^2.1.0",
+    "@nestia/fetcher": "^2.1.1",
     "@nestjs/common": ">= 7.0.1",
     "@nestjs/core": ">= 7.0.1",
     "@nestjs/platform-express": ">= 7.0.1",
@@ -47,7 +47,7 @@
     "typia": "^5.1.1"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">=2.1.0",
+    "@nestia/fetcher": ">=2.1.1",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "@nestjs/platform-express": ">=7.0.1",

--- a/packages/core/src/decorators/internal/route_error.ts
+++ b/packages/core/src/decorators/internal/route_error.ts
@@ -28,6 +28,7 @@ export function route_error(
         error.method = request.method;
         error.path =
             (request as express.Request).path ??
+            (request as FastifyRequest).routeOptions?.url ??
             (request as FastifyRequest).routerPath;
     } catch {}
 

--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/fetcher",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Fetcher library of Nestia SDK",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/sdk",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Nestia SDK and Swagger generator",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -35,7 +35,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^2.1.0",
+    "@nestia/fetcher": "^2.1.1",
     "cli": "^1.0.1",
     "glob": "^7.2.0",
     "path-to-regexp": "^6.2.1",
@@ -47,7 +47,7 @@
     "typia": "^5.1.1"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">=2.1.0",
+    "@nestia/fetcher": ">=2.1.1",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "reflect-metadata": ">=0.1.12",

--- a/test/features/distribute-assert/packages/api/package.json
+++ b/test/features/distribute-assert/packages/api/package.json
@@ -33,7 +33,7 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "@nestia/fetcher": "file:../../../../../packages/fetcher/nestia-fetcher-0.0.0-dev.20991231.tgz",
+    "@nestia/fetcher": "^2.1.1",
     "typia": "^5.1.1"
   }
 }

--- a/test/features/distribute-json/packages/api/package.json
+++ b/test/features/distribute-json/packages/api/package.json
@@ -33,7 +33,7 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "@nestia/fetcher": "file:../../../../../packages/fetcher/nestia-fetcher-0.0.0-dev.20991231.tgz",
+    "@nestia/fetcher": "^2.1.1",
     "typia": "^5.1.1"
   }
 }

--- a/test/features/distribute/packages/api/package.json
+++ b/test/features/distribute/packages/api/package.json
@@ -33,7 +33,7 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "@nestia/fetcher": "file:../../../../../packages/fetcher/nestia-fetcher-0.0.0-dev.20991231.tgz",
+    "@nestia/fetcher": "^2.1.1",
     "typia": "^5.1.1"
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@nestia/test",
-  "version": "0.0.0-dev.20991231",
+  "version": "2.1.1",
   "description": "Test program of Nestia",
   "main": "index.js",
   "scripts": {
@@ -36,9 +36,9 @@
     "typia": "^5.1.1",
     "uuid": "^9.0.0",
     "nestia": "^4.5.0",
-    "@nestia/core": "D:\\github\\samchon\\nestia\\packages\\core\\nestia-core-0.0.0-dev.20991231.tgz",
+    "@nestia/core": "^2.1.1",
     "@nestia/e2e": "^0.3.6",
-    "@nestia/fetcher": "D:\\github\\samchon\\nestia\\packages\\fetcher\\nestia-fetcher-0.0.0-dev.20991231.tgz",
-    "@nestia/sdk": "D:\\github\\samchon\\nestia\\packages\\sdk\\nestia-sdk-0.0.0-dev.20991231.tgz"
+    "@nestia/fetcher": "^2.1.1",
+    "@nestia/sdk": "^2.1.1"
   }
 }


### PR DESCRIPTION
`fastify@5` has depreacted `req.routePath` property like below. Therefore, changed  my code as `fastify` recommended.

```bash
(node:3756) [FSTDEP017] FastifyDeprecation: You are accessing the deprecated "request.routerPath" property. Use "request.routeOptions.url" instead. Property "req.routerPath" will be removed in `fastify@5`
```
