### PR TITLE
Ban `yarn berry` on setup manager.

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://nestia.io",
   "dependencies": {
     "@nestia/core": "^2.0.5-dev.20230921",
-    "typia": "^5.2.0"
+    "typia": "^5.2.1"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.1.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestia",
-  "version": "4.5.0",
+  "version": "5.0.0",
   "description": "Nestia CLI tool",
   "main": "bin/index.js",
   "bin": {
@@ -9,6 +9,7 @@
   "scripts": {
     "build": "rimraf bin && tsc",
     "prettier": "prettier ./src/**/*.ts --write",
+    "package:latest": "npm run build && npm publish --access public --tag latest",
     "package:next": "npm run build && npm publish --access public --tag next"
   },
   "repository": {
@@ -43,7 +44,7 @@
     "@types/node": "^18.11.16",
     "prettier": "^2.8.7",
     "rimraf": "^3.0.2",
-    "typescript": "^5.2.0"
+    "typescript": "^5.2.1"
   },
   "files": [
     "bin",

--- a/packages/cli/src/NestiaSetupWizard.ts
+++ b/packages/cli/src/NestiaSetupWizard.ts
@@ -28,26 +28,26 @@ export namespace NestiaSetupWizard {
 
         // SETUP TRANSFORMER
         await pack.save((data) => {
-            // COMPOSE POSTINSTALL COMMAND
+            // COMPOSE PREPARE COMMAND
             data.scripts ??= {};
             if (
-                typeof data.scripts.postinstall === "string" &&
-                data.scripts.postinstall.trim().length
+                typeof data.scripts.prepare === "string" &&
+                data.scripts.prepare.trim().length
             ) {
-                if (data.scripts.postinstall.indexOf("ts-patch install") === -1)
-                    data.scripts.postinstall =
-                        "ts-patch install && " + data.scripts.postinstall;
-            } else data.scripts.postinstall = "ts-patch install";
+                if (data.scripts.prepare.indexOf("ts-patch install") === -1)
+                    data.scripts.prepare =
+                        "ts-patch install && " + data.scripts.prepare;
+            } else data.scripts.prepare = "ts-patch install";
 
             // FOR OLDER VERSIONS
-            if (typeof data.scripts.prepare === "string") {
-                data.scripts.prepare = data.scripts.prepare
+            if (typeof data.scripts.postinstall === "string") {
+                data.scripts.postinstall = data.scripts.postinstall
                     .split("&&")
                     .map((str) => str.trim())
                     .filter((str) => str.indexOf("ts-patch install") === -1)
                     .join(" && ");
-                if (data.scripts.prepare.length === 0)
-                    delete data.scripts.prepare;
+                if (data.scripts.postinstall.length === 0)
+                    delete data.scripts.postinstall;
             }
         });
         CommandExecutor.run(`${pack.manager} run postinstall`);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/core",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Super-fast validation decorators of NestJS",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -34,7 +34,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^2.2.0",
+    "@nestia/fetcher": "^2.2.1",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "@nestjs/platform-express": ">=7.0.1",
@@ -44,10 +44,10 @@
     "raw-body": ">=2.0.0",
     "reflect-metadata": ">=0.1.12",
     "rxjs": ">=6.0.0",
-    "typia": ">=5.2.0 <6.0.0"
+    "typia": ">=5.2.1 <6.0.0"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">=2.2.0",
+    "@nestia/fetcher": ">=2.2.1",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "@nestjs/platform-express": ">=7.0.1",
@@ -56,7 +56,7 @@
     "reflect-metadata": ">=0.1.12",
     "rxjs": ">=6.0.0",
     "typescript": ">=4.8.0",
-    "typia": ">=5.2.0 <6.0.0"
+    "typia": ">=5.2.1 <6.0.0"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.0.0",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -40,7 +40,7 @@
     "ts-node": "^10.9.1",
     "ts-patch": "^3.0.2",
     "typescript": "^5.2.2",
-    "typia": "^5.2.0"
+    "typia": "^5.2.1"
   },
   "dependencies": {
     "chalk": "^4.1.2",

--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/fetcher",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Fetcher library of Nestia SDK",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/migrate",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Migration program from swagger to NestJS",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -30,8 +30,8 @@
   },
   "homepage": "https://github.com/samchon/nestia#readme",
   "devDependencies": {
-    "@nestia/core": "^2.2.0-dev.20231010",
-    "@nestia/fetcher": "^2.2.0-dev.20231010",
+    "@nestia/core": "^2.2.1",
+    "@nestia/fetcher": "^2.2.1",
     "@trivago/prettier-plugin-sort-imports": "^4.1.1",
     "@types/node": "^20.3.3",
     "prettier": "^2.8.8",

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -45,7 +45,7 @@
     "typescript-transform-paths": "^3.4.6"
   },
   "dependencies": {
-    "typia": "^5.2.0"
+    "typia": "^5.2.1"
   },
   "files": [
     "lib",

--- a/packages/migrate/src/programmers/RouteProgrammer.ts
+++ b/packages/migrate/src/programmers/RouteProgrammer.ts
@@ -294,7 +294,7 @@ export namespace RouteProgrammer {
                 meta["x-nestia-encrypted"] === true
                     ? e[0].includes("text/plain") ||
                       e[0].includes("application/json")
-                    : e[0].includes("application/json"),
+                    : e[0].includes("application/json") || e[0].includes("*/*"),
             );
             if (json) {
                 const { schema } = json[1];

--- a/packages/migrate/src/structures/ISwaggerRoute.ts
+++ b/packages/migrate/src/structures/ISwaggerRoute.ts
@@ -45,5 +45,8 @@ export namespace ISwaggerRoute {
         "application/x-www-form-urlencoded"?: {
             schema: ISwaggerSchema;
         };
+        "*/*"?: {
+            schema: ISwaggerSchema;
+        };
     }
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/sdk",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Nestia SDK and Swagger generator",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -35,7 +35,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^2.2.0",
+    "@nestia/fetcher": "^2.2.1",
     "cli": "^1.0.1",
     "glob": "^7.2.0",
     "path-to-regexp": "^6.2.1",
@@ -44,16 +44,16 @@
     "tsconfck": "^2.0.1",
     "tsconfig-paths": "^4.1.1",
     "tstl": "^2.5.13",
-    "typia": "^5.2.0"
+    "typia": "^5.2.1"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">=2.2.0",
+    "@nestia/fetcher": ">=2.2.1",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "reflect-metadata": ">=0.1.12",
     "ts-node": ">=10.6.0",
     "typescript": ">=4.8.0",
-    "typia": ">=5.2.0 <6.0.0"
+    "typia": ">=5.2.1 <6.0.0"
   },
   "devDependencies": {
     "@nestjs/common": ">= 7.0.1",

--- a/packages/sdk/src/generates/SdkGenerator.ts
+++ b/packages/sdk/src/generates/SdkGenerator.ts
@@ -67,7 +67,7 @@ export namespace SdkGenerator {
 
             // DISTRIBUTION
             if (config.distribute !== undefined)
-                await SdkDistributionComposer.compose(config);
+                await SdkDistributionComposer.compose(config)(routes);
         };
 
     export const BUNDLE_PATH = NodePath.join(

--- a/test/features/distribute-assert/packages/api/package.json
+++ b/test/features/distribute-assert/packages/api/package.json
@@ -9,7 +9,7 @@
     "build:sdk": "rimraf ../../src/api/functional && cd ../.. && npx nestia sdk && cd packages/api",
     "compile": "rimraf lib && tsc",
     "deploy": "npm run build && npm publish",
-    "postinstall": "ts-patch install"
+    "prepare": "ts-patch install"
   },
   "repository": {
     "type": "git",
@@ -34,6 +34,6 @@
   },
   "dependencies": {
     "@nestia/fetcher": "file:../../../../../packages/fetcher/nestia-fetcher-0.0.0-dev.20991231.tgz",
-    "typia": "^5.2.0"
+    "typia": "^5.2.1"
   }
 }

--- a/test/features/distribute-json/packages/api/package.json
+++ b/test/features/distribute-json/packages/api/package.json
@@ -9,7 +9,7 @@
     "build:sdk": "rimraf ../../src/api/functional && cd ../.. && npx nestia sdk && cd packages/api",
     "compile": "rimraf lib && tsc",
     "deploy": "npm run build && npm publish",
-    "postinstall": "ts-patch install"
+    "prepare": "ts-patch install"
   },
   "repository": {
     "type": "git",
@@ -34,6 +34,6 @@
   },
   "dependencies": {
     "@nestia/fetcher": "file:../../../../../packages/fetcher/nestia-fetcher-0.0.0-dev.20991231.tgz",
-    "typia": "^5.2.0"
+    "typia": "^5.2.1"
   }
 }

--- a/test/features/distribute/packages/api/package.json
+++ b/test/features/distribute/packages/api/package.json
@@ -9,7 +9,7 @@
     "build:sdk": "rimraf ../../src/api/functional && cd ../.. && npx nestia sdk && cd packages/api",
     "compile": "rimraf lib && tsc",
     "deploy": "npm run build && npm publish",
-    "postinstall": "ts-patch install"
+    "prepare": "ts-patch install"
   },
   "repository": {
     "type": "git",
@@ -34,6 +34,6 @@
   },
   "dependencies": {
     "@nestia/fetcher": "file:../../../../../packages/fetcher/nestia-fetcher-0.0.0-dev.20991231.tgz",
-    "typia": "^5.2.0"
+    "typia": "^5.2.1"
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@nestia/test",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Test program of Nestia",
   "main": "index.js",
   "scripts": {
@@ -32,14 +32,14 @@
     "@types/uuid": "^9.0.0",
     "ts-node": "^10.9.1",
     "ts-patch": "v3.0.2",
-    "typescript": "^5.2.0",
+    "typescript": "^5.2.1",
     "typescript-transform-paths": "^3.4.4",
-    "typia": "^5.2.0",
+    "typia": "^5.2.1",
     "uuid": "^9.0.0",
     "nestia": "^4.5.0",
-    "@nestia/core": "^2.2.0",
+    "@nestia/core": "^2.2.1",
     "@nestia/e2e": "^0.3.6",
-    "@nestia/fetcher": "^2.2.0",
-    "@nestia/sdk": "^2.2.0"
+    "@nestia/fetcher": "^2.2.1",
+    "@nestia/sdk": "^2.2.1"
   }
 }

--- a/website/pages/docs/setup.mdx
+++ b/website/pages/docs/setup.mdx
@@ -36,6 +36,7 @@ pnpm nestia setup --manager pnpm
     </Tab>
     <Tab>
 ```bash filename="Terminal" copy showLineNumbers
+# YARN BERRY IS NOT SUPPORTED
 yarn add -D nestia
 yarn nestia setup --manager yarn
 ```
@@ -283,7 +284,7 @@ Also, never forget to configure `strict` (or `strictNullChecks`) as `true`. It i
 ```json filename="package.json" showLineNumbers copy
 {
     "scripts": {
-        "postinstall": "ts-patch install"
+        "prepare": "ts-patch install"
     }
 }
 ```
@@ -291,24 +292,24 @@ Also, never forget to configure `strict` (or `strictNullChecks`) as `true`. It i
 <Tabs items={['npm', 'pnpm', 'yarn']}>
     <Tab>
 ```bash filename="Terminal" copy showLineNumbers
-npm run postinstall
+npm run prepare
 ```
     </Tab>
     <Tab>
 ```bash filename="Terminal" copy showLineNumbers
-pnpm run postinstall
+pnpm run prepare
 ```
     </Tab>
     <Tab>
 ```bash filename="Terminal" copy showLineNumbers
-yarn run postinstall
+yarn run prepare
 ```
     </Tab>
 </Tabs>
 
-At last, configure `npm run postinstall` command like above. 
+At last, configure `npm run prepare` command like above. 
 
-Of course, you've to run the `npm run postinstall` command after configuration.
+Of course, you've to run the `npm run prepare` command after configuration.
 
 For reference, [`ts-patch`](https://github.com/nonara/ts-patch) is an helper library of TypeScript compiler that supporting custom transformations by plugins. With the [`ts-patch`](https://github.com/nonara/ts-patch) setup and plugin configurations, whenever you run `tsc` command, your `@nestia/core` decorator function call statements would be transformed to the optimal operation codes in the compiled JavaScript files.
 


### PR DESCRIPTION
To support `yarn berry` which had banned `npm prepare` script, I'd changed setup wizard of `nestia` to define `npm postinstall` script instead.

By the way, unlike the `npm prepare` script which works on only in the local drive and does not work when be installed from remote `npm`, `npm postinstall` script is working even when installing from the remote `npm`. Therefore, when publishing an `npm` module which has installed `tyipa` through setup wizard, it enforces users of derived libraries to run the `npm postinstall` command that requires `ts-patch` module.

To fix this crazy bug, I've decided to ban `yarn berry` on the setup wizard. From now on, when you run the `npx nestia setup` command, it will print a text that "yarn berry is not supported". If you still want to utilize the `yarn berry`, configure it manually by yourself please.