### PR TITLE
Enhance e2e test functions generator

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/core",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "Super-fast validation decorators of NestJS",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -34,7 +34,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^2.3.2",
+    "@nestia/fetcher": "^2.3.3",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "@nestjs/platform-express": ">=7.0.1",
@@ -47,7 +47,7 @@
     "typia": "^5.2.3"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">=2.3.2",
+    "@nestia/fetcher": ">=2.3.3",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "@nestjs/platform-express": ">=7.0.1",

--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/fetcher",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "Fetcher library of Nestia SDK",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/sdk",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "Nestia SDK and Swagger generator",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -35,7 +35,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^2.3.2",
+    "@nestia/fetcher": "^2.3.3",
     "cli": "^1.0.1",
     "get-function-location": "^2.0.0",
     "glob": "^7.2.0",
@@ -47,7 +47,7 @@
     "typia": "^5.2.3"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">=2.3.2",
+    "@nestia/fetcher": ">=2.3.3",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "reflect-metadata": ">=0.1.12",

--- a/packages/sdk/src/generates/internal/E2eFileProgrammer.ts
+++ b/packages/sdk/src/generates/internal/E2eFileProgrammer.ts
@@ -5,6 +5,7 @@ import { IRoute } from "../../structures/IRoute";
 import { ImportDictionary } from "../../utils/ImportDictionary";
 import { SdkDtoGenerator } from "./SdkDtoGenerator";
 import { SdkImportWizard } from "./SdkImportWizard";
+import { SdkTypeDefiner } from "./SdkTypeDefiner";
 
 export namespace E2eFileProgrammer {
     export const generate =
@@ -78,7 +79,9 @@ export namespace E2eFileProgrammer {
                 ...(route.output.typeName === "void"
                     ? [`    ${output}`]
                     : [
-                          `    const output = ${output}`,
+                          `    const output: ${SdkTypeDefiner.output(config)(
+                              importer,
+                          )(route)} = ${output}`,
                           `    ${SdkImportWizard.typia(
                               importer,
                           )}.assert(output);`,

--- a/test/features/all/src/test/features/api/automated/test_api_all_store.ts
+++ b/test/features/all/src/test/features/api/automated/test_api_all_store.ts
@@ -7,7 +7,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_all_store = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.all.store(
+    const output: Primitive<IBbsArticle> = await api.functional.all.store(
         connection,
         typia.random<Primitive<IBbsArticle.IStore>>(),
     );

--- a/test/features/all/src/test/features/api/automated/test_api_performance_get.ts
+++ b/test/features/all/src/test/features/api/automated/test_api_performance_get.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IPerformance } from "../../../../api/structures/IPerformance";
 export const test_api_performance_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.performance.get(
+    const output: Primitive<IPerformance> = await api.functional.performance.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v1_articles_comments_at.ts
+++ b/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v1_articles_comments_at.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 import type { Format } from "typia/lib/tags/Format";
 
@@ -8,7 +8,7 @@ import type { IBbsComment } from "../../../../api/structures/IBbsComment";
 export const test_api_api_v1_articles_comments_at = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.api.v1.articles.comments.at(
+    const output: Primitive<IBbsComment> = await api.functional.api.v1.articles.comments.at(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v1_articles_comments_index.ts
+++ b/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v1_articles_comments_index.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 import type { Format } from "typia/lib/tags/Format";
 
@@ -9,7 +9,7 @@ import type { IPage } from "../../../../api/structures/IPage";
 export const test_api_api_v1_articles_comments_index = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.api.v1.articles.comments.index(
+    const output: Primitive<IPage<IBbsComment>> = await api.functional.api.v1.articles.comments.index(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v1_articles_comments_store.ts
+++ b/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v1_articles_comments_store.ts
@@ -8,7 +8,7 @@ import type { IBbsComment } from "../../../../api/structures/IBbsComment";
 export const test_api_api_v1_articles_comments_store = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.api.v1.articles.comments.store(
+    const output: Primitive<IBbsComment> = await api.functional.api.v1.articles.comments.store(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v1_articles_comments_update.ts
+++ b/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v1_articles_comments_update.ts
@@ -8,7 +8,7 @@ import type { IBbsComment } from "../../../../api/structures/IBbsComment";
 export const test_api_api_v1_articles_comments_update = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.api.v1.articles.comments.update(
+    const output: Primitive<IBbsComment> = await api.functional.api.v1.articles.comments.update(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v1_bbs_articles_at.ts
+++ b/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v1_bbs_articles_at.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 import type { Format } from "typia/lib/tags/Format";
 
@@ -8,7 +8,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_api_v1_bbs_articles_at = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.api.v1.bbs.articles.at(
+    const output: Primitive<IBbsArticle> = await api.functional.api.v1.bbs.articles.at(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v1_bbs_articles_index.ts
+++ b/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v1_bbs_articles_index.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -8,7 +8,7 @@ import type { IPage } from "../../../../api/structures/IPage";
 export const test_api_api_v1_bbs_articles_index = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.api.v1.bbs.articles.index(
+    const output: Primitive<IPage<IBbsArticle.ISummary>> = await api.functional.api.v1.bbs.articles.index(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<IPage.IRequest>>(),

--- a/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v1_bbs_articles_store.ts
+++ b/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v1_bbs_articles_store.ts
@@ -7,7 +7,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_api_v1_bbs_articles_store = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.api.v1.bbs.articles.store(
+    const output: Primitive<IBbsArticle> = await api.functional.api.v1.bbs.articles.store(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Primitive<IBbsArticle.IStore>>(),

--- a/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v1_bbs_articles_update.ts
+++ b/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v1_bbs_articles_update.ts
@@ -8,7 +8,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_api_v1_bbs_articles_update = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.api.v1.bbs.articles.update(
+    const output: Primitive<IBbsArticle> = await api.functional.api.v1.bbs.articles.update(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v1_performance_get.ts
+++ b/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v1_performance_get.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IPerformance } from "../../../../api/structures/IPerformance";
 export const test_api_api_v1_performance_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.api.v1.performance.get(
+    const output: Primitive<IPerformance> = await api.functional.api.v1.performance.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v2_articles_comments_at.ts
+++ b/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v2_articles_comments_at.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 import type { Format } from "typia/lib/tags/Format";
 
@@ -8,7 +8,7 @@ import type { IBbsComment } from "../../../../api/structures/IBbsComment";
 export const test_api_api_v2_articles_comments_at = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.api.v2.articles.comments.at(
+    const output: Primitive<IBbsComment> = await api.functional.api.v2.articles.comments.at(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v2_articles_comments_index.ts
+++ b/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v2_articles_comments_index.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 import type { Format } from "typia/lib/tags/Format";
 
@@ -9,7 +9,7 @@ import type { IPage } from "../../../../api/structures/IPage";
 export const test_api_api_v2_articles_comments_index = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.api.v2.articles.comments.index(
+    const output: Primitive<IPage<IBbsComment>> = await api.functional.api.v2.articles.comments.index(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v2_articles_comments_store.ts
+++ b/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v2_articles_comments_store.ts
@@ -8,7 +8,7 @@ import type { IBbsComment } from "../../../../api/structures/IBbsComment";
 export const test_api_api_v2_articles_comments_store = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.api.v2.articles.comments.store(
+    const output: Primitive<IBbsComment> = await api.functional.api.v2.articles.comments.store(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v2_articles_comments_update.ts
+++ b/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v2_articles_comments_update.ts
@@ -8,7 +8,7 @@ import type { IBbsComment } from "../../../../api/structures/IBbsComment";
 export const test_api_api_v2_articles_comments_update = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.api.v2.articles.comments.update(
+    const output: Primitive<IBbsComment> = await api.functional.api.v2.articles.comments.update(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v2_bbs_articles_at.ts
+++ b/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v2_bbs_articles_at.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 import type { Format } from "typia/lib/tags/Format";
 
@@ -8,7 +8,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_api_v2_bbs_articles_at = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.api.v2.bbs.articles.at(
+    const output: Primitive<IBbsArticle> = await api.functional.api.v2.bbs.articles.at(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v2_bbs_articles_index.ts
+++ b/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v2_bbs_articles_index.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -8,7 +8,7 @@ import type { IPage } from "../../../../api/structures/IPage";
 export const test_api_api_v2_bbs_articles_index = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.api.v2.bbs.articles.index(
+    const output: Primitive<IPage<IBbsArticle.ISummary>> = await api.functional.api.v2.bbs.articles.index(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<IPage.IRequest>>(),

--- a/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v2_bbs_articles_store.ts
+++ b/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v2_bbs_articles_store.ts
@@ -7,7 +7,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_api_v2_bbs_articles_store = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.api.v2.bbs.articles.store(
+    const output: Primitive<IBbsArticle> = await api.functional.api.v2.bbs.articles.store(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Primitive<IBbsArticle.IStore>>(),

--- a/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v2_bbs_articles_update.ts
+++ b/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v2_bbs_articles_update.ts
@@ -8,7 +8,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_api_v2_bbs_articles_update = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.api.v2.bbs.articles.update(
+    const output: Primitive<IBbsArticle> = await api.functional.api.v2.bbs.articles.update(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v2_performance_get.ts
+++ b/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v2_performance_get.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IPerformance } from "../../../../api/structures/IPerformance";
 export const test_api_api_v2_performance_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.api.v2.performance.get(
+    const output: Primitive<IPerformance> = await api.functional.api.v2.performance.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v3_articles_comments_at.ts
+++ b/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v3_articles_comments_at.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 import type { Format } from "typia/lib/tags/Format";
 
@@ -8,7 +8,7 @@ import type { IBbsComment } from "../../../../api/structures/IBbsComment";
 export const test_api_api_v3_articles_comments_at = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.api.v3.articles.comments.at(
+    const output: Primitive<IBbsComment> = await api.functional.api.v3.articles.comments.at(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v3_articles_comments_index.ts
+++ b/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v3_articles_comments_index.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 import type { Format } from "typia/lib/tags/Format";
 
@@ -9,7 +9,7 @@ import type { IPage } from "../../../../api/structures/IPage";
 export const test_api_api_v3_articles_comments_index = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.api.v3.articles.comments.index(
+    const output: Primitive<IPage<IBbsComment>> = await api.functional.api.v3.articles.comments.index(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v3_articles_comments_store.ts
+++ b/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v3_articles_comments_store.ts
@@ -8,7 +8,7 @@ import type { IBbsComment } from "../../../../api/structures/IBbsComment";
 export const test_api_api_v3_articles_comments_store = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.api.v3.articles.comments.store(
+    const output: Primitive<IBbsComment> = await api.functional.api.v3.articles.comments.store(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v3_articles_comments_update.ts
+++ b/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v3_articles_comments_update.ts
@@ -8,7 +8,7 @@ import type { IBbsComment } from "../../../../api/structures/IBbsComment";
 export const test_api_api_v3_articles_comments_update = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.api.v3.articles.comments.update(
+    const output: Primitive<IBbsComment> = await api.functional.api.v3.articles.comments.update(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v3_bbs_articles_at.ts
+++ b/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v3_bbs_articles_at.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 import type { Format } from "typia/lib/tags/Format";
 
@@ -8,7 +8,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_api_v3_bbs_articles_at = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.api.v3.bbs.articles.at(
+    const output: Primitive<IBbsArticle> = await api.functional.api.v3.bbs.articles.at(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v3_bbs_articles_index.ts
+++ b/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v3_bbs_articles_index.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -8,7 +8,7 @@ import type { IPage } from "../../../../api/structures/IPage";
 export const test_api_api_v3_bbs_articles_index = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.api.v3.bbs.articles.index(
+    const output: Primitive<IPage<IBbsArticle.ISummary>> = await api.functional.api.v3.bbs.articles.index(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<IPage.IRequest>>(),

--- a/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v3_bbs_articles_store.ts
+++ b/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v3_bbs_articles_store.ts
@@ -7,7 +7,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_api_v3_bbs_articles_store = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.api.v3.bbs.articles.store(
+    const output: Primitive<IBbsArticle> = await api.functional.api.v3.bbs.articles.store(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Primitive<IBbsArticle.IStore>>(),

--- a/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v3_bbs_articles_update.ts
+++ b/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v3_bbs_articles_update.ts
@@ -8,7 +8,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_api_v3_bbs_articles_update = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.api.v3.bbs.articles.update(
+    const output: Primitive<IBbsArticle> = await api.functional.api.v3.bbs.articles.update(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v3_performance_get.ts
+++ b/test/features/app-globalPrefix-versionUri-routerModule/src/test/features/api/automated/test_api_api_v3_performance_get.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IPerformance } from "../../../../api/structures/IPerformance";
 export const test_api_api_v3_performance_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.api.v3.performance.get(
+    const output: Primitive<IPerformance> = await api.functional.api.v3.performance.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/app-globalPrefix-versionUri/src/test/features/api/automated/test_api_api_internal_bbs_articles_comments_at.ts
+++ b/test/features/app-globalPrefix-versionUri/src/test/features/api/automated/test_api_api_internal_bbs_articles_comments_at.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 import type { Format } from "typia/lib/tags/Format";
 
@@ -8,7 +8,7 @@ import type { IBbsComment } from "../../../../api/structures/IBbsComment";
 export const test_api_api_internal_bbs_articles_comments_at = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.api.internal.bbs.articles.comments.at(
+    const output: Primitive<IBbsComment> = await api.functional.api.internal.bbs.articles.comments.at(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app-globalPrefix-versionUri/src/test/features/api/automated/test_api_api_internal_bbs_articles_comments_index.ts
+++ b/test/features/app-globalPrefix-versionUri/src/test/features/api/automated/test_api_api_internal_bbs_articles_comments_index.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 import type { Format } from "typia/lib/tags/Format";
 
@@ -9,7 +9,7 @@ import type { IPage } from "../../../../api/structures/IPage";
 export const test_api_api_internal_bbs_articles_comments_index = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.api.internal.bbs.articles.comments.index(
+    const output: Primitive<IPage<IBbsComment>> = await api.functional.api.internal.bbs.articles.comments.index(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app-globalPrefix-versionUri/src/test/features/api/automated/test_api_api_internal_bbs_articles_comments_store.ts
+++ b/test/features/app-globalPrefix-versionUri/src/test/features/api/automated/test_api_api_internal_bbs_articles_comments_store.ts
@@ -8,7 +8,7 @@ import type { IBbsComment } from "../../../../api/structures/IBbsComment";
 export const test_api_api_internal_bbs_articles_comments_store = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.api.internal.bbs.articles.comments.store(
+    const output: Primitive<IBbsComment> = await api.functional.api.internal.bbs.articles.comments.store(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app-globalPrefix-versionUri/src/test/features/api/automated/test_api_api_internal_bbs_articles_comments_update.ts
+++ b/test/features/app-globalPrefix-versionUri/src/test/features/api/automated/test_api_api_internal_bbs_articles_comments_update.ts
@@ -8,7 +8,7 @@ import type { IBbsComment } from "../../../../api/structures/IBbsComment";
 export const test_api_api_internal_bbs_articles_comments_update = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.api.internal.bbs.articles.comments.update(
+    const output: Primitive<IBbsComment> = await api.functional.api.internal.bbs.articles.comments.update(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app-globalPrefix-versionUri/src/test/features/api/automated/test_api_api_internal_bbs_articles_index.ts
+++ b/test/features/app-globalPrefix-versionUri/src/test/features/api/automated/test_api_api_internal_bbs_articles_index.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -8,7 +8,7 @@ import type { IPage } from "../../../../api/structures/IPage";
 export const test_api_api_internal_bbs_articles_index = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.api.internal.bbs.articles.index(
+    const output: Primitive<IPage<IBbsArticle.ISummary>> = await api.functional.api.internal.bbs.articles.index(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<IPage.IRequest>>(),

--- a/test/features/app-globalPrefix-versionUri/src/test/features/api/automated/test_api_api_internal_bbs_articles_store.ts
+++ b/test/features/app-globalPrefix-versionUri/src/test/features/api/automated/test_api_api_internal_bbs_articles_store.ts
@@ -7,7 +7,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_api_internal_bbs_articles_store = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.api.internal.bbs.articles.store(
+    const output: Primitive<IBbsArticle> = await api.functional.api.internal.bbs.articles.store(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Primitive<IBbsArticle.IStore>>(),

--- a/test/features/app-globalPrefix-versionUri/src/test/features/api/automated/test_api_api_internal_v1_bbs_articles_at.ts
+++ b/test/features/app-globalPrefix-versionUri/src/test/features/api/automated/test_api_api_internal_v1_bbs_articles_at.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 import type { Format } from "typia/lib/tags/Format";
 
@@ -8,7 +8,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_api_internal_v1_bbs_articles_at = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.api.internal.v1.bbs.articles.at(
+    const output: Primitive<IBbsArticle> = await api.functional.api.internal.v1.bbs.articles.at(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app-globalPrefix-versionUri/src/test/features/api/automated/test_api_api_internal_v1_bbs_articles_index.ts
+++ b/test/features/app-globalPrefix-versionUri/src/test/features/api/automated/test_api_api_internal_v1_bbs_articles_index.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -8,7 +8,7 @@ import type { IPage } from "../../../../api/structures/IPage";
 export const test_api_api_internal_v1_bbs_articles_index = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.api.internal.v1.bbs.articles.index(
+    const output: Primitive<IPage<IBbsArticle.ISummary>> = await api.functional.api.internal.v1.bbs.articles.index(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<IPage.IRequest>>(),

--- a/test/features/app-globalPrefix-versionUri/src/test/features/api/automated/test_api_api_internal_v1_performance_get.ts
+++ b/test/features/app-globalPrefix-versionUri/src/test/features/api/automated/test_api_api_internal_v1_performance_get.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IPerformance } from "../../../../api/structures/IPerformance";
 export const test_api_api_internal_v1_performance_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.api.internal.v1.performance.get(
+    const output: Primitive<IPerformance> = await api.functional.api.internal.v1.performance.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/app-globalPrefix-versionUri/src/test/features/api/automated/test_api_api_internal_v2_bbs_articles_index.ts
+++ b/test/features/app-globalPrefix-versionUri/src/test/features/api/automated/test_api_api_internal_v2_bbs_articles_index.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -8,7 +8,7 @@ import type { IPage } from "../../../../api/structures/IPage";
 export const test_api_api_internal_v2_bbs_articles_index = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.api.internal.v2.bbs.articles.index(
+    const output: Primitive<IPage<IBbsArticle.ISummary>> = await api.functional.api.internal.v2.bbs.articles.index(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<IPage.IRequest>>(),

--- a/test/features/app-globalPrefix-versionUri/src/test/features/api/automated/test_api_api_internal_v2_bbs_articles_update.ts
+++ b/test/features/app-globalPrefix-versionUri/src/test/features/api/automated/test_api_api_internal_v2_bbs_articles_update.ts
@@ -8,7 +8,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_api_internal_v2_bbs_articles_update = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.api.internal.v2.bbs.articles.update(
+    const output: Primitive<IBbsArticle> = await api.functional.api.internal.v2.bbs.articles.update(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app-globalPrefix/src/test/features/api/automated/test_api_bbs_articles_at.ts
+++ b/test/features/app-globalPrefix/src/test/features/api/automated/test_api_bbs_articles_at.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 import type { Format } from "typia/lib/tags/Format";
 
@@ -8,7 +8,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_bbs_articles_at = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.articles.at(
+    const output: Primitive<IBbsArticle> = await api.functional.bbs.articles.at(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app-globalPrefix/src/test/features/api/automated/test_api_bbs_articles_comments_at.ts
+++ b/test/features/app-globalPrefix/src/test/features/api/automated/test_api_bbs_articles_comments_at.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 import type { Format } from "typia/lib/tags/Format";
 
@@ -8,7 +8,7 @@ import type { IBbsComment } from "../../../../api/structures/IBbsComment";
 export const test_api_bbs_articles_comments_at = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.articles.comments.at(
+    const output: Primitive<IBbsComment> = await api.functional.bbs.articles.comments.at(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app-globalPrefix/src/test/features/api/automated/test_api_bbs_articles_comments_index.ts
+++ b/test/features/app-globalPrefix/src/test/features/api/automated/test_api_bbs_articles_comments_index.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 import type { Format } from "typia/lib/tags/Format";
 
@@ -9,7 +9,7 @@ import type { IPage } from "../../../../api/structures/IPage";
 export const test_api_bbs_articles_comments_index = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.articles.comments.index(
+    const output: Primitive<IPage<IBbsComment>> = await api.functional.bbs.articles.comments.index(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app-globalPrefix/src/test/features/api/automated/test_api_bbs_articles_comments_store.ts
+++ b/test/features/app-globalPrefix/src/test/features/api/automated/test_api_bbs_articles_comments_store.ts
@@ -8,7 +8,7 @@ import type { IBbsComment } from "../../../../api/structures/IBbsComment";
 export const test_api_bbs_articles_comments_store = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.articles.comments.store(
+    const output: Primitive<IBbsComment> = await api.functional.bbs.articles.comments.store(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app-globalPrefix/src/test/features/api/automated/test_api_bbs_articles_comments_update.ts
+++ b/test/features/app-globalPrefix/src/test/features/api/automated/test_api_bbs_articles_comments_update.ts
@@ -8,7 +8,7 @@ import type { IBbsComment } from "../../../../api/structures/IBbsComment";
 export const test_api_bbs_articles_comments_update = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.articles.comments.update(
+    const output: Primitive<IBbsComment> = await api.functional.bbs.articles.comments.update(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app-globalPrefix/src/test/features/api/automated/test_api_bbs_articles_index.ts
+++ b/test/features/app-globalPrefix/src/test/features/api/automated/test_api_bbs_articles_index.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -8,7 +8,7 @@ import type { IPage } from "../../../../api/structures/IPage";
 export const test_api_bbs_articles_index = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.articles.index(
+    const output: Primitive<IPage<IBbsArticle.ISummary>> = await api.functional.bbs.articles.index(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<IPage.IRequest>>(),

--- a/test/features/app-globalPrefix/src/test/features/api/automated/test_api_bbs_articles_store.ts
+++ b/test/features/app-globalPrefix/src/test/features/api/automated/test_api_bbs_articles_store.ts
@@ -7,7 +7,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_bbs_articles_store = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.articles.store(
+    const output: Primitive<IBbsArticle> = await api.functional.bbs.articles.store(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Primitive<IBbsArticle.IStore>>(),

--- a/test/features/app-globalPrefix/src/test/features/api/automated/test_api_bbs_articles_update.ts
+++ b/test/features/app-globalPrefix/src/test/features/api/automated/test_api_bbs_articles_update.ts
@@ -8,7 +8,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_bbs_articles_update = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.articles.update(
+    const output: Primitive<IBbsArticle> = await api.functional.bbs.articles.update(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app-globalPrefix/src/test/features/api/automated/test_api_performance_get.ts
+++ b/test/features/app-globalPrefix/src/test/features/api/automated/test_api_performance_get.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IPerformance } from "../../../../api/structures/IPerformance";
 export const test_api_performance_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.performance.get(
+    const output: Primitive<IPerformance> = await api.functional.performance.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/app-routerModule/src/test/features/api/automated/test_api_articles_comments_at.ts
+++ b/test/features/app-routerModule/src/test/features/api/automated/test_api_articles_comments_at.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 import type { Format } from "typia/lib/tags/Format";
 
@@ -8,7 +8,7 @@ import type { IBbsComment } from "../../../../api/structures/IBbsComment";
 export const test_api_articles_comments_at = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.articles.comments.at(
+    const output: Primitive<IBbsComment> = await api.functional.articles.comments.at(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app-routerModule/src/test/features/api/automated/test_api_articles_comments_index.ts
+++ b/test/features/app-routerModule/src/test/features/api/automated/test_api_articles_comments_index.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 import type { Format } from "typia/lib/tags/Format";
 
@@ -9,7 +9,7 @@ import type { IPage } from "../../../../api/structures/IPage";
 export const test_api_articles_comments_index = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.articles.comments.index(
+    const output: Primitive<IPage<IBbsComment>> = await api.functional.articles.comments.index(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app-routerModule/src/test/features/api/automated/test_api_articles_comments_store.ts
+++ b/test/features/app-routerModule/src/test/features/api/automated/test_api_articles_comments_store.ts
@@ -8,7 +8,7 @@ import type { IBbsComment } from "../../../../api/structures/IBbsComment";
 export const test_api_articles_comments_store = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.articles.comments.store(
+    const output: Primitive<IBbsComment> = await api.functional.articles.comments.store(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app-routerModule/src/test/features/api/automated/test_api_articles_comments_update.ts
+++ b/test/features/app-routerModule/src/test/features/api/automated/test_api_articles_comments_update.ts
@@ -8,7 +8,7 @@ import type { IBbsComment } from "../../../../api/structures/IBbsComment";
 export const test_api_articles_comments_update = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.articles.comments.update(
+    const output: Primitive<IBbsComment> = await api.functional.articles.comments.update(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app-routerModule/src/test/features/api/automated/test_api_bbs_articles_at.ts
+++ b/test/features/app-routerModule/src/test/features/api/automated/test_api_bbs_articles_at.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 import type { Format } from "typia/lib/tags/Format";
 
@@ -8,7 +8,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_bbs_articles_at = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.articles.at(
+    const output: Primitive<IBbsArticle> = await api.functional.bbs.articles.at(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app-routerModule/src/test/features/api/automated/test_api_bbs_articles_index.ts
+++ b/test/features/app-routerModule/src/test/features/api/automated/test_api_bbs_articles_index.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -8,7 +8,7 @@ import type { IPage } from "../../../../api/structures/IPage";
 export const test_api_bbs_articles_index = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.articles.index(
+    const output: Primitive<IPage<IBbsArticle.ISummary>> = await api.functional.bbs.articles.index(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<IPage.IRequest>>(),

--- a/test/features/app-routerModule/src/test/features/api/automated/test_api_bbs_articles_store.ts
+++ b/test/features/app-routerModule/src/test/features/api/automated/test_api_bbs_articles_store.ts
@@ -7,7 +7,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_bbs_articles_store = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.articles.store(
+    const output: Primitive<IBbsArticle> = await api.functional.bbs.articles.store(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Primitive<IBbsArticle.IStore>>(),

--- a/test/features/app-routerModule/src/test/features/api/automated/test_api_bbs_articles_update.ts
+++ b/test/features/app-routerModule/src/test/features/api/automated/test_api_bbs_articles_update.ts
@@ -8,7 +8,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_bbs_articles_update = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.articles.update(
+    const output: Primitive<IBbsArticle> = await api.functional.bbs.articles.update(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app-routerModule/src/test/features/api/automated/test_api_performance_get.ts
+++ b/test/features/app-routerModule/src/test/features/api/automated/test_api_performance_get.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IPerformance } from "../../../../api/structures/IPerformance";
 export const test_api_performance_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.performance.get(
+    const output: Primitive<IPerformance> = await api.functional.performance.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/app-versionHeader/src/test/features/api/automated/test_api_bbs_articles_at.ts
+++ b/test/features/app-versionHeader/src/test/features/api/automated/test_api_bbs_articles_at.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 import type { Format } from "typia/lib/tags/Format";
 
@@ -8,7 +8,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_bbs_articles_at = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.articles.at(
+    const output: Primitive<IBbsArticle> = await api.functional.bbs.articles.at(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app-versionHeader/src/test/features/api/automated/test_api_bbs_articles_comments_at.ts
+++ b/test/features/app-versionHeader/src/test/features/api/automated/test_api_bbs_articles_comments_at.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 import type { Format } from "typia/lib/tags/Format";
 
@@ -8,7 +8,7 @@ import type { IBbsComment } from "../../../../api/structures/IBbsComment";
 export const test_api_bbs_articles_comments_at = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.articles.comments.at(
+    const output: Primitive<IBbsComment> = await api.functional.bbs.articles.comments.at(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app-versionHeader/src/test/features/api/automated/test_api_bbs_articles_comments_index.ts
+++ b/test/features/app-versionHeader/src/test/features/api/automated/test_api_bbs_articles_comments_index.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 import type { Format } from "typia/lib/tags/Format";
 
@@ -9,7 +9,7 @@ import type { IPage } from "../../../../api/structures/IPage";
 export const test_api_bbs_articles_comments_index = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.articles.comments.index(
+    const output: Primitive<IPage<IBbsComment>> = await api.functional.bbs.articles.comments.index(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app-versionHeader/src/test/features/api/automated/test_api_bbs_articles_comments_store.ts
+++ b/test/features/app-versionHeader/src/test/features/api/automated/test_api_bbs_articles_comments_store.ts
@@ -8,7 +8,7 @@ import type { IBbsComment } from "../../../../api/structures/IBbsComment";
 export const test_api_bbs_articles_comments_store = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.articles.comments.store(
+    const output: Primitive<IBbsComment> = await api.functional.bbs.articles.comments.store(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app-versionHeader/src/test/features/api/automated/test_api_bbs_articles_comments_update.ts
+++ b/test/features/app-versionHeader/src/test/features/api/automated/test_api_bbs_articles_comments_update.ts
@@ -8,7 +8,7 @@ import type { IBbsComment } from "../../../../api/structures/IBbsComment";
 export const test_api_bbs_articles_comments_update = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.articles.comments.update(
+    const output: Primitive<IBbsComment> = await api.functional.bbs.articles.comments.update(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app-versionHeader/src/test/features/api/automated/test_api_bbs_articles_index.ts
+++ b/test/features/app-versionHeader/src/test/features/api/automated/test_api_bbs_articles_index.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -8,7 +8,7 @@ import type { IPage } from "../../../../api/structures/IPage";
 export const test_api_bbs_articles_index = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.articles.index(
+    const output: Primitive<IPage<IBbsArticle.ISummary>> = await api.functional.bbs.articles.index(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<IPage.IRequest>>(),

--- a/test/features/app-versionHeader/src/test/features/api/automated/test_api_bbs_articles_store.ts
+++ b/test/features/app-versionHeader/src/test/features/api/automated/test_api_bbs_articles_store.ts
@@ -7,7 +7,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_bbs_articles_store = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.articles.store(
+    const output: Primitive<IBbsArticle> = await api.functional.bbs.articles.store(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Primitive<IBbsArticle.IStore>>(),

--- a/test/features/app-versionHeader/src/test/features/api/automated/test_api_bbs_articles_update.ts
+++ b/test/features/app-versionHeader/src/test/features/api/automated/test_api_bbs_articles_update.ts
@@ -8,7 +8,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_bbs_articles_update = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.articles.update(
+    const output: Primitive<IBbsArticle> = await api.functional.bbs.articles.update(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app-versionHeader/src/test/features/api/automated/test_api_performance_get.ts
+++ b/test/features/app-versionHeader/src/test/features/api/automated/test_api_performance_get.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IPerformance } from "../../../../api/structures/IPerformance";
 export const test_api_performance_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.performance.get(
+    const output: Primitive<IPerformance> = await api.functional.performance.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/app-versionUri/src/test/features/api/automated/test_api_bbs_articles_comments_at.ts
+++ b/test/features/app-versionUri/src/test/features/api/automated/test_api_bbs_articles_comments_at.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 import type { Format } from "typia/lib/tags/Format";
 
@@ -8,7 +8,7 @@ import type { IBbsComment } from "../../../../api/structures/IBbsComment";
 export const test_api_bbs_articles_comments_at = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.articles.comments.at(
+    const output: Primitive<IBbsComment> = await api.functional.bbs.articles.comments.at(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app-versionUri/src/test/features/api/automated/test_api_bbs_articles_comments_index.ts
+++ b/test/features/app-versionUri/src/test/features/api/automated/test_api_bbs_articles_comments_index.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 import type { Format } from "typia/lib/tags/Format";
 
@@ -9,7 +9,7 @@ import type { IPage } from "../../../../api/structures/IPage";
 export const test_api_bbs_articles_comments_index = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.articles.comments.index(
+    const output: Primitive<IPage<IBbsComment>> = await api.functional.bbs.articles.comments.index(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app-versionUri/src/test/features/api/automated/test_api_bbs_articles_comments_store.ts
+++ b/test/features/app-versionUri/src/test/features/api/automated/test_api_bbs_articles_comments_store.ts
@@ -8,7 +8,7 @@ import type { IBbsComment } from "../../../../api/structures/IBbsComment";
 export const test_api_bbs_articles_comments_store = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.articles.comments.store(
+    const output: Primitive<IBbsComment> = await api.functional.bbs.articles.comments.store(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app-versionUri/src/test/features/api/automated/test_api_bbs_articles_comments_update.ts
+++ b/test/features/app-versionUri/src/test/features/api/automated/test_api_bbs_articles_comments_update.ts
@@ -8,7 +8,7 @@ import type { IBbsComment } from "../../../../api/structures/IBbsComment";
 export const test_api_bbs_articles_comments_update = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.articles.comments.update(
+    const output: Primitive<IBbsComment> = await api.functional.bbs.articles.comments.update(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app-versionUri/src/test/features/api/automated/test_api_bbs_articles_index.ts
+++ b/test/features/app-versionUri/src/test/features/api/automated/test_api_bbs_articles_index.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -8,7 +8,7 @@ import type { IPage } from "../../../../api/structures/IPage";
 export const test_api_bbs_articles_index = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.articles.index(
+    const output: Primitive<IPage<IBbsArticle.ISummary>> = await api.functional.bbs.articles.index(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<IPage.IRequest>>(),

--- a/test/features/app-versionUri/src/test/features/api/automated/test_api_bbs_articles_store.ts
+++ b/test/features/app-versionUri/src/test/features/api/automated/test_api_bbs_articles_store.ts
@@ -7,7 +7,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_bbs_articles_store = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.articles.store(
+    const output: Primitive<IBbsArticle> = await api.functional.bbs.articles.store(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Primitive<IBbsArticle.IStore>>(),

--- a/test/features/app-versionUri/src/test/features/api/automated/test_api_v1_bbs_articles_at.ts
+++ b/test/features/app-versionUri/src/test/features/api/automated/test_api_v1_bbs_articles_at.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 import type { Format } from "typia/lib/tags/Format";
 
@@ -8,7 +8,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_v1_bbs_articles_at = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.v1.bbs.articles.at(
+    const output: Primitive<IBbsArticle> = await api.functional.v1.bbs.articles.at(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app-versionUri/src/test/features/api/automated/test_api_v1_bbs_articles_index.ts
+++ b/test/features/app-versionUri/src/test/features/api/automated/test_api_v1_bbs_articles_index.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -8,7 +8,7 @@ import type { IPage } from "../../../../api/structures/IPage";
 export const test_api_v1_bbs_articles_index = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.v1.bbs.articles.index(
+    const output: Primitive<IPage<IBbsArticle.ISummary>> = await api.functional.v1.bbs.articles.index(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<IPage.IRequest>>(),

--- a/test/features/app-versionUri/src/test/features/api/automated/test_api_v1_performance_get.ts
+++ b/test/features/app-versionUri/src/test/features/api/automated/test_api_v1_performance_get.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IPerformance } from "../../../../api/structures/IPerformance";
 export const test_api_v1_performance_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.v1.performance.get(
+    const output: Primitive<IPerformance> = await api.functional.v1.performance.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/app-versionUri/src/test/features/api/automated/test_api_v2_bbs_articles_index.ts
+++ b/test/features/app-versionUri/src/test/features/api/automated/test_api_v2_bbs_articles_index.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -8,7 +8,7 @@ import type { IPage } from "../../../../api/structures/IPage";
 export const test_api_v2_bbs_articles_index = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.v2.bbs.articles.index(
+    const output: Primitive<IPage<IBbsArticle.ISummary>> = await api.functional.v2.bbs.articles.index(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<IPage.IRequest>>(),

--- a/test/features/app-versionUri/src/test/features/api/automated/test_api_v2_bbs_articles_update.ts
+++ b/test/features/app-versionUri/src/test/features/api/automated/test_api_v2_bbs_articles_update.ts
@@ -8,7 +8,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_v2_bbs_articles_update = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.v2.bbs.articles.update(
+    const output: Primitive<IBbsArticle> = await api.functional.v2.bbs.articles.update(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app/src/test/features/api/automated/test_api_articles_comments_at.ts
+++ b/test/features/app/src/test/features/api/automated/test_api_articles_comments_at.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 import type { Format } from "typia/lib/tags/Format";
 
@@ -8,7 +8,7 @@ import type { IBbsComment } from "../../../../api/structures/IBbsComment";
 export const test_api_articles_comments_at = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.articles.comments.at(
+    const output: Primitive<IBbsComment> = await api.functional.articles.comments.at(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app/src/test/features/api/automated/test_api_articles_comments_index.ts
+++ b/test/features/app/src/test/features/api/automated/test_api_articles_comments_index.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 import type { Format } from "typia/lib/tags/Format";
 
@@ -9,7 +9,7 @@ import type { IPage } from "../../../../api/structures/IPage";
 export const test_api_articles_comments_index = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.articles.comments.index(
+    const output: Primitive<IPage<IBbsComment>> = await api.functional.articles.comments.index(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app/src/test/features/api/automated/test_api_articles_comments_store.ts
+++ b/test/features/app/src/test/features/api/automated/test_api_articles_comments_store.ts
@@ -8,7 +8,7 @@ import type { IBbsComment } from "../../../../api/structures/IBbsComment";
 export const test_api_articles_comments_store = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.articles.comments.store(
+    const output: Primitive<IBbsComment> = await api.functional.articles.comments.store(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app/src/test/features/api/automated/test_api_articles_comments_update.ts
+++ b/test/features/app/src/test/features/api/automated/test_api_articles_comments_update.ts
@@ -8,7 +8,7 @@ import type { IBbsComment } from "../../../../api/structures/IBbsComment";
 export const test_api_articles_comments_update = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.articles.comments.update(
+    const output: Primitive<IBbsComment> = await api.functional.articles.comments.update(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app/src/test/features/api/automated/test_api_bbs_articles_at.ts
+++ b/test/features/app/src/test/features/api/automated/test_api_bbs_articles_at.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 import type { Format } from "typia/lib/tags/Format";
 
@@ -8,7 +8,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_bbs_articles_at = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.articles.at(
+    const output: Primitive<IBbsArticle> = await api.functional.bbs.articles.at(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app/src/test/features/api/automated/test_api_bbs_articles_index.ts
+++ b/test/features/app/src/test/features/api/automated/test_api_bbs_articles_index.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -8,7 +8,7 @@ import type { IPage } from "../../../../api/structures/IPage";
 export const test_api_bbs_articles_index = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.articles.index(
+    const output: Primitive<IPage<IBbsArticle.ISummary>> = await api.functional.bbs.articles.index(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<IPage.IRequest>>(),

--- a/test/features/app/src/test/features/api/automated/test_api_bbs_articles_store.ts
+++ b/test/features/app/src/test/features/api/automated/test_api_bbs_articles_store.ts
@@ -7,7 +7,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_bbs_articles_store = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.articles.store(
+    const output: Primitive<IBbsArticle> = await api.functional.bbs.articles.store(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Primitive<IBbsArticle.IStore>>(),

--- a/test/features/app/src/test/features/api/automated/test_api_bbs_articles_update.ts
+++ b/test/features/app/src/test/features/api/automated/test_api_bbs_articles_update.ts
@@ -8,7 +8,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_bbs_articles_update = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.articles.update(
+    const output: Primitive<IBbsArticle> = await api.functional.bbs.articles.update(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/app/src/test/features/api/automated/test_api_performance_get.ts
+++ b/test/features/app/src/test/features/api/automated/test_api_performance_get.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IPerformance } from "../../../../api/structures/IPerformance";
 export const test_api_performance_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.performance.get(
+    const output: Primitive<IPerformance> = await api.functional.performance.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/assertEquals/src/test/features/api/automated/test_api_performance_get.ts
+++ b/test/features/assertEquals/src/test/features/api/automated/test_api_performance_get.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IPerformance } from "../../../../api/structures/IPerformance";
 export const test_api_performance_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.performance.get(
+    const output: Primitive<IPerformance> = await api.functional.performance.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/assertEquals/src/test/features/api/automated/test_api_request.ts
+++ b/test/features/assertEquals/src/test/features/api/automated/test_api_request.ts
@@ -7,7 +7,7 @@ import type { IRequestDto } from "../../../../api/structures/IRequestDto";
 export const test_api_request = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.request(
+    const output: Primitive<IRequestDto> = await api.functional.request(
         connection,
         typia.random<Primitive<IRequestDto>>(),
     );

--- a/test/features/body-manual-assert/src/test/features/api/automated/test_api_body_store.ts
+++ b/test/features/body-manual-assert/src/test/features/api/automated/test_api_body_store.ts
@@ -7,7 +7,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_body_store = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.body.store(
+    const output: Primitive<IBbsArticle> = await api.functional.body.store(
         connection,
         typia.random<Primitive<IBbsArticle.IStore>>(),
     );

--- a/test/features/body-manual-assert/src/test/features/api/automated/test_api_performance_get.ts
+++ b/test/features/body-manual-assert/src/test/features/api/automated/test_api_performance_get.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IPerformance } from "../../../../api/structures/IPerformance";
 export const test_api_performance_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.performance.get(
+    const output: Primitive<IPerformance> = await api.functional.performance.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/body-manual-is/src/test/features/api/automated/test_api_body_store.ts
+++ b/test/features/body-manual-is/src/test/features/api/automated/test_api_body_store.ts
@@ -7,7 +7,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_body_store = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.body.store(
+    const output: Primitive<IBbsArticle> = await api.functional.body.store(
         connection,
         typia.random<Primitive<IBbsArticle.IStore>>(),
     );

--- a/test/features/body-manual-is/src/test/features/api/automated/test_api_performance_get.ts
+++ b/test/features/body-manual-is/src/test/features/api/automated/test_api_performance_get.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IPerformance } from "../../../../api/structures/IPerformance";
 export const test_api_performance_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.performance.get(
+    const output: Primitive<IPerformance> = await api.functional.performance.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/body-manual-validate/src/test/features/api/automated/test_api_body_store.ts
+++ b/test/features/body-manual-validate/src/test/features/api/automated/test_api_body_store.ts
@@ -7,7 +7,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_body_store = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.body.store(
+    const output: Primitive<IBbsArticle> = await api.functional.body.store(
         connection,
         typia.random<Primitive<IBbsArticle.IStore>>(),
     );

--- a/test/features/body-manual-validate/src/test/features/api/automated/test_api_performance_get.ts
+++ b/test/features/body-manual-validate/src/test/features/api/automated/test_api_performance_get.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IPerformance } from "../../../../api/structures/IPerformance";
 export const test_api_performance_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.performance.get(
+    const output: Primitive<IPerformance> = await api.functional.performance.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/body/src/test/features/api/automated/test_api_body_store.ts
+++ b/test/features/body/src/test/features/api/automated/test_api_body_store.ts
@@ -7,7 +7,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_body_store = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.body.store(
+    const output: Primitive<IBbsArticle> = await api.functional.body.store(
         connection,
         typia.random<Primitive<IBbsArticle.IStore>>(),
     );

--- a/test/features/body/src/test/features/api/automated/test_api_performance_get.ts
+++ b/test/features/body/src/test/features/api/automated/test_api_performance_get.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IPerformance } from "../../../../api/structures/IPerformance";
 export const test_api_performance_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.performance.get(
+    const output: Primitive<IPerformance> = await api.functional.performance.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/cli-config-project/src/test/features/api/automated/test_api_body_store.ts
+++ b/test/features/cli-config-project/src/test/features/api/automated/test_api_body_store.ts
@@ -7,7 +7,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_body_store = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.body.store(
+    const output: Primitive<IBbsArticle> = await api.functional.body.store(
         connection,
         typia.random<Primitive<IBbsArticle.IStore>>(),
     );

--- a/test/features/cli-config-project/src/test/features/api/automated/test_api_performance_get.ts
+++ b/test/features/cli-config-project/src/test/features/api/automated/test_api_performance_get.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IPerformance } from "../../../../api/structures/IPerformance";
 export const test_api_performance_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.performance.get(
+    const output: Primitive<IPerformance> = await api.functional.performance.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/cli-config/src/test/features/api/automated/test_api_body_store.ts
+++ b/test/features/cli-config/src/test/features/api/automated/test_api_body_store.ts
@@ -7,7 +7,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_body_store = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.body.store(
+    const output: Primitive<IBbsArticle> = await api.functional.body.store(
         connection,
         typia.random<Primitive<IBbsArticle.IStore>>(),
     );

--- a/test/features/cli-config/src/test/features/api/automated/test_api_performance_get.ts
+++ b/test/features/cli-config/src/test/features/api/automated/test_api_performance_get.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IPerformance } from "../../../../api/structures/IPerformance";
 export const test_api_performance_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.performance.get(
+    const output: Primitive<IPerformance> = await api.functional.performance.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/cli-project/nestia.config.ts
+++ b/test/features/cli-project/nestia.config.ts
@@ -1,7 +1,6 @@
 import { INestiaConfig } from "@nestia/sdk";
 
 export const NESTIA_CONFIG: INestiaConfig = {
-    project: "tsconfig.nestia.json",
     input: ["src/controllers"],
     output: "src/api",
     swagger: {

--- a/test/features/clone-and-exact-optional-property/src/test/features/api/automated/test_api_partial_dto_test_original.ts
+++ b/test/features/clone-and-exact-optional-property/src/test/features/api/automated/test_api_partial_dto_test_original.ts
@@ -1,11 +1,15 @@
+import type { IPropagation } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
+import type { IOriginal } from "../../../../api/structures/IOriginal";
 
 export const test_api_partial_dto_test_original = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.partial_dto_test.original(
+    const output: IPropagation<{
+        200: IOriginal;
+    }> = await api.functional.partial_dto_test.original(
         connection,
     );
     typia.assert(output);

--- a/test/features/clone-and-exact-optional-property/src/test/features/api/automated/test_api_partial_dto_test_partial_interface_partialInterface.ts
+++ b/test/features/clone-and-exact-optional-property/src/test/features/api/automated/test_api_partial_dto_test_partial_interface_partialInterface.ts
@@ -1,13 +1,16 @@
-import type { Primitive } from "@nestia/fetcher";
+import type { IPropagation, Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
 import type { IOriginal } from "../../../../api/structures/IOriginal";
+import type { IPartialInterface } from "../../../../api/structures/IPartialInterface";
 
 export const test_api_partial_dto_test_partial_interface_partialInterface = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.partial_dto_test.partial_interface.partialInterface(
+    const output: IPropagation<{
+        201: IPartialInterface;
+    }> = await api.functional.partial_dto_test.partial_interface.partialInterface(
         connection,
         typia.random<Primitive<IOriginal.IPartialInterface>>(),
     );

--- a/test/features/clone-and-exact-optional-property/src/test/features/api/automated/test_api_partial_dto_test_partial_type_partialType.ts
+++ b/test/features/clone-and-exact-optional-property/src/test/features/api/automated/test_api_partial_dto_test_partial_type_partialType.ts
@@ -1,13 +1,16 @@
-import type { Primitive } from "@nestia/fetcher";
+import type { IPropagation, Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
 import type { PartialPickIOriginaldemailcreated_atoriginal_optionalundefinable_attr } from "../../../../api/structures/PartialPickIOriginaldemailcreated_atoriginal_optionalundefinable_attr";
+import type { PartialPickIOriginalemailcreated_atoriginal_optionalundefinable_attrb } from "../../../../api/structures/PartialPickIOriginalemailcreated_atoriginal_optionalundefinable_attrb";
 
 export const test_api_partial_dto_test_partial_type_partialType = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.partial_dto_test.partial_type.partialType(
+    const output: IPropagation<{
+        201: PartialPickIOriginalemailcreated_atoriginal_optionalundefinable_attrb;
+    }> = await api.functional.partial_dto_test.partial_type.partialType(
         connection,
         typia.random<Primitive<PartialPickIOriginaldemailcreated_atoriginal_optionalundefinable_attr>>(),
     );

--- a/test/features/clone-and-propagate/src/test/features/api/automated/test_api_arrayRecursiveUnionExplicit_at.ts
+++ b/test/features/clone-and-propagate/src/test/features/api/automated/test_api_arrayRecursiveUnionExplicit_at.ts
@@ -1,12 +1,15 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { IPropagation, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
+import type { ArrayRecursiveUnionExplicit } from "../../../../api/structures/ArrayRecursiveUnionExplicit";
 
 export const test_api_arrayRecursiveUnionExplicit_at = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.arrayRecursiveUnionExplicit.at(
+    const output: IPropagation<{
+        200: ArrayRecursiveUnionExplicit.IBucket;
+    }> = await api.functional.arrayRecursiveUnionExplicit.at(
         connection,
         typia.random<Resolved<number>>(),
     );

--- a/test/features/clone-and-propagate/src/test/features/api/automated/test_api_arrayRecursiveUnionExplicit_index.ts
+++ b/test/features/clone-and-propagate/src/test/features/api/automated/test_api_arrayRecursiveUnionExplicit_index.ts
@@ -1,11 +1,15 @@
+import type { IPropagation } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
+import type { ArrayRecursiveUnionExplicit } from "../../../../api/structures/ArrayRecursiveUnionExplicit";
 
 export const test_api_arrayRecursiveUnionExplicit_index = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.arrayRecursiveUnionExplicit.index(
+    const output: IPropagation<{
+        200: ArrayRecursiveUnionExplicit;
+    }> = await api.functional.arrayRecursiveUnionExplicit.index(
         connection,
     );
     typia.assert(output);

--- a/test/features/clone-and-propagate/src/test/features/api/automated/test_api_arrayRecursiveUnionExplicit_store.ts
+++ b/test/features/clone-and-propagate/src/test/features/api/automated/test_api_arrayRecursiveUnionExplicit_store.ts
@@ -1,4 +1,4 @@
-import type { Primitive } from "@nestia/fetcher";
+import type { IPropagation, Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -7,7 +7,9 @@ import type { ArrayRecursiveUnionExplicit } from "../../../../api/structures/Arr
 export const test_api_arrayRecursiveUnionExplicit_store = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.arrayRecursiveUnionExplicit.store(
+    const output: IPropagation<{
+        201: ArrayRecursiveUnionExplicit.IBucket;
+    }> = await api.functional.arrayRecursiveUnionExplicit.store(
         connection,
         typia.random<Primitive<ArrayRecursiveUnionExplicit.IBucket>>(),
     );

--- a/test/features/clone-and-propagate/src/test/features/api/automated/test_api_arrayRecursiveUnionImplicit_at.ts
+++ b/test/features/clone-and-propagate/src/test/features/api/automated/test_api_arrayRecursiveUnionImplicit_at.ts
@@ -1,12 +1,15 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { IPropagation, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
+import type { ArrayRecursiveUnionImplicit } from "../../../../api/structures/ArrayRecursiveUnionImplicit";
 
 export const test_api_arrayRecursiveUnionImplicit_at = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.arrayRecursiveUnionImplicit.at(
+    const output: IPropagation<{
+        200: ArrayRecursiveUnionImplicit.IBucket;
+    }> = await api.functional.arrayRecursiveUnionImplicit.at(
         connection,
         typia.random<Resolved<number>>(),
     );

--- a/test/features/clone-and-propagate/src/test/features/api/automated/test_api_arrayRecursiveUnionImplicit_index.ts
+++ b/test/features/clone-and-propagate/src/test/features/api/automated/test_api_arrayRecursiveUnionImplicit_index.ts
@@ -1,11 +1,15 @@
+import type { IPropagation } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
+import type { ArrayRecursiveUnionImplicit } from "../../../../api/structures/ArrayRecursiveUnionImplicit";
 
 export const test_api_arrayRecursiveUnionImplicit_index = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.arrayRecursiveUnionImplicit.index(
+    const output: IPropagation<{
+        200: ArrayRecursiveUnionImplicit;
+    }> = await api.functional.arrayRecursiveUnionImplicit.index(
         connection,
     );
     typia.assert(output);

--- a/test/features/clone-and-propagate/src/test/features/api/automated/test_api_arrayRecursiveUnionImplicit_store.ts
+++ b/test/features/clone-and-propagate/src/test/features/api/automated/test_api_arrayRecursiveUnionImplicit_store.ts
@@ -1,4 +1,4 @@
-import type { Primitive } from "@nestia/fetcher";
+import type { IPropagation, Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -7,7 +7,9 @@ import type { ArrayRecursiveUnionImplicit } from "../../../../api/structures/Arr
 export const test_api_arrayRecursiveUnionImplicit_store = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.arrayRecursiveUnionImplicit.store(
+    const output: IPropagation<{
+        201: ArrayRecursiveUnionImplicit.IBucket;
+    }> = await api.functional.arrayRecursiveUnionImplicit.store(
         connection,
         typia.random<Primitive<ArrayRecursiveUnionImplicit.IBucket>>(),
     );

--- a/test/features/clone-and-propagate/src/test/features/api/automated/test_api_arrayRecursive_at.ts
+++ b/test/features/clone-and-propagate/src/test/features/api/automated/test_api_arrayRecursive_at.ts
@@ -1,12 +1,15 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { IPropagation, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
+import type { ArrayRecursive } from "../../../../api/structures/ArrayRecursive";
 
 export const test_api_arrayRecursive_at = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.arrayRecursive.at(
+    const output: IPropagation<{
+        200: ArrayRecursive.ICategory;
+    }> = await api.functional.arrayRecursive.at(
         connection,
         typia.random<Resolved<number>>(),
     );

--- a/test/features/clone-and-propagate/src/test/features/api/automated/test_api_arrayRecursive_index.ts
+++ b/test/features/clone-and-propagate/src/test/features/api/automated/test_api_arrayRecursive_index.ts
@@ -1,11 +1,15 @@
+import type { IPropagation } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
+import type { ArrayRecursive } from "../../../../api/structures/ArrayRecursive";
 
 export const test_api_arrayRecursive_index = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.arrayRecursive.index(
+    const output: IPropagation<{
+        200: Array<ArrayRecursive.ICategory>;
+    }> = await api.functional.arrayRecursive.index(
         connection,
     );
     typia.assert(output);

--- a/test/features/clone-and-propagate/src/test/features/api/automated/test_api_arrayRecursive_store.ts
+++ b/test/features/clone-and-propagate/src/test/features/api/automated/test_api_arrayRecursive_store.ts
@@ -1,4 +1,4 @@
-import type { Primitive } from "@nestia/fetcher";
+import type { IPropagation, Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -7,7 +7,9 @@ import type { ArrayRecursive } from "../../../../api/structures/ArrayRecursive";
 export const test_api_arrayRecursive_store = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.arrayRecursive.store(
+    const output: IPropagation<{
+        201: ArrayRecursive.ICategory;
+    }> = await api.functional.arrayRecursive.store(
         connection,
         typia.random<Primitive<ArrayRecursive.ICategory>>(),
     );

--- a/test/features/clone-and-propagate/src/test/features/api/automated/test_api_arraySimple_at.ts
+++ b/test/features/clone-and-propagate/src/test/features/api/automated/test_api_arraySimple_at.ts
@@ -1,13 +1,16 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { IPropagation, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 import type { Format } from "typia/lib/tags/Format";
 
 import api from "../../../../api";
+import type { ArraySimple } from "../../../../api/structures/ArraySimple";
 
 export const test_api_arraySimple_at = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.arraySimple.at(
+    const output: IPropagation<{
+        200: ArraySimple.IPerson;
+    }> = await api.functional.arraySimple.at(
         connection,
         typia.random<Resolved<(string & Format<"uuid">)>>(),
     );

--- a/test/features/clone-and-propagate/src/test/features/api/automated/test_api_arraySimple_index.ts
+++ b/test/features/clone-and-propagate/src/test/features/api/automated/test_api_arraySimple_index.ts
@@ -1,11 +1,15 @@
+import type { IPropagation } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
+import type { ArraySimple } from "../../../../api/structures/ArraySimple";
 
 export const test_api_arraySimple_index = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.arraySimple.index(
+    const output: IPropagation<{
+        200: ArraySimple;
+    }> = await api.functional.arraySimple.index(
         connection,
     );
     typia.assert(output);

--- a/test/features/clone-and-propagate/src/test/features/api/automated/test_api_arraySimple_store.ts
+++ b/test/features/clone-and-propagate/src/test/features/api/automated/test_api_arraySimple_store.ts
@@ -1,4 +1,4 @@
-import type { Primitive } from "@nestia/fetcher";
+import type { IPropagation, Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -7,7 +7,9 @@ import type { ArraySimple } from "../../../../api/structures/ArraySimple";
 export const test_api_arraySimple_store = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.arraySimple.store(
+    const output: IPropagation<{
+        201: ArraySimple.IPerson;
+    }> = await api.functional.arraySimple.store(
         connection,
         typia.random<Primitive<ArraySimple.IPerson>>(),
     );

--- a/test/features/clone-and-propagate/src/test/features/api/automated/test_api_bbs_articles_index.ts
+++ b/test/features/clone-and-propagate/src/test/features/api/automated/test_api_bbs_articles_index.ts
@@ -1,13 +1,16 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { IPropagation, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
 import type { IPage } from "../../../../api/structures/IPage";
+import type { IPageIBbsArticle } from "../../../../api/structures/IPageIBbsArticle";
 
 export const test_api_bbs_articles_index = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.articles.index(
+    const output: IPropagation<{
+        200: IPageIBbsArticle.ISummary;
+    }> = await api.functional.bbs.articles.index(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<IPage.IRequest>>(),

--- a/test/features/clone-and-propagate/src/test/features/api/automated/test_api_bbs_articles_store.ts
+++ b/test/features/clone-and-propagate/src/test/features/api/automated/test_api_bbs_articles_store.ts
@@ -1,4 +1,4 @@
-import type { Primitive, Resolved } from "@nestia/fetcher";
+import type { IPropagation, Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -7,7 +7,9 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_bbs_articles_store = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.articles.store(
+    const output: IPropagation<{
+        201: IBbsArticle;
+    }> = await api.functional.bbs.articles.store(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Primitive<IBbsArticle.IStore>>(),

--- a/test/features/clone-and-propagate/src/test/features/api/automated/test_api_bbs_articles_update.ts
+++ b/test/features/clone-and-propagate/src/test/features/api/automated/test_api_bbs_articles_update.ts
@@ -1,4 +1,4 @@
-import type { Primitive, Resolved } from "@nestia/fetcher";
+import type { IPropagation, Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 import type { Format } from "typia/lib/tags/Format";
 
@@ -8,7 +8,9 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_bbs_articles_update = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.articles.update(
+    const output: IPropagation<{
+        200: IBbsArticle;
+    }> = await api.functional.bbs.articles.update(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<(string & Format<"uuid">)>>(),

--- a/test/features/clone-and-propagate/src/test/features/api/automated/test_api_objectSimple_at.ts
+++ b/test/features/clone-and-propagate/src/test/features/api/automated/test_api_objectSimple_at.ts
@@ -1,12 +1,15 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { IPropagation, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
+import type { ObjectSimple } from "../../../../api/structures/ObjectSimple";
 
 export const test_api_objectSimple_at = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.objectSimple.at(
+    const output: IPropagation<{
+        200: ObjectSimple.IBox3D;
+    }> = await api.functional.objectSimple.at(
         connection,
         typia.random<Resolved<number>>(),
     );

--- a/test/features/clone-and-propagate/src/test/features/api/automated/test_api_objectSimple_index.ts
+++ b/test/features/clone-and-propagate/src/test/features/api/automated/test_api_objectSimple_index.ts
@@ -1,11 +1,15 @@
+import type { IPropagation } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
+import type { ObjectSimple } from "../../../../api/structures/ObjectSimple";
 
 export const test_api_objectSimple_index = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.objectSimple.index(
+    const output: IPropagation<{
+        200: Array<ObjectSimple.IBox3D>;
+    }> = await api.functional.objectSimple.index(
         connection,
     );
     typia.assert(output);

--- a/test/features/clone-and-propagate/src/test/features/api/automated/test_api_objectSimple_store.ts
+++ b/test/features/clone-and-propagate/src/test/features/api/automated/test_api_objectSimple_store.ts
@@ -1,4 +1,4 @@
-import type { Primitive } from "@nestia/fetcher";
+import type { IPropagation, Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -7,7 +7,9 @@ import type { ObjectSimple } from "../../../../api/structures/ObjectSimple";
 export const test_api_objectSimple_store = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.objectSimple.store(
+    const output: IPropagation<{
+        201: ObjectSimple.IBox3D;
+    }> = await api.functional.objectSimple.store(
         connection,
         typia.random<Primitive<ObjectSimple.IBox3D>>(),
     );

--- a/test/features/clone-and-propagate/src/test/features/api/automated/test_api_objectUnionExplicit_get.ts
+++ b/test/features/clone-and-propagate/src/test/features/api/automated/test_api_objectUnionExplicit_get.ts
@@ -1,11 +1,15 @@
+import type { IPropagation } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
+import type { ObjectUnionExplicit } from "../../../../api/structures/ObjectUnionExplicit";
 
 export const test_api_objectUnionExplicit_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.objectUnionExplicit.get(
+    const output: IPropagation<{
+        200: ObjectUnionExplicit;
+    }> = await api.functional.objectUnionExplicit.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/clone-and-propagate/src/test/features/api/automated/test_api_objectUnionImplicitControllere_get.ts
+++ b/test/features/clone-and-propagate/src/test/features/api/automated/test_api_objectUnionImplicitControllere_get.ts
@@ -1,11 +1,15 @@
+import type { IPropagation } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
+import type { ObjectUnionImplicit } from "../../../../api/structures/ObjectUnionImplicit";
 
 export const test_api_objectUnionImplicitControllere_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.objectUnionImplicitControllere.get(
+    const output: IPropagation<{
+        200: ObjectUnionImplicit;
+    }> = await api.functional.objectUnionImplicitControllere.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/clone-and-propagate/src/test/features/api/automated/test_api_performance_cpu.ts
+++ b/test/features/clone-and-propagate/src/test/features/api/automated/test_api_performance_cpu.ts
@@ -1,11 +1,15 @@
+import type { IPropagation } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
+import type { process } from "../../../../api/structures/process";
 
 export const test_api_performance_cpu = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.performance.cpu(
+    const output: IPropagation<{
+        200: process.global.NodeJS.CpuUsage;
+    }> = await api.functional.performance.cpu(
         connection,
     );
     typia.assert(output);

--- a/test/features/clone-and-propagate/src/test/features/api/automated/test_api_performance_memory.ts
+++ b/test/features/clone-and-propagate/src/test/features/api/automated/test_api_performance_memory.ts
@@ -1,11 +1,15 @@
+import type { IPropagation } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
+import type { process } from "../../../../api/structures/process";
 
 export const test_api_performance_memory = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.performance.memory(
+    const output: IPropagation<{
+        200: process.global.NodeJS.MemoryUsage;
+    }> = await api.functional.performance.memory(
         connection,
     );
     typia.assert(output);

--- a/test/features/clone-and-propagate/src/test/features/api/automated/test_api_performance_resource.ts
+++ b/test/features/clone-and-propagate/src/test/features/api/automated/test_api_performance_resource.ts
@@ -1,11 +1,15 @@
+import type { IPropagation } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
+import type { process } from "../../../../api/structures/process";
 
 export const test_api_performance_resource = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.performance.resource(
+    const output: IPropagation<{
+        200: process.global.NodeJS.ResourceUsage;
+    }> = await api.functional.performance.resource(
         connection,
     );
     typia.assert(output);

--- a/test/features/clone-and-propagate/src/test/features/api/automated/test_api_sellers_authenticate_join.ts
+++ b/test/features/clone-and-propagate/src/test/features/api/automated/test_api_sellers_authenticate_join.ts
@@ -1,4 +1,4 @@
-import type { Primitive } from "@nestia/fetcher";
+import type { IPropagation, Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -7,7 +7,9 @@ import type { ISeller } from "../../../../api/structures/ISeller";
 export const test_api_sellers_authenticate_join = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.sellers.authenticate.join(
+    const output: IPropagation<{
+        201: ISeller.IAuthorized;
+    }> = await api.functional.sellers.authenticate.join(
         connection,
         typia.random<Primitive<ISeller.IJoin>>(),
     );

--- a/test/features/clone-and-propagate/src/test/features/api/automated/test_api_sellers_authenticate_login.ts
+++ b/test/features/clone-and-propagate/src/test/features/api/automated/test_api_sellers_authenticate_login.ts
@@ -1,4 +1,4 @@
-import type { Primitive } from "@nestia/fetcher";
+import type { IPropagation, Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -7,7 +7,9 @@ import type { ISeller } from "../../../../api/structures/ISeller";
 export const test_api_sellers_authenticate_login = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.sellers.authenticate.login(
+    const output: IPropagation<{
+        201: ISeller.IAuthorized;
+    }> = await api.functional.sellers.authenticate.login(
         connection,
         typia.random<Primitive<ISeller.ILogin>>(),
     );

--- a/test/features/clone-and-propagate/src/test/features/api/automated/test_api_swagger_get.ts
+++ b/test/features/clone-and-propagate/src/test/features/api/automated/test_api_swagger_get.ts
@@ -1,11 +1,15 @@
+import type { IPropagation } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
+import type { ISwagger } from "../../../../api/structures/ISwagger";
 
 export const test_api_swagger_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.swagger.get(
+    const output: IPropagation<{
+        200: ISwagger;
+    }> = await api.functional.swagger.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/clone-and-propagate/src/test/features/api/automated/test_api_tupleHierarchicalController_at.ts
+++ b/test/features/clone-and-propagate/src/test/features/api/automated/test_api_tupleHierarchicalController_at.ts
@@ -1,12 +1,15 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { IPropagation, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
+import type { TupleHierarchical } from "../../../../api/structures/TupleHierarchical";
 
 export const test_api_tupleHierarchicalController_at = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.tupleHierarchicalController.at(
+    const output: IPropagation<{
+        200: TupleHierarchical;
+    }> = await api.functional.tupleHierarchicalController.at(
         connection,
         typia.random<Resolved<number>>(),
     );

--- a/test/features/clone-and-propagate/src/test/features/api/automated/test_api_tupleHierarchicalController_index.ts
+++ b/test/features/clone-and-propagate/src/test/features/api/automated/test_api_tupleHierarchicalController_index.ts
@@ -1,11 +1,15 @@
+import type { IPropagation } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
+import type { TupleHierarchical } from "../../../../api/structures/TupleHierarchical";
 
 export const test_api_tupleHierarchicalController_index = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.tupleHierarchicalController.index(
+    const output: IPropagation<{
+        200: Array<TupleHierarchical>;
+    }> = await api.functional.tupleHierarchicalController.index(
         connection,
     );
     typia.assert(output);

--- a/test/features/clone-and-propagate/src/test/features/api/automated/test_api_tupleHierarchicalController_store.ts
+++ b/test/features/clone-and-propagate/src/test/features/api/automated/test_api_tupleHierarchicalController_store.ts
@@ -1,4 +1,4 @@
-import type { Primitive } from "@nestia/fetcher";
+import type { IPropagation, Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -7,7 +7,9 @@ import type { TupleHierarchical } from "../../../../api/structures/TupleHierarch
 export const test_api_tupleHierarchicalController_store = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.tupleHierarchicalController.store(
+    const output: IPropagation<{
+        201: TupleHierarchical;
+    }> = await api.functional.tupleHierarchicalController.store(
         connection,
         typia.random<Primitive<TupleHierarchical>>(),
     );

--- a/test/features/clone-and-propagate/src/test/features/api/automated/test_api_tupleRestController_get.ts
+++ b/test/features/clone-and-propagate/src/test/features/api/automated/test_api_tupleRestController_get.ts
@@ -1,11 +1,15 @@
+import type { IPropagation } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
+import type { TupleRest } from "../../../../api/structures/TupleRest";
 
 export const test_api_tupleRestController_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.tupleRestController.get(
+    const output: IPropagation<{
+        200: TupleRest;
+    }> = await api.functional.tupleRestController.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/clone-and-propagate/src/test/features/api/automated/test_api_users_oauth_getOauthProfile.ts
+++ b/test/features/clone-and-propagate/src/test/features/api/automated/test_api_users_oauth_getOauthProfile.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { IPropagation, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -7,7 +7,10 @@ import type { IAuthentication } from "../../../../api/structures/IAuthentication
 export const test_api_users_oauth_getOauthProfile = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.users.oauth.getOauthProfile(
+    const output: IPropagation<{
+        200: IAuthentication.IProfile;
+        404: ("404 Not Found");
+    }> = await api.functional.users.oauth.getOauthProfile(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<IAuthentication>>(),

--- a/test/features/clone-and-propagate/src/test/features/api/automated/test_api_users_user_getUserProfile.ts
+++ b/test/features/clone-and-propagate/src/test/features/api/automated/test_api_users_user_getUserProfile.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { IPropagation, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -7,7 +7,10 @@ import type { IUser } from "../../../../api/structures/IUser";
 export const test_api_users_user_getUserProfile = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.users.user.getUserProfile(
+    const output: IPropagation<{
+        202: IUser;
+        404: ("404 Not Found");
+    }, 202> = await api.functional.users.user.getUserProfile(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<IUser.ISearch>>(),

--- a/test/features/clone-and-propagate/src/test/features/api/automated/test_api_users_user_updateUserProfile.ts
+++ b/test/features/clone-and-propagate/src/test/features/api/automated/test_api_users_user_updateUserProfile.ts
@@ -1,13 +1,16 @@
-import type { Primitive, Resolved } from "@nestia/fetcher";
+import type { IPropagation, Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
+import type { IUser } from "../../../../api/structures/IUser";
 import type { PartialPickIUsernameemailnullable_attroptional_attr } from "../../../../api/structures/PartialPickIUsernameemailnullable_attroptional_attr";
 
 export const test_api_users_user_updateUserProfile = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.users.user.updateUserProfile(
+    const output: IPropagation<{
+        201: IUser;
+    }> = await api.functional.users.user.updateUserProfile(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Primitive<PartialPickIUsernameemailnullable_attroptional_attr>>(),

--- a/test/features/clone-date/src/test/features/api/automated/test_api_date_get.ts
+++ b/test/features/clone-date/src/test/features/api/automated/test_api_date_get.ts
@@ -1,11 +1,13 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
+import type { IDateDefined } from "../../../../api/structures/IDateDefined";
 
 export const test_api_date_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.date.get(
+    const output: Primitive<IDateDefined> = await api.functional.date.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/config-pattern/src/test/features/api/automated/test_api_performance_get.ts
+++ b/test/features/config-pattern/src/test/features/api/automated/test_api_performance_get.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IPerformance } from "../../../../api/structures/IPerformance";
 export const test_api_performance_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.performance.get(
+    const output: Primitive<IPerformance> = await api.functional.performance.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/date/src/test/features/api/automated/test_api_date_get.ts
+++ b/test/features/date/src/test/features/api/automated/test_api_date_get.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IDateDefined } from "../../../../api/structures/IDateDefined";
 export const test_api_date_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.date.get(
+    const output: Primitive<IDateDefined> = await api.functional.date.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/date/src/test/features/api/automated/test_api_performance_get.ts
+++ b/test/features/date/src/test/features/api/automated/test_api_performance_get.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IPerformance } from "../../../../api/structures/IPerformance";
 export const test_api_performance_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.performance.get(
+    const output: Primitive<IPerformance> = await api.functional.performance.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/duplicated/src/test/features/api/automated/test_api_duplicated_at.ts
+++ b/test/features/duplicated/src/test/features/api/automated/test_api_duplicated_at.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_duplicated_at = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.duplicated.at(
+    const output: Primitive<IBbsArticle> = await api.functional.duplicated.at(
         connection,
     );
     typia.assert(output);

--- a/test/features/duplicated/src/test/features/api/automated/test_api_multiple_at.ts
+++ b/test/features/duplicated/src/test/features/api/automated/test_api_multiple_at.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_multiple_at = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.multiple.at(
+    const output: Primitive<IBbsArticle> = await api.functional.multiple.at(
         connection,
     );
     typia.assert(output);

--- a/test/features/duplicated/src/test/features/api/automated/test_api_performance_get.ts
+++ b/test/features/duplicated/src/test/features/api/automated/test_api_performance_get.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IPerformance } from "../../../../api/structures/IPerformance";
 export const test_api_performance_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.performance.get(
+    const output: Primitive<IPerformance> = await api.functional.performance.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/e2e/src/test/features/api/automated/test_api_bbs_articles_store.ts
+++ b/test/features/e2e/src/test/features/api/automated/test_api_bbs_articles_store.ts
@@ -7,7 +7,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_bbs_articles_store = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.articles.store(
+    const output: Primitive<IBbsArticle> = await api.functional.bbs.articles.store(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Primitive<IBbsArticle.IStore>>(),

--- a/test/features/e2e/src/test/features/api/automated/test_api_bbs_articles_update.ts
+++ b/test/features/e2e/src/test/features/api/automated/test_api_bbs_articles_update.ts
@@ -8,7 +8,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_bbs_articles_update = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.articles.update(
+    const output: Primitive<IBbsArticle> = await api.functional.bbs.articles.update(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/e2e/src/test/features/api/automated/test_api_performance_get.ts
+++ b/test/features/e2e/src/test/features/api/automated/test_api_performance_get.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IPerformance } from "../../../../api/structures/IPerformance";
 export const test_api_performance_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.performance.get(
+    const output: Primitive<IPerformance> = await api.functional.performance.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/encrypted/src/test/features/api/automated/test_api_performance_get.ts
+++ b/test/features/encrypted/src/test/features/api/automated/test_api_performance_get.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IPerformance } from "../../../../api/structures/IPerformance";
 export const test_api_performance_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.performance.get(
+    const output: Primitive<IPerformance> = await api.functional.performance.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/encrypted/src/test/features/api/automated/test_api_sellers_authenticate_join.ts
+++ b/test/features/encrypted/src/test/features/api/automated/test_api_sellers_authenticate_join.ts
@@ -7,7 +7,7 @@ import type { ISeller } from "../../../../api/structures/ISeller";
 export const test_api_sellers_authenticate_join = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.sellers.authenticate.join(
+    const output: Primitive<ISeller.IAuthorized> = await api.functional.sellers.authenticate.join(
         connection,
         typia.random<Primitive<ISeller.IJoin>>(),
     );

--- a/test/features/encrypted/src/test/features/api/automated/test_api_sellers_authenticate_login.ts
+++ b/test/features/encrypted/src/test/features/api/automated/test_api_sellers_authenticate_login.ts
@@ -7,7 +7,7 @@ import type { ISeller } from "../../../../api/structures/ISeller";
 export const test_api_sellers_authenticate_login = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.sellers.authenticate.login(
+    const output: Primitive<ISeller.IAuthorized> = await api.functional.sellers.authenticate.login(
         connection,
         typia.random<Primitive<ISeller.ILogin>>(),
     );

--- a/test/features/exception/src/test/features/api/automated/test_api_exception_composite.ts
+++ b/test/features/exception/src/test/features/api/automated/test_api_exception_composite.ts
@@ -7,7 +7,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_exception_composite = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.exception.composite(
+    const output: Primitive<IBbsArticle> = await api.functional.exception.composite(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Primitive<IBbsArticle.IStore>>(),

--- a/test/features/exception/src/test/features/api/automated/test_api_exception_tags.ts
+++ b/test/features/exception/src/test/features/api/automated/test_api_exception_tags.ts
@@ -7,7 +7,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_exception_tags = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.exception.tags(
+    const output: Primitive<IBbsArticle> = await api.functional.exception.tags(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Primitive<IBbsArticle.IStore>>(),

--- a/test/features/exception/src/test/features/api/automated/test_api_exception_typed.ts
+++ b/test/features/exception/src/test/features/api/automated/test_api_exception_typed.ts
@@ -7,7 +7,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_exception_typed = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.exception.typed(
+    const output: Primitive<IBbsArticle> = await api.functional.exception.typed(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Primitive<IBbsArticle.IStore>>(),

--- a/test/features/exception/src/test/features/api/automated/test_api_performance_get.ts
+++ b/test/features/exception/src/test/features/api/automated/test_api_performance_get.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IPerformance } from "../../../../api/structures/IPerformance";
 export const test_api_performance_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.performance.get(
+    const output: Primitive<IPerformance> = await api.functional.performance.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/fastify/src/test/features/api/automated/test_api_bbs_articles_index.ts
+++ b/test/features/fastify/src/test/features/api/automated/test_api_bbs_articles_index.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -8,7 +8,7 @@ import type { IPage } from "../../../../api/structures/IPage";
 export const test_api_bbs_articles_index = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.articles.index(
+    const output: Primitive<IPage<IBbsArticle.ISummary>> = await api.functional.bbs.articles.index(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<IPage.IRequest>>(),

--- a/test/features/fastify/src/test/features/api/automated/test_api_bbs_articles_store.ts
+++ b/test/features/fastify/src/test/features/api/automated/test_api_bbs_articles_store.ts
@@ -7,7 +7,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_bbs_articles_store = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.articles.store(
+    const output: Primitive<IBbsArticle> = await api.functional.bbs.articles.store(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Primitive<IBbsArticle.IStore>>(),

--- a/test/features/fastify/src/test/features/api/automated/test_api_bbs_articles_update.ts
+++ b/test/features/fastify/src/test/features/api/automated/test_api_bbs_articles_update.ts
@@ -8,7 +8,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_bbs_articles_update = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.articles.update(
+    const output: Primitive<IBbsArticle> = await api.functional.bbs.articles.update(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/fastify/src/test/features/api/automated/test_api_param_boolean.ts
+++ b/test/features/fastify/src/test/features/api/automated/test_api_param_boolean.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +6,7 @@ import api from "../../../../api";
 export const test_api_param_boolean = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.param.boolean(
+    const output: Primitive<false | true> = await api.functional.param.boolean(
         connection,
         typia.random<Resolved<false | true>>(),
     );

--- a/test/features/fastify/src/test/features/api/automated/test_api_param_literal.ts
+++ b/test/features/fastify/src/test/features/api/automated/test_api_param_literal.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +6,7 @@ import api from "../../../../api";
 export const test_api_param_literal = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.param.literal(
+    const output: Primitive<"A" | "B" | "C"> = await api.functional.param.literal(
         connection,
         typia.random<Resolved<"A" | "B" | "C">>(),
     );

--- a/test/features/fastify/src/test/features/api/automated/test_api_param_nullable.ts
+++ b/test/features/fastify/src/test/features/api/automated/test_api_param_nullable.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +6,7 @@ import api from "../../../../api";
 export const test_api_param_nullable = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.param.nullable(
+    const output: Primitive<null | string> = await api.functional.param.nullable(
         connection,
         typia.random<Resolved<null | string>>(),
     );

--- a/test/features/fastify/src/test/features/api/automated/test_api_param_number.ts
+++ b/test/features/fastify/src/test/features/api/automated/test_api_param_number.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +6,7 @@ import api from "../../../../api";
 export const test_api_param_number = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.param.number(
+    const output: Primitive<number> = await api.functional.param.number(
         connection,
         typia.random<Resolved<number>>(),
     );

--- a/test/features/fastify/src/test/features/api/automated/test_api_param_string.ts
+++ b/test/features/fastify/src/test/features/api/automated/test_api_param_string.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +6,7 @@ import api from "../../../../api";
 export const test_api_param_string = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.param.string(
+    const output: Primitive<string> = await api.functional.param.string(
         connection,
         typia.random<Resolved<string>>(),
     );

--- a/test/features/fastify/src/test/features/api/automated/test_api_performance_get.ts
+++ b/test/features/fastify/src/test/features/api/automated/test_api_performance_get.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IPerformance } from "../../../../api/structures/IPerformance";
 export const test_api_performance_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.performance.get(
+    const output: Primitive<IPerformance> = await api.functional.performance.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/fastify/src/test/features/api/automated/test_api_plain_send.ts
+++ b/test/features/fastify/src/test/features/api/automated/test_api_plain_send.ts
@@ -6,7 +6,7 @@ import api from "../../../../api";
 export const test_api_plain_send = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.plain.send(
+    const output: Primitive<string> = await api.functional.plain.send(
         connection,
         typia.random<Primitive<string>>(),
     );

--- a/test/features/fastify/src/test/features/api/automated/test_api_sellers_authenticate_join.ts
+++ b/test/features/fastify/src/test/features/api/automated/test_api_sellers_authenticate_join.ts
@@ -7,7 +7,7 @@ import type { ISeller } from "../../../../api/structures/ISeller";
 export const test_api_sellers_authenticate_join = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.sellers.authenticate.join(
+    const output: Primitive<ISeller.IAuthorized> = await api.functional.sellers.authenticate.join(
         connection,
         typia.random<Primitive<ISeller.IJoin>>(),
     );

--- a/test/features/fastify/src/test/features/api/automated/test_api_sellers_authenticate_login.ts
+++ b/test/features/fastify/src/test/features/api/automated/test_api_sellers_authenticate_login.ts
@@ -7,7 +7,7 @@ import type { ISeller } from "../../../../api/structures/ISeller";
 export const test_api_sellers_authenticate_login = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.sellers.authenticate.login(
+    const output: Primitive<ISeller.IAuthorized> = await api.functional.sellers.authenticate.login(
         connection,
         typia.random<Primitive<ISeller.ILogin>>(),
     );

--- a/test/features/headers-decompose/src/test/features/api/automated/test_api_headers_emplace.ts
+++ b/test/features/headers-decompose/src/test/features/api/automated/test_api_headers_emplace.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -7,7 +7,7 @@ import type { IHeaders } from "../../../../api/structures/IHeaders";
 export const test_api_headers_emplace = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.headers.emplace(
+    const output: Primitive<IHeaders> = await api.functional.headers.emplace(
         {
             ...connection,
             headers: {

--- a/test/features/headers-decompose/src/test/features/api/automated/test_api_headers_store.ts
+++ b/test/features/headers-decompose/src/test/features/api/automated/test_api_headers_store.ts
@@ -8,7 +8,7 @@ import type { IHeaders } from "../../../../api/structures/IHeaders";
 export const test_api_headers_store = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.headers.store(
+    const output: Primitive<IBbsArticle> = await api.functional.headers.store(
         {
             ...connection,
             headers: {

--- a/test/features/headers-decompose/src/test/features/api/automated/test_api_performance_get.ts
+++ b/test/features/headers-decompose/src/test/features/api/automated/test_api_performance_get.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IPerformance } from "../../../../api/structures/IPerformance";
 export const test_api_performance_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.performance.get(
+    const output: Primitive<IPerformance> = await api.functional.performance.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/headers/src/test/features/api/automated/test_api_headers_emplace.ts
+++ b/test/features/headers/src/test/features/api/automated/test_api_headers_emplace.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -7,7 +7,7 @@ import type { IHeaders } from "../../../../api/structures/IHeaders";
 export const test_api_headers_emplace = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.headers.emplace(
+    const output: Primitive<IHeaders> = await api.functional.headers.emplace(
         {
             ...connection,
             headers: {

--- a/test/features/headers/src/test/features/api/automated/test_api_headers_store.ts
+++ b/test/features/headers/src/test/features/api/automated/test_api_headers_store.ts
@@ -8,7 +8,7 @@ import type { IHeaders } from "../../../../api/structures/IHeaders";
 export const test_api_headers_store = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.headers.store(
+    const output: Primitive<IBbsArticle> = await api.functional.headers.store(
         {
             ...connection,
             headers: {

--- a/test/features/headers/src/test/features/api/automated/test_api_performance_get.ts
+++ b/test/features/headers/src/test/features/api/automated/test_api_performance_get.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IPerformance } from "../../../../api/structures/IPerformance";
 export const test_api_performance_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.performance.get(
+    const output: Primitive<IPerformance> = await api.functional.performance.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/kebab/src/test/features/api/automated/test_api_ke_bab_with_dashes_store.ts
+++ b/test/features/kebab/src/test/features/api/automated/test_api_ke_bab_with_dashes_store.ts
@@ -7,7 +7,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_ke_bab_with_dashes_store = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.ke_bab_with_dashes.store(
+    const output: Primitive<IBbsArticle> = await api.functional.ke_bab_with_dashes.store(
         connection,
         typia.random<Primitive<IBbsArticle.IStore>>(),
     );

--- a/test/features/kebab/src/test/features/api/automated/test_api_performance_get.ts
+++ b/test/features/kebab/src/test/features/api/automated/test_api_performance_get.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IPerformance } from "../../../../api/structures/IPerformance";
 export const test_api_performance_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.performance.get(
+    const output: Primitive<IPerformance> = await api.functional.performance.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/method/src/test/features/api/automated/test_api_performance_get.ts
+++ b/test/features/method/src/test/features/api/automated/test_api_performance_get.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IPerformance } from "../../../../api/structures/IPerformance";
 export const test_api_performance_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.performance.get(
+    const output: Primitive<IPerformance> = await api.functional.performance.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/non-equals/src/test/features/api/automated/test_api_performance_get.ts
+++ b/test/features/non-equals/src/test/features/api/automated/test_api_performance_get.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IPerformance } from "../../../../api/structures/IPerformance";
 export const test_api_performance_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.performance.get(
+    const output: Primitive<IPerformance> = await api.functional.performance.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/non-equals/src/test/features/api/automated/test_api_request.ts
+++ b/test/features/non-equals/src/test/features/api/automated/test_api_request.ts
@@ -7,7 +7,7 @@ import type { IRequestDto } from "../../../../api/structures/IRequestDto";
 export const test_api_request = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.request(
+    const output: Primitive<IRequestDto> = await api.functional.request(
         connection,
         typia.random<Primitive<IRequestDto>>(),
     );

--- a/test/features/operationId/src/test/features/api/automated/test_api_performance_get.ts
+++ b/test/features/operationId/src/test/features/api/automated/test_api_performance_get.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IPerformance } from "../../../../api/structures/IPerformance";
 export const test_api_performance_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.performance.get(
+    const output: Primitive<IPerformance> = await api.functional.performance.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/param/src/test/features/api/automated/test_api_param_boolean.ts
+++ b/test/features/param/src/test/features/api/automated/test_api_param_boolean.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +6,7 @@ import api from "../../../../api";
 export const test_api_param_boolean = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.param.boolean(
+    const output: Primitive<false | true> = await api.functional.param.boolean(
         connection,
         typia.random<Resolved<false | true>>(),
     );

--- a/test/features/param/src/test/features/api/automated/test_api_param_date.ts
+++ b/test/features/param/src/test/features/api/automated/test_api_param_date.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 import type { Format } from "typia/lib/tags/Format";
 
@@ -7,7 +7,7 @@ import api from "../../../../api";
 export const test_api_param_date = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.param.date(
+    const output: Primitive<string> = await api.functional.param.date(
         connection,
         typia.random<Resolved<string & Format<"date">>>(),
     );

--- a/test/features/param/src/test/features/api/automated/test_api_param_date_nullable.ts
+++ b/test/features/param/src/test/features/api/automated/test_api_param_date_nullable.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 import type { Format } from "typia/lib/tags/Format";
 
@@ -7,7 +7,7 @@ import api from "../../../../api";
 export const test_api_param_date_nullable = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.param.date_nullable(
+    const output: Primitive<null | string> = await api.functional.param.date_nullable(
         connection,
         typia.random<Resolved<null | string & Format<"date">>>(),
     );

--- a/test/features/param/src/test/features/api/automated/test_api_param_literal.ts
+++ b/test/features/param/src/test/features/api/automated/test_api_param_literal.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +6,7 @@ import api from "../../../../api";
 export const test_api_param_literal = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.param.literal(
+    const output: Primitive<"A" | "B" | "C"> = await api.functional.param.literal(
         connection,
         typia.random<Resolved<"A" | "B" | "C">>(),
     );

--- a/test/features/param/src/test/features/api/automated/test_api_param_nullable.ts
+++ b/test/features/param/src/test/features/api/automated/test_api_param_nullable.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +6,7 @@ import api from "../../../../api";
 export const test_api_param_nullable = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.param.nullable(
+    const output: Primitive<null | string> = await api.functional.param.nullable(
         connection,
         typia.random<Resolved<null | string>>(),
     );

--- a/test/features/param/src/test/features/api/automated/test_api_param_number.ts
+++ b/test/features/param/src/test/features/api/automated/test_api_param_number.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +6,7 @@ import api from "../../../../api";
 export const test_api_param_number = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.param.number(
+    const output: Primitive<number> = await api.functional.param.number(
         connection,
         typia.random<Resolved<number>>(),
     );

--- a/test/features/param/src/test/features/api/automated/test_api_param_string.ts
+++ b/test/features/param/src/test/features/api/automated/test_api_param_string.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +6,7 @@ import api from "../../../../api";
 export const test_api_param_string = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.param.string(
+    const output: Primitive<string> = await api.functional.param.string(
         connection,
         typia.random<Resolved<string>>(),
     );

--- a/test/features/param/src/test/features/api/automated/test_api_param_uuid.ts
+++ b/test/features/param/src/test/features/api/automated/test_api_param_uuid.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 import type { Format } from "typia/lib/tags/Format";
 
@@ -7,7 +7,7 @@ import api from "../../../../api";
 export const test_api_param_uuid = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.param.uuid(
+    const output: Primitive<string> = await api.functional.param.uuid(
         connection,
         typia.random<Resolved<string & Format<"uuid">>>(),
     );

--- a/test/features/param/src/test/features/api/automated/test_api_param_uuid_nullable.ts
+++ b/test/features/param/src/test/features/api/automated/test_api_param_uuid_nullable.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 import type { Format } from "typia/lib/tags/Format";
 
@@ -7,7 +7,7 @@ import api from "../../../../api";
 export const test_api_param_uuid_nullable = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.param.uuid_nullable(
+    const output: Primitive<null | string> = await api.functional.param.uuid_nullable(
         connection,
         typia.random<Resolved<null | string & Format<"uuid">>>(),
     );

--- a/test/features/param/src/test/features/api/automated/test_api_performance_get.ts
+++ b/test/features/param/src/test/features/api/automated/test_api_performance_get.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IPerformance } from "../../../../api/structures/IPerformance";
 export const test_api_performance_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.performance.get(
+    const output: Primitive<IPerformance> = await api.functional.performance.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/plain/src/test/features/api/automated/test_api_performance_get.ts
+++ b/test/features/plain/src/test/features/api/automated/test_api_performance_get.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IPerformance } from "../../../../api/structures/IPerformance";
 export const test_api_performance_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.performance.get(
+    const output: Primitive<IPerformance> = await api.functional.performance.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/plain/src/test/features/api/automated/test_api_plain_constant.ts
+++ b/test/features/plain/src/test/features/api/automated/test_api_plain_constant.ts
@@ -6,7 +6,7 @@ import api from "../../../../api";
 export const test_api_plain_constant = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.plain.constant(
+    const output: Primitive<string> = await api.functional.plain.constant(
         connection,
         typia.random<Primitive<"A" | "B" | "C">>(),
     );

--- a/test/features/plain/src/test/features/api/automated/test_api_plain_string.ts
+++ b/test/features/plain/src/test/features/api/automated/test_api_plain_string.ts
@@ -6,7 +6,7 @@ import api from "../../../../api";
 export const test_api_plain_string = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.plain.string(
+    const output: Primitive<string> = await api.functional.plain.string(
         connection,
         typia.random<Primitive<string>>(),
     );

--- a/test/features/plain/src/test/features/api/automated/test_api_plain_template.ts
+++ b/test/features/plain/src/test/features/api/automated/test_api_plain_template.ts
@@ -6,7 +6,7 @@ import api from "../../../../api";
 export const test_api_plain_template = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.plain.template(
+    const output: Primitive<string> = await api.functional.plain.template(
         connection,
         typia.random<Primitive<`something_${number}_interesting_${string}_is_not_false_it?` | `something_${number}_interesting_${string}_is_not_true_it?`>>(),
     );

--- a/test/features/propagate/src/test/features/api/automated/test_api_members_login.ts
+++ b/test/features/propagate/src/test/features/api/automated/test_api_members_login.ts
@@ -1,4 +1,4 @@
-import type { Primitive } from "@nestia/fetcher";
+import type { IPropagation, Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -9,7 +9,12 @@ import type { INotFound } from "../../../../api/structures/INotFound";
 export const test_api_members_login = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.members.login(
+    const output: IPropagation<{
+        201: IMember;
+        403: IForbidden;
+        404: INotFound;
+        422: IForbidden.IExpired;
+    }> = await api.functional.members.login(
         connection,
         typia.random<Primitive<IMember.ILogin>>(),
     );

--- a/test/features/propagate/src/test/features/api/automated/test_api_performance_get.ts
+++ b/test/features/propagate/src/test/features/api/automated/test_api_performance_get.ts
@@ -1,3 +1,4 @@
+import type { IPropagation } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,9 @@ import type { IPerformance } from "../../../../api/structures/IPerformance";
 export const test_api_performance_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.performance.get(
+    const output: IPropagation<{
+        200: IPerformance;
+    }> = await api.functional.performance.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/route-manual-assert/src/test/features/api/automated/test_api_performance_get.ts
+++ b/test/features/route-manual-assert/src/test/features/api/automated/test_api_performance_get.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IPerformance } from "../../../../api/structures/IPerformance";
 export const test_api_performance_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.performance.get(
+    const output: Primitive<IPerformance> = await api.functional.performance.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/route-manual-assert/src/test/features/api/automated/test_api_route_random.ts
+++ b/test/features/route-manual-assert/src/test/features/api/automated/test_api_route_random.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_route_random = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.route.random(
+    const output: Primitive<IBbsArticle> = await api.functional.route.random(
         connection,
     );
     typia.assert(output);

--- a/test/features/route-manual-is/src/test/features/api/automated/test_api_performance_get.ts
+++ b/test/features/route-manual-is/src/test/features/api/automated/test_api_performance_get.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IPerformance } from "../../../../api/structures/IPerformance";
 export const test_api_performance_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.performance.get(
+    const output: Primitive<IPerformance> = await api.functional.performance.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/route-manual-is/src/test/features/api/automated/test_api_route_random.ts
+++ b/test/features/route-manual-is/src/test/features/api/automated/test_api_route_random.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_route_random = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.route.random(
+    const output: Primitive<IBbsArticle> = await api.functional.route.random(
         connection,
     );
     typia.assert(output);

--- a/test/features/route-manual-stringify/src/test/features/api/automated/test_api_performance_get.ts
+++ b/test/features/route-manual-stringify/src/test/features/api/automated/test_api_performance_get.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IPerformance } from "../../../../api/structures/IPerformance";
 export const test_api_performance_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.performance.get(
+    const output: Primitive<IPerformance> = await api.functional.performance.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/route-manual-stringify/src/test/features/api/automated/test_api_route_random.ts
+++ b/test/features/route-manual-stringify/src/test/features/api/automated/test_api_route_random.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_route_random = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.route.random(
+    const output: Primitive<IBbsArticle> = await api.functional.route.random(
         connection,
     );
     typia.assert(output);

--- a/test/features/route-manual-validate/src/test/features/api/automated/test_api_performance_get.ts
+++ b/test/features/route-manual-validate/src/test/features/api/automated/test_api_performance_get.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IPerformance } from "../../../../api/structures/IPerformance";
 export const test_api_performance_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.performance.get(
+    const output: Primitive<IPerformance> = await api.functional.performance.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/route-manual-validate/src/test/features/api/automated/test_api_route_random.ts
+++ b/test/features/route-manual-validate/src/test/features/api/automated/test_api_route_random.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_route_random = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.route.random(
+    const output: Primitive<IBbsArticle> = await api.functional.route.random(
         connection,
     );
     typia.assert(output);

--- a/test/features/route/src/test/features/api/automated/test_api_performance_get.ts
+++ b/test/features/route/src/test/features/api/automated/test_api_performance_get.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IPerformance } from "../../../../api/structures/IPerformance";
 export const test_api_performance_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.performance.get(
+    const output: Primitive<IPerformance> = await api.functional.performance.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/route/src/test/features/api/automated/test_api_route_random.ts
+++ b/test/features/route/src/test/features/api/automated/test_api_route_random.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_route_random = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.route.random(
+    const output: Primitive<IBbsArticle> = await api.functional.route.random(
         connection,
     );
     typia.assert(output);

--- a/test/features/security/src/test/features/api/automated/test_api_basic.ts
+++ b/test/features/security/src/test/features/api/automated/test_api_basic.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IToken } from "../../../../api/structures/IToken";
 export const test_api_basic = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.basic(
+    const output: Primitive<IToken> = await api.functional.basic(
         connection,
     );
     typia.assert(output);

--- a/test/features/security/src/test/features/api/automated/test_api_basic_by_comment.ts
+++ b/test/features/security/src/test/features/api/automated/test_api_basic_by_comment.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IToken } from "../../../../api/structures/IToken";
 export const test_api_basic_by_comment = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.basic_by_comment(
+    const output: Primitive<IToken> = await api.functional.basic_by_comment(
         connection,
     );
     typia.assert(output);

--- a/test/features/security/src/test/features/api/automated/test_api_bearer.ts
+++ b/test/features/security/src/test/features/api/automated/test_api_bearer.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IToken } from "../../../../api/structures/IToken";
 export const test_api_bearer = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bearer(
+    const output: Primitive<IToken> = await api.functional.bearer(
         connection,
     );
     typia.assert(output);

--- a/test/features/security/src/test/features/api/automated/test_api_bearer_by_comment.ts
+++ b/test/features/security/src/test/features/api/automated/test_api_bearer_by_comment.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IToken } from "../../../../api/structures/IToken";
 export const test_api_bearer_by_comment = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bearer_by_comment(
+    const output: Primitive<IToken> = await api.functional.bearer_by_comment(
         connection,
     );
     typia.assert(output);

--- a/test/features/security/src/test/features/api/automated/test_api_oauth2.ts
+++ b/test/features/security/src/test/features/api/automated/test_api_oauth2.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IToken } from "../../../../api/structures/IToken";
 export const test_api_oauth2 = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.oauth2(
+    const output: Primitive<IToken> = await api.functional.oauth2(
         connection,
     );
     typia.assert(output);

--- a/test/features/security/src/test/features/api/automated/test_api_oauth2_by_comment.ts
+++ b/test/features/security/src/test/features/api/automated/test_api_oauth2_by_comment.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IToken } from "../../../../api/structures/IToken";
 export const test_api_oauth2_by_comment = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.oauth2_by_comment(
+    const output: Primitive<IToken> = await api.functional.oauth2_by_comment(
         connection,
     );
     typia.assert(output);

--- a/test/features/security/src/test/features/api/automated/test_api_security.ts
+++ b/test/features/security/src/test/features/api/automated/test_api_security.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IToken } from "../../../../api/structures/IToken";
 export const test_api_security = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.security(
+    const output: Primitive<IToken> = await api.functional.security(
         connection,
     );
     typia.assert(output);

--- a/test/features/simulate/src/test/features/api/automated/test_api_bbs_articles_at.ts
+++ b/test/features/simulate/src/test/features/api/automated/test_api_bbs_articles_at.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 import type { Format } from "typia/lib/tags/Format";
 
@@ -8,7 +8,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_bbs_articles_at = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.articles.at(
+    const output: Primitive<IBbsArticle> = await api.functional.bbs.articles.at(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<null | string & Format<"uuid">>>(),

--- a/test/features/simulate/src/test/features/api/automated/test_api_bbs_articles_first.ts
+++ b/test/features/simulate/src/test/features/api/automated/test_api_bbs_articles_first.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 import type { Format } from "typia/lib/tags/Format";
 
@@ -8,7 +8,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_bbs_articles_first = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.articles.first(
+    const output: Primitive<IBbsArticle> = await api.functional.bbs.articles.first(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"date">>>(),

--- a/test/features/simulate/src/test/features/api/automated/test_api_bbs_articles_index.ts
+++ b/test/features/simulate/src/test/features/api/automated/test_api_bbs_articles_index.ts
@@ -8,7 +8,7 @@ import type { IPage } from "../../../../api/structures/IPage";
 export const test_api_bbs_articles_index = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.articles.index(
+    const output: Primitive<IPage<IBbsArticle.ISummary>> = await api.functional.bbs.articles.index(
         connection,
         typia.random<Resolved<null | string>>(),
         typia.random<Primitive<IPage.IRequest>>(),

--- a/test/features/simulate/src/test/features/api/automated/test_api_bbs_articles_query.ts
+++ b/test/features/simulate/src/test/features/api/automated/test_api_bbs_articles_query.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -8,7 +8,7 @@ import type { IPage } from "../../../../api/structures/IPage";
 export const test_api_bbs_articles_query = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.articles.query(
+    const output: Primitive<IPage<IBbsArticle.ISummary>> = await api.functional.bbs.articles.query(
         connection,
         typia.random<Resolved<null | string>>(),
         typia.random<Resolved<IPage.IRequest>>(),

--- a/test/features/simulate/src/test/features/api/automated/test_api_bbs_articles_store.ts
+++ b/test/features/simulate/src/test/features/api/automated/test_api_bbs_articles_store.ts
@@ -7,7 +7,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_bbs_articles_store = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.articles.store(
+    const output: Primitive<IBbsArticle> = await api.functional.bbs.articles.store(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Primitive<IBbsArticle.IStore>>(),

--- a/test/features/simulate/src/test/features/api/automated/test_api_bbs_articles_update.ts
+++ b/test/features/simulate/src/test/features/api/automated/test_api_bbs_articles_update.ts
@@ -8,7 +8,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_bbs_articles_update = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.articles.update(
+    const output: Primitive<IBbsArticle> = await api.functional.bbs.articles.update(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/simulate/src/test/features/api/automated/test_api_performance_get.ts
+++ b/test/features/simulate/src/test/features/api/automated/test_api_performance_get.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IPerformance } from "../../../../api/structures/IPerformance";
 export const test_api_performance_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.performance.get(
+    const output: Primitive<IPerformance> = await api.functional.performance.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/simulate/src/test/features/api/automated/test_api_sellers_authenticate_join.ts
+++ b/test/features/simulate/src/test/features/api/automated/test_api_sellers_authenticate_join.ts
@@ -7,7 +7,7 @@ import type { ISeller } from "../../../../api/structures/ISeller";
 export const test_api_sellers_authenticate_join = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.sellers.authenticate.join(
+    const output: Primitive<ISeller.IAuthorized> = await api.functional.sellers.authenticate.join(
         connection,
         typia.random<Primitive<ISeller.IJoin>>(),
     );

--- a/test/features/simulate/src/test/features/api/automated/test_api_sellers_authenticate_login.ts
+++ b/test/features/simulate/src/test/features/api/automated/test_api_sellers_authenticate_login.ts
@@ -7,7 +7,7 @@ import type { ISeller } from "../../../../api/structures/ISeller";
 export const test_api_sellers_authenticate_login = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.sellers.authenticate.login(
+    const output: Primitive<ISeller.IAuthorized> = await api.functional.sellers.authenticate.login(
         connection,
         typia.random<Primitive<ISeller.ILogin>>(),
     );

--- a/test/features/status/src/test/features/api/automated/test_api_performance_get.ts
+++ b/test/features/status/src/test/features/api/automated/test_api_performance_get.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IPerformance } from "../../../../api/structures/IPerformance";
 export const test_api_performance_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.performance.get(
+    const output: Primitive<IPerformance> = await api.functional.performance.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/status/src/test/features/api/automated/test_api_status_random.ts
+++ b/test/features/status/src/test/features/api/automated/test_api_status_random.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_status_random = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.status.random(
+    const output: Primitive<IBbsArticle> = await api.functional.status.random(
         connection,
     );
     typia.assert(output);

--- a/test/features/swagger/src/test/features/api/automated/test_api_performance_get.ts
+++ b/test/features/swagger/src/test/features/api/automated/test_api_performance_get.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IPerformance } from "../../../../api/structures/IPerformance";
 export const test_api_performance_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.performance.get(
+    const output: Primitive<IPerformance> = await api.functional.performance.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/tags/src/test/features/api/automated/test_api_bbs_articles_store.ts
+++ b/test/features/tags/src/test/features/api/automated/test_api_bbs_articles_store.ts
@@ -7,7 +7,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_bbs_articles_store = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.articles.store(
+    const output: Primitive<IBbsArticle> = await api.functional.bbs.articles.store(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Primitive<IBbsArticle.IStore>>(),

--- a/test/features/tags/src/test/features/api/automated/test_api_bbs_articles_update.ts
+++ b/test/features/tags/src/test/features/api/automated/test_api_bbs_articles_update.ts
@@ -8,7 +8,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_bbs_articles_update = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.articles.update(
+    const output: Primitive<IBbsArticle> = await api.functional.bbs.articles.update(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/validateEquals/src/test/features/api/automated/test_api_performance_get.ts
+++ b/test/features/validateEquals/src/test/features/api/automated/test_api_performance_get.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IPerformance } from "../../../../api/structures/IPerformance";
 export const test_api_performance_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.performance.get(
+    const output: Primitive<IPerformance> = await api.functional.performance.get(
         connection,
     );
     typia.assert(output);

--- a/test/features/validateEquals/src/test/features/api/automated/test_api_request.ts
+++ b/test/features/validateEquals/src/test/features/api/automated/test_api_request.ts
@@ -7,7 +7,7 @@ import type { IRequestDto } from "../../../../api/structures/IRequestDto";
 export const test_api_request = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.request(
+    const output: Primitive<IRequestDto> = await api.functional.request(
         connection,
         typia.random<Primitive<IRequestDto>>(),
     );

--- a/test/features/variable/src/test/features/api/automated/test_api_bbs_$package_articles_$catch.ts
+++ b/test/features/variable/src/test/features/api/automated/test_api_bbs_$package_articles_$catch.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -8,7 +8,7 @@ import type { IPage } from "../../../../api/structures/IPage";
 export const test_api_bbs_$package_articles_$catch = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.$package.articles.$catch(
+    const output: Primitive<IPage<IBbsArticle.ISummary>> = await api.functional.bbs.$package.articles.$catch(
         connection,
         typia.random<Resolved<null | string>>(),
         typia.random<Resolved<IPage.IRequest>>(),

--- a/test/features/variable/src/test/features/api/automated/test_api_bbs_$package_articles_$new.ts
+++ b/test/features/variable/src/test/features/api/automated/test_api_bbs_$package_articles_$new.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 import type { Format } from "typia/lib/tags/Format";
 
@@ -8,7 +8,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_bbs_$package_articles_$new = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.$package.articles.$new(
+    const output: Primitive<IBbsArticle> = await api.functional.bbs.$package.articles.$new(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"date">>>(),

--- a/test/features/variable/src/test/features/api/automated/test_api_bbs_$package_articles_at.ts
+++ b/test/features/variable/src/test/features/api/automated/test_api_bbs_$package_articles_at.ts
@@ -1,4 +1,4 @@
-import type { Resolved } from "@nestia/fetcher";
+import type { Primitive, Resolved } from "@nestia/fetcher";
 import typia from "typia";
 import type { Format } from "typia/lib/tags/Format";
 
@@ -8,7 +8,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_bbs_$package_articles_at = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.$package.articles.at(
+    const output: Primitive<IBbsArticle> = await api.functional.bbs.$package.articles.at(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<null | string & Format<"uuid">>>(),

--- a/test/features/variable/src/test/features/api/automated/test_api_bbs_$package_articles_index.ts
+++ b/test/features/variable/src/test/features/api/automated/test_api_bbs_$package_articles_index.ts
@@ -8,7 +8,7 @@ import type { IPage } from "../../../../api/structures/IPage";
 export const test_api_bbs_$package_articles_index = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.$package.articles.index(
+    const output: Primitive<IPage<IBbsArticle.ISummary>> = await api.functional.bbs.$package.articles.index(
         connection,
         typia.random<Resolved<null | string>>(),
         typia.random<Primitive<IPage.IRequest>>(),

--- a/test/features/variable/src/test/features/api/automated/test_api_bbs_$package_articles_store.ts
+++ b/test/features/variable/src/test/features/api/automated/test_api_bbs_$package_articles_store.ts
@@ -7,7 +7,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_bbs_$package_articles_store = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.$package.articles.store(
+    const output: Primitive<IBbsArticle> = await api.functional.bbs.$package.articles.store(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Primitive<IBbsArticle.IStore>>(),

--- a/test/features/variable/src/test/features/api/automated/test_api_bbs_$package_articles_update.ts
+++ b/test/features/variable/src/test/features/api/automated/test_api_bbs_$package_articles_update.ts
@@ -8,7 +8,7 @@ import type { IBbsArticle } from "../../../../api/structures/IBbsArticle";
 export const test_api_bbs_$package_articles_update = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.bbs.$package.articles.update(
+    const output: Primitive<IBbsArticle> = await api.functional.bbs.$package.articles.update(
         connection,
         typia.random<Resolved<string>>(),
         typia.random<Resolved<string & Format<"uuid">>>(),

--- a/test/features/variable/src/test/features/api/automated/test_api_performance_get.ts
+++ b/test/features/variable/src/test/features/api/automated/test_api_performance_get.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from "@nestia/fetcher";
 import typia from "typia";
 
 import api from "../../../../api";
@@ -6,7 +7,7 @@ import type { IPerformance } from "../../../../api/structures/IPerformance";
 export const test_api_performance_get = async (
     connection: api.IConnection
 ): Promise<void> => {
-    const output = await api.functional.performance.get(
+    const output: Primitive<IPerformance> = await api.functional.performance.get(
         connection,
     );
     typia.assert(output);

--- a/test/package.json
+++ b/test/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@nestia/test",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "Test program of Nestia",
   "main": "index.js",
   "scripts": {
@@ -37,9 +37,9 @@
     "typia": "^5.2.3",
     "uuid": "^9.0.0",
     "nestia": "^4.5.0",
-    "@nestia/core": "^2.3.2",
+    "@nestia/core": "^2.3.3",
     "@nestia/e2e": "^0.3.6",
-    "@nestia/fetcher": "^2.3.2",
-    "@nestia/sdk": "^2.3.2"
+    "@nestia/fetcher": "^2.3.3",
+    "@nestia/sdk": "^2.3.3"
   }
 }


### PR DESCRIPTION
When `@nestia/sdk` generates e2e test functions, it had not declared return types of responsed value from each API explicitly.

Changed the program to make returned value to be explicit.
