### PR TITLE
Ignore wildcard URL case.

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://nestia.io",
   "dependencies": {
     "@nestia/core": "^2.2.1-dev.20231012",
-    "typia": "^5.2.4"
+    "typia": "^5.2.5"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.1.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/core",
-  "version": "2.3.4",
+  "version": "0.0.0-dev.20991231",
   "description": "Super-fast validation decorators of NestJS",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -34,7 +34,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^2.3.4",
+    "@nestia/fetcher": "D:\\github\\samchon\\nestia\\packages\\fetcher\\nestia-fetcher-0.0.0-dev.20991231.tgz",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "@nestjs/platform-express": ">=7.0.1",
@@ -44,10 +44,10 @@
     "raw-body": ">=2.0.0",
     "reflect-metadata": ">=0.1.12",
     "rxjs": ">=6.0.0",
-    "typia": "^5.2.4"
+    "typia": "^5.2.5"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">=2.3.4",
+    "@nestia/fetcher": ">=0.0.0-dev.20991231",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "@nestjs/platform-express": ">=7.0.1",
@@ -56,7 +56,7 @@
     "reflect-metadata": ">=0.1.12",
     "rxjs": ">=6.0.0",
     "typescript": ">=4.8.0 <5.3.0",
-    "typia": ">=5.2.4 <6.0.0"
+    "typia": ">=5.2.5 <6.0.0"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.0.0",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -40,7 +40,7 @@
     "ts-node": "^10.9.1",
     "ts-patch": "^3.0.2",
     "typescript": "^5.2.2",
-    "typia": "^5.2.4"
+    "typia": "^5.2.5"
   },
   "dependencies": {
     "chalk": "^4.1.2",

--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/fetcher",
-  "version": "2.3.4",
+  "version": "0.0.0-dev.20991231",
   "description": "Fetcher library of Nestia SDK",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -45,7 +45,7 @@
     "typescript-transform-paths": "^3.4.6"
   },
   "dependencies": {
-    "typia": "^5.2.4"
+    "typia": "^5.2.5"
   },
   "files": [
     "lib",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/sdk",
-  "version": "2.3.4",
+  "version": "2.3.5-dev.20231105-4",
   "description": "Nestia SDK and Swagger generator",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -35,7 +35,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^2.3.4",
+    "@nestia/fetcher": ">=2.3.4",
     "cli": "^1.0.1",
     "get-function-location": "^2.0.0",
     "glob": "^7.2.0",
@@ -44,7 +44,7 @@
     "tsconfck": "^2.0.1",
     "tsconfig-paths": "^4.1.1",
     "tstl": "^2.5.13",
-    "typia": "^5.2.4"
+    "typia": ">=5.2.4 <6.0.0"
   },
   "peerDependencies": {
     "@nestia/fetcher": ">=2.3.4",
@@ -56,6 +56,7 @@
     "typia": ">=5.2.4 <6.0.0"
   },
   "devDependencies": {
+    "@nestia/e2e": "^0.3.7",
     "@nestjs/common": ">= 7.0.1",
     "@nestjs/core": ">= 7.0.1",
     "@trivago/prettier-plugin-sort-imports": "^4.0.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/sdk",
-  "version": "2.3.5-dev.20231105-4",
+  "version": "0.0.0-dev.20991231",
   "description": "Nestia SDK and Swagger generator",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -35,7 +35,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": ">=2.3.4",
+    "@nestia/fetcher": "D:\\github\\samchon\\nestia\\packages\\fetcher\\nestia-fetcher-0.0.0-dev.20991231.tgz",
     "cli": "^1.0.1",
     "get-function-location": "^2.0.0",
     "glob": "^7.2.0",
@@ -44,16 +44,16 @@
     "tsconfck": "^2.0.1",
     "tsconfig-paths": "^4.1.1",
     "tstl": "^2.5.13",
-    "typia": ">=5.2.4 <6.0.0"
+    "typia": "^5.2.5"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">=2.3.4",
+    "@nestia/fetcher": ">=0.0.0-dev.20991231",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "reflect-metadata": ">=0.1.12",
     "ts-node": ">=10.6.0",
     "typescript": ">=4.8.0 <5.3.0",
-    "typia": ">=5.2.4 <6.0.0"
+    "typia": ">=5.2.5 <6.0.0"
   },
   "devDependencies": {
     "@nestia/e2e": "^0.3.7",

--- a/packages/sdk/src/analyses/ReflectAnalyzer.ts
+++ b/packages/sdk/src/analyses/ReflectAnalyzer.ts
@@ -99,7 +99,19 @@ export namespace ReflectAnalyzer {
                 name,
                 functions: [],
                 prefixes,
-                paths: _Get_paths(creator),
+                paths: _Get_paths(creator).filter((str) => {
+                    if (str.includes("*") === true) {
+                        project.warnings.push({
+                            file,
+                            controller: name,
+                            function: null,
+                            message:
+                                "@nestia/sdk does not compose wildcard controller.",
+                        });
+                        return false;
+                    }
+                    return true;
+                }),
                 versions: _Get_versions(creator),
                 security: _Get_securities(creator),
                 swaggerTgas:
@@ -251,7 +263,19 @@ export namespace ReflectAnalyzer {
             const meta: IController.IFunction = {
                 name,
                 method: method === "ALL" ? "POST" : method,
-                paths: _Get_paths(proto),
+                paths: _Get_paths(proto).filter((str) => {
+                    if (str.includes("*") === true) {
+                        project.warnings.push({
+                            file: controller.file,
+                            controller: controller.name,
+                            function: name,
+                            message:
+                                "@nestia/sdk does not compose wildcard method.",
+                        });
+                        return false;
+                    }
+                    return true;
+                }),
                 versions: _Get_versions(proto),
                 parameters,
                 status: Reflect.getMetadata(
@@ -291,6 +315,7 @@ export namespace ReflectAnalyzer {
                         controllerLocation,
                         metaLocation,
                     );
+                    if (location.includes("*")) continue;
 
                     // LIST UP PARAMETERS
                     const binded: string[] = PathAnalyzer.parameters(

--- a/packages/sdk/src/structures/IErrorReport.ts
+++ b/packages/sdk/src/structures/IErrorReport.ts
@@ -1,6 +1,6 @@
 export interface IErrorReport {
     file: string;
     controller: string;
-    function: string;
+    function: string | null;
     message: string;
 }

--- a/packages/sdk/src/structures/INestiaProject.ts
+++ b/packages/sdk/src/structures/INestiaProject.ts
@@ -9,4 +9,5 @@ export interface INestiaProject {
     input: INormalizedInput;
     checker: ts.TypeChecker;
     errors: IErrorReport[];
+    warnings: IErrorReport[];
 }

--- a/test/features/distribute-assert/packages/api/package.json
+++ b/test/features/distribute-assert/packages/api/package.json
@@ -34,6 +34,6 @@
   },
   "dependencies": {
     "@nestia/fetcher": "file:../../../../../packages/fetcher/nestia-fetcher-0.0.0-dev.20991231.tgz",
-    "typia": "^5.2.4"
+    "typia": "^5.2.5"
   }
 }

--- a/test/features/distribute-json/packages/api/package.json
+++ b/test/features/distribute-json/packages/api/package.json
@@ -34,6 +34,6 @@
   },
   "dependencies": {
     "@nestia/fetcher": "file:../../../../../packages/fetcher/nestia-fetcher-0.0.0-dev.20991231.tgz",
-    "typia": "^5.2.4"
+    "typia": "^5.2.5"
   }
 }

--- a/test/features/distribute/packages/api/package.json
+++ b/test/features/distribute/packages/api/package.json
@@ -34,6 +34,6 @@
   },
   "dependencies": {
     "@nestia/fetcher": "file:../../../../../packages/fetcher/nestia-fetcher-0.0.0-dev.20991231.tgz",
-    "typia": "^5.2.4"
+    "typia": "^5.2.5"
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@nestia/test",
-  "version": "2.3.4",
+  "version": "0.0.0-dev.20991231",
   "description": "Test program of Nestia",
   "main": "index.js",
   "scripts": {
@@ -34,12 +34,12 @@
     "ts-patch": "v3.0.2",
     "typescript": "^5.2.2",
     "typescript-transform-paths": "^3.4.4",
-    "typia": "^5.2.4",
+    "typia": "^5.2.5",
     "uuid": "^9.0.0",
     "nestia": "^4.5.0",
-    "@nestia/core": "^2.3.4",
+    "@nestia/core": "D:\\github\\samchon\\nestia\\packages\\core\\nestia-core-0.0.0-dev.20991231.tgz",
     "@nestia/e2e": "^0.3.6",
-    "@nestia/fetcher": "^2.3.4",
-    "@nestia/sdk": "^2.3.4"
+    "@nestia/fetcher": "D:\\github\\samchon\\nestia\\packages\\fetcher\\nestia-fetcher-0.0.0-dev.20991231.tgz",
+    "@nestia/sdk": "D:\\github\\samchon\\nestia\\packages\\sdk\\nestia-sdk-0.0.0-dev.20991231.tgz"
   }
 }

--- a/website/pages/docs/sdk/sdk.mdx
+++ b/website/pages/docs/sdk/sdk.mdx
@@ -891,7 +891,7 @@ Also, if your SDK library utilize special alias `paths`, you also need to custom
   },
   "dependencies": {
     "@nestia/fetcher": "^2.3.4",
-    "typia": "^5.2.4"
+    "typia": "^5.2.5"
   },
   "files": [
     "lib",


### PR DESCRIPTION
When wildcase URL controller method exists, `@nestia/sdk` could't build it due to error from `path-to-regexp` library.

Therefore, decided to skip the wildcard controller method case.

```typescript
export class SomeController {
    @All("*")
    public someMethod() {...}
}
```