### PR TITLE
`ts.CompilerHost.jsDocParsingMode`

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://nestia.io",
   "dependencies": {
     "@nestia/core": "^2.2.1-dev.20231012",
-    "typia": "^5.2.5"
+    "typia": "^5.2.6"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.1.1",

--- a/build/index.js
+++ b/build/index.js
@@ -9,24 +9,25 @@ const execute = (command) => {
     cp.execSync(command, { stdio: "inherit" });
 };
 
-const main = () => fs.readdirSync(PACKAGES).forEach((lib) => {
-    const location = `${PACKAGES}/${lib}`;
-    if (fs.existsSync(`${location}/package.json`) === false)
-        return;
+const main = () =>
+    fs.readdirSync(PACKAGES).forEach((lib) => {
+        const location = `${PACKAGES}/${lib}`;
+        if (fs.existsSync(`${location}/package.json`) === false) return;
 
-    console.log("----------------------------------------");
-    console.log(`@nestia/${lib}`);
-    console.log("----------------------------------------");
-    process.chdir(location);
+        console.log("----------------------------------------");
+        console.log(`@nestia/${lib}`);
+        console.log("----------------------------------------");
+        process.chdir(location);
 
-    fs.copyFileSync(README, "README.md");
+        fs.copyFileSync(README, "README.md");
 
-    const test = !!JSON.parse(
-        fs.readFileSync("package.json", { encoding: "utf-8" })
-    ).scripts?.test;
+        const test = !!JSON.parse(
+            fs.readFileSync("package.json", { encoding: "utf-8" }),
+        ).scripts?.test;
 
-    execute("npm install");
-    execute("npm run build");
-    if (test) execute("npm run test");
-});
+        // @todo: REMOVE --FORCE KEYWORD AFTER TS 5.3 RELEASE
+        execute("npm install --force");
+        execute("npm run build");
+        if (test) execute("npm run test");
+    });
 main();

--- a/deploy/publish.js
+++ b/deploy/publish.js
@@ -27,7 +27,9 @@ const setup = (tag) => (version) => (directory) => {
                     tag === "tgz" &&
                     fs.existsSync(`${directory}/node_modules/${key}`)
                 )
-                    execute(directory)(`npm uninstall ${key}`);
+                    try {
+                        execute(directory)(`npm uninstall ${key}`);
+                    } catch {}
                 record[key] =
                     tag === "tgz"
                         ? path.resolve(
@@ -51,7 +53,7 @@ const setup = (tag) => (version) => (directory) => {
     // SETUP UPDATED DEPENDENCIES
     fs.writeFileSync(file, JSON.stringify(info, null, 2), "utf8");
     execute(directory)("npm cache clean --force");
-    execute(directory)(`npm install`);
+    execute(directory)(`npm install --force`); // @todo: REMOVE AFTER TS 5.3 RELEASE
 };
 
 const deploy = (tag) => (version) => (name) => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/core",
-  "version": "2.3.5",
+  "version": "2.3.7",
   "description": "Super-fast validation decorators of NestJS",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -34,7 +34,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^2.3.5",
+    "@nestia/fetcher": "^2.3.7",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "@nestjs/platform-express": ">=7.0.1",
@@ -44,10 +44,10 @@
     "raw-body": ">=2.0.0",
     "reflect-metadata": ">=0.1.12",
     "rxjs": ">=6.0.0",
-    "typia": "^5.2.5"
+    "typia": "^5.2.6"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">=2.3.5",
+    "@nestia/fetcher": ">=2.3.7",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "@nestjs/platform-express": ">=7.0.1",
@@ -56,7 +56,7 @@
     "reflect-metadata": ">=0.1.12",
     "rxjs": ">=6.0.0",
     "typescript": ">=4.8.0 <5.3.0",
-    "typia": ">=5.2.5 <6.0.0"
+    "typia": ">=5.2.6 <6.0.0"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.0.0",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -40,7 +40,7 @@
     "ts-node": "^10.9.1",
     "ts-patch": "^3.0.2",
     "typescript": "^5.2.2",
-    "typia": "^5.2.5"
+    "typia": "^5.2.6"
   },
   "dependencies": {
     "chalk": "^4.1.2",

--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/fetcher",
-  "version": "2.3.5",
+  "version": "2.3.7",
   "description": "Fetcher library of Nestia SDK",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -45,7 +45,7 @@
     "typescript-transform-paths": "^3.4.6"
   },
   "dependencies": {
-    "typia": "^5.2.5"
+    "typia": "^5.2.6"
   },
   "files": [
     "lib",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/sdk",
-  "version": "2.3.5",
+  "version": "2.3.7",
   "description": "Nestia SDK and Swagger generator",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -35,7 +35,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^2.3.5",
+    "@nestia/fetcher": "^2.3.7",
     "cli": "^1.0.1",
     "get-function-location": "^2.0.0",
     "glob": "^7.2.0",
@@ -44,16 +44,16 @@
     "tsconfck": "^2.0.1",
     "tsconfig-paths": "^4.1.1",
     "tstl": "^2.5.13",
-    "typia": "^5.2.5"
+    "typia": "^5.2.6"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">=2.3.5",
+    "@nestia/fetcher": ">=2.3.7",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "reflect-metadata": ">=0.1.12",
     "ts-node": ">=10.6.0",
     "typescript": ">=4.8.0 <5.3.0",
-    "typia": ">=5.2.5 <6.0.0"
+    "typia": ">=5.2.6 <6.0.0"
   },
   "devDependencies": {
     "@nestia/e2e": "^0.3.7",
@@ -74,7 +74,7 @@
     "rimraf": "^3.0.2",
     "ts-node": "^10.9.1",
     "ts-patch": "v3.0.2",
-    "typescript": "^5.2.2",
+    "typescript": "^5.3.0-beta",
     "typescript-transform-paths": "^3.4.4",
     "uuid": "^9.0.0"
   },

--- a/packages/sdk/src/NestiaSdkApplication.ts
+++ b/packages/sdk/src/NestiaSdkApplication.ts
@@ -104,7 +104,9 @@ export class NestiaSdkApplication {
             checker: ts.TypeChecker,
         ) => (config: Config) => (routes: IRoute[]) => Promise<void>,
     ): Promise<void> {
+        //----
         // ANALYZE REFLECTS
+        //----
         const unique: WeakSet<any> = new WeakSet();
         const controllers: IController[] = [];
         const project: INestiaProject = {
@@ -150,11 +152,20 @@ export class NestiaSdkApplication {
                 .reduce((a, b) => a + b, 0)}`,
         );
 
+        //----
         // ANALYZE TYPESCRIPT CODE
+        //----
         console.log("Analyzing source codes");
+
+        // FOR TS 5.3+ CASE: https://github.com/microsoft/TypeScript/pull/55739
+        const host: ts.CompilerHost = ts.createCompilerHost(
+            this.compilerOptions,
+        );
+        host.jsDocParsingMode = 0;
         const program: ts.Program = ts.createProgram(
             controllers.map((c) => c.file),
             this.compilerOptions,
+            host,
         );
         project.checker = program.getTypeChecker();
 

--- a/test/features/distribute-assert/packages/api/package.json
+++ b/test/features/distribute-assert/packages/api/package.json
@@ -34,6 +34,6 @@
   },
   "dependencies": {
     "@nestia/fetcher": "file:../../../../../packages/fetcher/nestia-fetcher-0.0.0-dev.20991231.tgz",
-    "typia": "^5.2.5"
+    "typia": "^5.2.6"
   }
 }

--- a/test/features/distribute-json/packages/api/package.json
+++ b/test/features/distribute-json/packages/api/package.json
@@ -34,6 +34,6 @@
   },
   "dependencies": {
     "@nestia/fetcher": "file:../../../../../packages/fetcher/nestia-fetcher-0.0.0-dev.20991231.tgz",
-    "typia": "^5.2.5"
+    "typia": "^5.2.6"
   }
 }

--- a/test/features/distribute/packages/api/package.json
+++ b/test/features/distribute/packages/api/package.json
@@ -34,6 +34,6 @@
   },
   "dependencies": {
     "@nestia/fetcher": "file:../../../../../packages/fetcher/nestia-fetcher-0.0.0-dev.20991231.tgz",
-    "typia": "^5.2.5"
+    "typia": "^5.2.6"
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@nestia/test",
-  "version": "2.3.5",
+  "version": "2.3.7",
   "description": "Test program of Nestia",
   "main": "index.js",
   "scripts": {
@@ -32,14 +32,14 @@
     "@types/uuid": "^9.0.0",
     "ts-node": "^10.9.1",
     "ts-patch": "v3.0.2",
-    "typescript": "^5.2.2",
+    "typescript": "^5.3.0-beta",
     "typescript-transform-paths": "^3.4.4",
-    "typia": "^5.2.5",
+    "typia": "^5.2.6",
     "uuid": "^9.0.0",
     "nestia": "^4.5.0",
-    "@nestia/core": "^2.3.5",
+    "@nestia/core": "^2.3.7",
     "@nestia/e2e": "^0.3.6",
-    "@nestia/fetcher": "^2.3.5",
-    "@nestia/sdk": "^2.3.5"
+    "@nestia/fetcher": "^2.3.7",
+    "@nestia/sdk": "^2.3.7"
   }
 }

--- a/website/pages/docs/sdk/sdk.mdx
+++ b/website/pages/docs/sdk/sdk.mdx
@@ -891,7 +891,7 @@ Also, if your SDK library utilize special alias `paths`, you also need to custom
   },
   "dependencies": {
     "@nestia/fetcher": "^2.3.4",
-    "typia": "^5.2.5"
+    "typia": "^5.2.6"
   },
   "files": [
     "lib",


### PR DESCRIPTION
Since TypeScript v5.3 update, TypeScript compiler no more analyzes `JsDocComment` as default.

> The desire of that is to boosting up the compilation speed by not parsing the JS Doc Comments.

Therefore, to parepare the future TypeScript v5.3 release, I've updated `@nestia/sdk` to configure the `jsDocParsingMode` to parse every comments manually. For reference, the restriction of `peerDependencies` -> `"typescript": ">=4.8.0 <5.3.0"` would also be erased after formal TS v5.3 release.

https://github.com/microsoft/TypeScript/pull/55739
