### PR TITLE
Fix mis-published dependency info

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/core",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "Super-fast validation decorators of NestJS",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -34,7 +34,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^2.2.4",
+    "@nestia/fetcher": "^2.2.5",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "@nestjs/platform-express": ">=7.0.1",
@@ -44,10 +44,10 @@
     "raw-body": ">=2.0.0",
     "reflect-metadata": ">=0.1.12",
     "rxjs": ">=6.0.0",
-    "typia": ">=5.2.2 <6.0.0"
+    "typia": "^5.2.2"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">=2.2.4",
+    "@nestia/fetcher": ">=2.2.5",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "@nestjs/platform-express": ">=7.0.1",

--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/fetcher",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "Fetcher library of Nestia SDK",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/sdk",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "Nestia SDK and Swagger generator",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -35,7 +35,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^2.2.4",
+    "@nestia/fetcher": "^2.2.5",
     "cli": "^1.0.1",
     "glob": "^7.2.0",
     "path-to-regexp": "^6.2.1",
@@ -47,7 +47,7 @@
     "typia": "^5.2.2"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">=2.2.4",
+    "@nestia/fetcher": ">=2.2.5",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "reflect-metadata": ">=0.1.12",

--- a/test/package.json
+++ b/test/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@nestia/test",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "Test program of Nestia",
   "main": "index.js",
   "scripts": {
@@ -37,9 +37,9 @@
     "typia": "^5.2.2",
     "uuid": "^9.0.0",
     "nestia": "^4.5.0",
-    "@nestia/core": "^2.2.4",
+    "@nestia/core": "^2.2.5",
     "@nestia/e2e": "^0.3.6",
-    "@nestia/fetcher": "^2.2.4",
-    "@nestia/sdk": "^2.2.4"
+    "@nestia/fetcher": "^2.2.5",
+    "@nestia/sdk": "^2.2.5"
   }
 }


### PR DESCRIPTION
I've mis-published `typia` dependency version.

It had to be `^5.2.2`, but had configured to `>=5.2.2 <6.0.0` like `peerDependencies` case.
