### PR TITLE
Fix #631 - when non-class value being exported

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://nestia.io",
   "dependencies": {
     "@nestia/core": "^2.0.5-dev.20230921",
-    "typia": "^5.1.5"
+    "typia": "^5.1.6"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.1.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/core",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "description": "Super-fast validation decorators of NestJS",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -34,7 +34,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^2.1.7",
+    "@nestia/fetcher": "^2.1.8",
     "@nestjs/common": ">= 7.0.1",
     "@nestjs/core": ">= 7.0.1",
     "@nestjs/platform-express": ">= 7.0.1",
@@ -44,10 +44,10 @@
     "raw-body": ">= 2.0.0",
     "reflect-metadata": ">= 0.1.12",
     "rxjs": ">= 6.0.0",
-    "typia": "^5.1.5"
+    "typia": "^5.1.6"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">=2.1.7",
+    "@nestia/fetcher": ">=2.1.8",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "@nestjs/platform-express": ">=7.0.1",
@@ -56,7 +56,7 @@
     "reflect-metadata": ">=0.1.12",
     "rxjs": ">=6.0.0",
     "typescript": ">=4.8.0",
-    "typia": ">=5.1.5 <6.0.0"
+    "typia": ">=5.1.6 <6.0.0"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.0.0",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -40,7 +40,7 @@
     "ts-node": "^10.9.1",
     "ts-patch": "^3.0.2",
     "typescript": "^5.2.2",
-    "typia": "^5.1.5"
+    "typia": "^5.1.6"
   },
   "dependencies": {
     "chalk": "^4.1.2",

--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/fetcher",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "description": "Fetcher library of Nestia SDK",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -45,7 +45,7 @@
     "typescript-transform-paths": "^3.4.6"
   },
   "dependencies": {
-    "typia": "^5.1.5"
+    "typia": "^5.1.6"
   },
   "files": [
     "lib",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/sdk",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "description": "Nestia SDK and Swagger generator",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -35,7 +35,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^2.1.7",
+    "@nestia/fetcher": "^2.1.8",
     "cli": "^1.0.1",
     "glob": "^7.2.0",
     "path-to-regexp": "^6.2.1",
@@ -44,16 +44,16 @@
     "tsconfck": "^2.0.1",
     "tsconfig-paths": "^4.1.1",
     "tstl": "^2.5.13",
-    "typia": "^5.1.5"
+    "typia": "^5.1.6"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">=2.1.7",
+    "@nestia/fetcher": ">=2.1.8",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "reflect-metadata": ">=0.1.12",
     "ts-node": ">=10.6.0",
     "typescript": ">=4.8.0",
-    "typia": ">=5.1.5 <6.0.0"
+    "typia": ">=5.1.6 <6.0.0"
   },
   "devDependencies": {
     "@nestjs/common": ">= 7.0.1",

--- a/packages/sdk/src/NestiaSdkApplication.ts
+++ b/packages/sdk/src/NestiaSdkApplication.ts
@@ -224,7 +224,10 @@ export class NestiaSdkApplication {
                     "\n" +
                     "List of implicit return typed routes:\n" +
                     implicit
-                        .map((it) => `  - ${it.symbol.class}.${it.symbol.function} at "${it.location}"`)
+                        .map(
+                            (it) =>
+                                `  - ${it.symbol.class}.${it.symbol.function} at "${it.location}"`,
+                        )
                         .join("\n"),
             );
 

--- a/packages/sdk/src/analyses/ReflectAnalyzer.ts
+++ b/packages/sdk/src/analyses/ReflectAnalyzer.ts
@@ -34,13 +34,14 @@ export namespace ReflectAnalyzer {
         })();
         const ret: IController[] = [];
 
-        for (const tuple of Object.entries(module)) {
-            if (unique.has(tuple[1])) continue;
-            else unique.add(tuple[1]);
+        for (const [key, value] of Object.entries(module)) {
+            if (typeof value !== "function" || unique.has(value)) continue;
+            else unique.add(value);
 
             const controller: IController | null = _Analyze_controller(
                 file,
-                ...tuple,
+                key,
+                value,
             );
             if (controller !== null) ret.push(controller);
         }

--- a/test/features/clone-and-exact-optional-property/swagger.json
+++ b/test/features/clone-and-exact-optional-property/swagger.json
@@ -272,7 +272,7 @@
           },
           "undefinable_attr": {
             "x-typia-required": false,
-            "x-typia-optional": false,
+            "x-typia-optional": true,
             "type": "string"
           },
           "c": {
@@ -342,7 +342,7 @@
           },
           "undefinable_attr": {
             "x-typia-required": false,
-            "x-typia-optional": false,
+            "x-typia-optional": true,
             "type": "string"
           },
           "a": {
@@ -417,7 +417,7 @@
           },
           "undefinable_attr": {
             "x-typia-required": false,
-            "x-typia-optional": false,
+            "x-typia-optional": true,
             "type": "string"
           }
         },
@@ -482,7 +482,7 @@
           },
           "undefinable_attr": {
             "x-typia-required": false,
-            "x-typia-optional": false,
+            "x-typia-optional": true,
             "type": "string"
           },
           "b": {

--- a/test/features/date/swagger.json
+++ b/test/features/date/swagger.json
@@ -83,7 +83,7 @@
           "string": {
             "x-typia-jsDocTags": [
               {
-                "name": "formt",
+                "name": "format",
                 "text": [
                   {
                     "text": "date-time",
@@ -94,7 +94,18 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
-            "type": "string"
+            "type": "string",
+            "format": "date-time",
+            "x-typia-typeTags": [
+              {
+                "name": "Format<\"date-time\">",
+                "target": "string",
+                "kind": "format",
+                "value": "date-time",
+                "validate": "!isNaN(new Date($input).getTime())",
+                "exclusive": true
+              }
+            ]
           },
           "date": {
             "x-typia-required": true,
@@ -105,7 +116,7 @@
           "date_with_tag": {
             "x-typia-jsDocTags": [
               {
-                "name": "formt",
+                "name": "format",
                 "text": [
                   {
                     "text": "date-time",

--- a/test/features/distribute-assert/packages/api/package.json
+++ b/test/features/distribute-assert/packages/api/package.json
@@ -34,6 +34,6 @@
   },
   "dependencies": {
     "@nestia/fetcher": "file:../../../../../packages/fetcher/nestia-fetcher-0.0.0-dev.20991231.tgz",
-    "typia": "^5.1.5"
+    "typia": "^5.1.6"
   }
 }

--- a/test/features/distribute-json/packages/api/package.json
+++ b/test/features/distribute-json/packages/api/package.json
@@ -34,6 +34,6 @@
   },
   "dependencies": {
     "@nestia/fetcher": "file:../../../../../packages/fetcher/nestia-fetcher-0.0.0-dev.20991231.tgz",
-    "typia": "^5.1.5"
+    "typia": "^5.1.6"
   }
 }

--- a/test/features/distribute/packages/api/package.json
+++ b/test/features/distribute/packages/api/package.json
@@ -34,6 +34,6 @@
   },
   "dependencies": {
     "@nestia/fetcher": "file:../../../../../packages/fetcher/nestia-fetcher-0.0.0-dev.20991231.tgz",
-    "typia": "^5.1.5"
+    "typia": "^5.1.6"
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@nestia/test",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "description": "Test program of Nestia",
   "main": "index.js",
   "scripts": {
@@ -34,12 +34,12 @@
     "ts-patch": "v3.0.2",
     "typescript": "^5.1.6",
     "typescript-transform-paths": "^3.4.4",
-    "typia": "^5.1.5",
+    "typia": "^5.1.6",
     "uuid": "^9.0.0",
     "nestia": "^4.5.0",
-    "@nestia/core": "^2.1.7",
+    "@nestia/core": "^2.1.8",
     "@nestia/e2e": "^0.3.6",
-    "@nestia/fetcher": "^2.1.7",
-    "@nestia/sdk": "^2.1.7"
+    "@nestia/fetcher": "^2.1.8",
+    "@nestia/sdk": "^2.1.8"
   }
 }


### PR DESCRIPTION
As current `@nestia/sdk`'s `ReflectAnalyzer` class had not checked whether exported member is class type or not, if user exports any atomic value in a controller class file, it became an error due to characteristics of `WeakSet`.

Therefore, fixed this bug just by adding a `typeof value === 'function` statement. Thanks to @Val0429 for such special case reporting.

```typescript
@Controller("something")
export class SomeController {}
export const SOME_ATOMIC_VALUE = 0;
```

https://github.com/samchon/nestia/blob/e995adcf0b78448ca53efe569bd37e9e25ead4a3/packages/sdk/src/analyses/ReflectAnalyzer.ts#L15-L39
