### PR TITLE
Pending TypeScript v5.3 update.

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://nestia.io",
   "dependencies": {
     "@nestia/core": "^2.2.1-dev.20231012",
-    "typia": "^5.2.3"
+    "typia": "^5.2.4"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.1.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestia",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "Nestia CLI tool",
   "main": "bin/index.js",
   "bin": {
@@ -37,8 +37,8 @@
     "inquirer": "^8.2.5"
   },
   "devDependencies": {
-    "@nestia/core": "^2.0.0",
-    "@nestia/sdk": "^2.0.0",
+    "@nestia/core": "^2.3.4",
+    "@nestia/sdk": "^2.3.4",
     "@trivago/prettier-plugin-sort-imports": "^4.1.1",
     "@types/inquirer": "^9.0.3",
     "@types/node": "^18.11.16",

--- a/packages/cli/src/NestiaSetupWizard.ts
+++ b/packages/cli/src/NestiaSetupWizard.ts
@@ -18,7 +18,7 @@ export namespace NestiaSetupWizard {
         // INSTALL TYPESCRIPT COMPILERS
         pack.install({ dev: true, modulo: "ts-patch", version: "latest" });
         pack.install({ dev: true, modulo: "ts-node", version: "latest" });
-        pack.install({ dev: true, modulo: "typescript", version: "latest" });
+        pack.install({ dev: true, modulo: "typescript", version: "5.2.2" });
         args.project ??= (() => {
             const runner: string =
                 pack.manager === "npm" ? "npx" : pack.manager;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/core",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "description": "Super-fast validation decorators of NestJS",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -34,7 +34,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^2.3.3",
+    "@nestia/fetcher": "^2.3.4",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "@nestjs/platform-express": ">=7.0.1",
@@ -44,10 +44,10 @@
     "raw-body": ">=2.0.0",
     "reflect-metadata": ">=0.1.12",
     "rxjs": ">=6.0.0",
-    "typia": "^5.2.3"
+    "typia": "^5.2.4"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">=2.3.3",
+    "@nestia/fetcher": ">=2.3.4",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "@nestjs/platform-express": ">=7.0.1",
@@ -55,8 +55,8 @@
     "raw-body": ">=2.0.0",
     "reflect-metadata": ">=0.1.12",
     "rxjs": ">=6.0.0",
-    "typescript": ">=4.8.0",
-    "typia": ">=5.2.3 <6.0.0"
+    "typescript": ">=4.8.0 <5.3.0",
+    "typia": ">=5.2.4 <6.0.0"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.0.0",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -40,7 +40,7 @@
     "ts-node": "^10.9.1",
     "ts-patch": "^3.0.2",
     "typescript": "^5.2.2",
-    "typia": "^5.2.3"
+    "typia": "^5.2.4"
   },
   "dependencies": {
     "chalk": "^4.1.2",

--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/fetcher",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "description": "Fetcher library of Nestia SDK",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -45,7 +45,7 @@
     "typescript-transform-paths": "^3.4.6"
   },
   "dependencies": {
-    "typia": "^5.2.3"
+    "typia": "^5.2.4"
   },
   "files": [
     "lib",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/sdk",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "description": "Nestia SDK and Swagger generator",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -35,7 +35,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^2.3.3",
+    "@nestia/fetcher": "^2.3.4",
     "cli": "^1.0.1",
     "get-function-location": "^2.0.0",
     "glob": "^7.2.0",
@@ -44,16 +44,16 @@
     "tsconfck": "^2.0.1",
     "tsconfig-paths": "^4.1.1",
     "tstl": "^2.5.13",
-    "typia": "^5.2.3"
+    "typia": "^5.2.4"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">=2.3.3",
+    "@nestia/fetcher": ">=2.3.4",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "reflect-metadata": ">=0.1.12",
     "ts-node": ">=10.6.0",
-    "typescript": ">=4.8.0",
-    "typia": ">=5.2.3 <6.0.0"
+    "typescript": ">=4.8.0 <5.3.0",
+    "typia": ">=5.2.4 <6.0.0"
   },
   "devDependencies": {
     "@nestjs/common": ">= 7.0.1",

--- a/test/features/distribute-assert/packages/api/package.json
+++ b/test/features/distribute-assert/packages/api/package.json
@@ -34,6 +34,6 @@
   },
   "dependencies": {
     "@nestia/fetcher": "file:../../../../../packages/fetcher/nestia-fetcher-0.0.0-dev.20991231.tgz",
-    "typia": "^5.2.3"
+    "typia": "^5.2.4"
   }
 }

--- a/test/features/distribute-json/packages/api/package.json
+++ b/test/features/distribute-json/packages/api/package.json
@@ -34,6 +34,6 @@
   },
   "dependencies": {
     "@nestia/fetcher": "file:../../../../../packages/fetcher/nestia-fetcher-0.0.0-dev.20991231.tgz",
-    "typia": "^5.2.3"
+    "typia": "^5.2.4"
   }
 }

--- a/test/features/distribute/packages/api/package.json
+++ b/test/features/distribute/packages/api/package.json
@@ -34,6 +34,6 @@
   },
   "dependencies": {
     "@nestia/fetcher": "file:../../../../../packages/fetcher/nestia-fetcher-0.0.0-dev.20991231.tgz",
-    "typia": "^5.2.3"
+    "typia": "^5.2.4"
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@nestia/test",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "description": "Test program of Nestia",
   "main": "index.js",
   "scripts": {
@@ -34,12 +34,12 @@
     "ts-patch": "v3.0.2",
     "typescript": "^5.2.2",
     "typescript-transform-paths": "^3.4.4",
-    "typia": "^5.2.3",
+    "typia": "^5.2.4",
     "uuid": "^9.0.0",
     "nestia": "^4.5.0",
-    "@nestia/core": "^2.3.3",
+    "@nestia/core": "^2.3.4",
     "@nestia/e2e": "^0.3.6",
-    "@nestia/fetcher": "^2.3.3",
-    "@nestia/sdk": "^2.3.3"
+    "@nestia/fetcher": "^2.3.4",
+    "@nestia/sdk": "^2.3.4"
   }
 }

--- a/website/pages/docs/sdk/sdk.mdx
+++ b/website/pages/docs/sdk/sdk.mdx
@@ -890,8 +890,8 @@ Also, if your SDK library utilize special alias `paths`, you also need to custom
     "ts-patch": "^3.0.2"
   },
   "dependencies": {
-    "@nestia/fetcher": "^2.3.2",
-    "typia": "^5.2.3"
+    "@nestia/fetcher": "^2.3.4",
+    "typia": "^5.2.4"
   },
   "files": [
     "lib",


### PR DESCRIPTION
As TypeScript v5.3 has break change on compiler API, current version of `ts-patch` does not work on the `typescript@5.3`.

Therefore, I've blocked the TypeScript v5.3 update by configuring `peedDependencies` of `package.json`.

This limitation would be resolved when `ts-patch` starts supporting the TypeScript v5.3 update.

  - Related issue: https://github.com/nonara/ts-patch/issues/122
