### PR TITLE
Print CLI output when running `npx nestia setup`.

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestia",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Nestia CLI tool",
   "main": "bin/index.js",
   "bin": {

--- a/packages/cli/src/NestiaStarter.ts
+++ b/packages/cli/src/NestiaStarter.ts
@@ -36,7 +36,7 @@ export namespace NestiaStarter {
         };
 
     function execute(command: string): void {
-        console.log(command);
+        console.log(`\n$ ${command}`);
         cp.execSync(command, { stdio: "inherit" });
     }
 }

--- a/packages/cli/src/internal/CommandExecutor.ts
+++ b/packages/cli/src/internal/CommandExecutor.ts
@@ -2,7 +2,7 @@ import cp from "child_process";
 
 export namespace CommandExecutor {
     export function run(str: string): void {
-        console.log(str);
-        cp.execSync(str, { stdio: "ignore" });
+        console.log(`\n$ ${str}`);
+        cp.execSync(str, { stdio: "inherit" });
     }
 }

--- a/packages/sdk/src/executable/sdk.ts
+++ b/packages/sdk/src/executable/sdk.ts
@@ -31,6 +31,7 @@ function dependencies(argv: string[]): void {
 
     for (const lib of ["@nestia/fetcher", "typia"]) {
         const command: string = `${prefix} ${lib}`;
+        console.log(`\n$ ${command}`);
         cp.execSync(command, { stdio: "inherit" });
     }
 }


### PR DESCRIPTION
When installing dependencies of `nestia` through the `npx nestia setup` command, the setup process can be failed by another libraries' `peerDependencies` restriction. By the way, as current nestia setup wizard does not print the console output during the dependencies' setup, user can't know the reason why of the setup failure.

Therefore, changed the setup wizard to print the console output during the dependencies' setup process.
