### PR TITLE
Complement #652 - fix bug of SDK distrubition composer.

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/core",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Super-fast validation decorators of NestJS",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -34,7 +34,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^2.2.2",
+    "@nestia/fetcher": "^2.2.3",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "@nestjs/platform-express": ">=7.0.1",
@@ -47,7 +47,7 @@
     "typia": ">=5.2.2 <6.0.0"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">=2.2.2",
+    "@nestia/fetcher": ">=2.2.3",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "@nestjs/platform-express": ">=7.0.1",

--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/fetcher",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Fetcher library of Nestia SDK",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/sdk",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Nestia SDK and Swagger generator",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -35,7 +35,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^2.2.2",
+    "@nestia/fetcher": "^2.2.3",
     "cli": "^1.0.1",
     "glob": "^7.2.0",
     "path-to-regexp": "^6.2.1",
@@ -47,7 +47,7 @@
     "typia": "^5.2.2"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">=2.2.2",
+    "@nestia/fetcher": ">=2.2.3",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "reflect-metadata": ">=0.1.12",

--- a/packages/sdk/src/generates/SdkGenerator.ts
+++ b/packages/sdk/src/generates/SdkGenerator.ts
@@ -67,7 +67,7 @@ export namespace SdkGenerator {
 
             // DISTRIBUTION
             if (config.distribute !== undefined)
-                await SdkDistributionComposer.compose(config)(routes);
+                await SdkDistributionComposer.compose(config);
         };
 
     export const BUNDLE_PATH = NodePath.join(

--- a/packages/sdk/src/generates/internal/SdkDistributionComposer.ts
+++ b/packages/sdk/src/generates/internal/SdkDistributionComposer.ts
@@ -3,78 +3,48 @@ import fs from "fs";
 import path from "path";
 
 import { INestiaConfig } from "../../INestiaConfig";
-import { IRoute } from "../../structures/IRoute";
 
 export namespace SdkDistributionComposer {
-    export const compose =
-        (config: INestiaConfig) =>
-        async (routes: IRoute[]): Promise<void> => {
-            if (!fs.existsSync(config.distribute!))
-                await fs.promises.mkdir(config.distribute!);
+    export const compose = async (config: INestiaConfig) => {
+        if (!fs.existsSync(config.distribute!))
+            await fs.promises.mkdir(config.distribute!);
 
-            const root: string = process.cwd();
-            const output: string = path.resolve(config.output!);
-            process.chdir(config.distribute!);
+        const root: string = process.cwd();
+        const output: string = path.resolve(config.output!);
+        process.chdir(config.distribute!);
 
-            const exit = () => process.chdir(root);
+        const exit = () => process.chdir(root);
+        if (await configured()) return exit();
 
-            const typia: boolean =
-                !!config.assert ||
-                !!config.json ||
-                !!config.simulate ||
-                routes.some(
-                    (r) =>
-                        r.output.contentType ===
-                        "application/x-www-form-urlencoded",
-                );
-            const done: boolean = await configured({
-                typia,
-                distribute: config.distribute!,
-            });
-            if (done) return exit();
+        // COPY FILES
+        console.log("Composing SDK distribution environments...");
+        for (const file of await fs.promises.readdir(BUNDLE))
+            await fs.promises.copyFile(`${BUNDLE}/${file}`, file);
 
-            // COPY FILES
-            console.log("Composing SDK distribution environments...");
-            for (const file of await fs.promises.readdir(BUNDLE))
-                await fs.promises.copyFile(`${BUNDLE}/${file}`, file);
+        // CONFIGURE PATHS
+        for (const file of ["package.json", "tsconfig.json"])
+            await replace({ root, output })(file);
 
-            // CONFIGURE PATHS
-            for (const file of ["package.json", "tsconfig.json"])
-                await replace({ root, output })(file);
+        // INSTALL PACKAGES
+        const versions: IDependencies = await dependencies();
+        execute("npm install --save-dev rimraf");
+        execute(
+            `npm install --save @nestia/fetcher@${versions["@nestia/fetcher"]}`,
+        );
+        execute(`npm install --save typia@${versions["typia"]}`);
+        execute("npx typia setup --manager npm");
 
-            // INSTALL PACKAGES
-            const versions: IDependencies = await dependencies();
-            execute("npm install --save-dev rimraf");
-            execute(
-                `npm install --save @nestia/fetcher@${versions["@nestia/fetcher"]}`,
-            );
-            execute(`npm install --save typia@${versions["typia"]}`);
-            execute("npx typia setup --manager npm");
+        exit();
+    };
 
-            exit();
-        };
-
-    const configured = async (config: {
-        typia: boolean;
-        distribute: string;
-    }): Promise<boolean> =>
+    const configured = async (): Promise<boolean> =>
         ["package.json", "tsconfig.json"].every(fs.existsSync) &&
         (await (async () => {
             const content = JSON.parse(
                 await fs.promises.readFile("package.json", "utf8"),
             );
-            return (
-                !!content.dependencies?.["@nestia/fetcher"] &&
-                (config.typia === false ||
-                    !!content.scripts?.prepare?.includes("ts-patch install")) &&
-                (config.typia === false || !!content.dependencies?.["typia"])
-            );
-        })()) &&
-        (config.typia === false ||
-            (await (async () => {
-                const content = await fs.promises.readFile("tsconfig.json");
-                return content.includes("typia/lib/transform");
-            })()));
+            return !!content.dependencies?.["@nestia/fetcher"];
+        })());
 
     const execute = (command: string) => {
         console.log(`  - ${command}`);

--- a/test/package.json
+++ b/test/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@nestia/test",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Test program of Nestia",
   "main": "index.js",
   "scripts": {
@@ -37,9 +37,9 @@
     "typia": "^5.2.2",
     "uuid": "^9.0.0",
     "nestia": "^4.5.0",
-    "@nestia/core": "^2.2.2",
+    "@nestia/core": "^2.2.3",
     "@nestia/e2e": "^0.3.6",
-    "@nestia/fetcher": "^2.2.2",
-    "@nestia/sdk": "^2.2.2"
+    "@nestia/fetcher": "^2.2.3",
+    "@nestia/sdk": "^2.2.3"
   }
 }


### PR DESCRIPTION
I've banned `yarn berry` which does not support `npm prepare` command to change setup wizard to using the standard `npm prepare` command.

By the way, SDK distribution composer had determined whether the target distribution directory has been prepared by checking the `package.json` file with the `npm run prepare` command.

Therefore, if the SDK distrubition directory being composed by older version of `@nestia/sdk`, newer version's SDK distribution composer re-composed the distribution directory vulnerably.

This PR fixes such bug.
