### PR TITLE
Safe nullish coalescing for speical cases

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/core",
-  "version": "2.3.7",
+  "version": "2.3.8",
   "description": "Super-fast validation decorators of NestJS",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -34,7 +34,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^2.3.7",
+    "@nestia/fetcher": "^2.3.8",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "@nestjs/platform-express": ">=7.0.1",
@@ -47,7 +47,7 @@
     "typia": "^5.2.6"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">=2.3.7",
+    "@nestia/fetcher": ">=2.3.8",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "@nestjs/platform-express": ">=7.0.1",

--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/fetcher",
-  "version": "2.3.7",
+  "version": "2.3.8",
   "description": "Fetcher library of Nestia SDK",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/sdk",
-  "version": "2.3.7",
+  "version": "2.3.8",
   "description": "Nestia SDK and Swagger generator",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -35,7 +35,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^2.3.7",
+    "@nestia/fetcher": "^2.3.8",
     "cli": "^1.0.1",
     "get-function-location": "^2.0.0",
     "glob": "^7.2.0",
@@ -47,7 +47,7 @@
     "typia": "^5.2.6"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">=2.3.7",
+    "@nestia/fetcher": ">=2.3.8",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "reflect-metadata": ">=0.1.12",

--- a/packages/sdk/src/analyses/GenericAnalyzer.ts
+++ b/packages/sdk/src/analyses/GenericAnalyzer.ts
@@ -25,10 +25,14 @@ export namespace GenericAnalyzer {
                 const expression: ts.Type = checker.getTypeAtLocation(
                     hType.expression,
                 );
-                const superNode: ts.Declaration =
-                    expression.symbol.getDeclarations()![0];
+                const superNode: ts.Declaration | undefined =
+                    expression.symbol.getDeclarations()?.[0];
 
-                if (!ts.isClassDeclaration(superNode)) continue;
+                if (
+                    superNode === undefined ||
+                    !ts.isClassDeclaration(superNode)
+                )
+                    continue;
 
                 // SPECIFY GENERICS
                 const usages: ReadonlyArray<ts.TypeNode> =

--- a/packages/sdk/src/analyses/ImportAnalyzer.ts
+++ b/packages/sdk/src/analyses/ImportAnalyzer.ts
@@ -61,7 +61,7 @@ export namespace ImportAnalyzer {
     function get_name(symbol: ts.Symbol): string {
         return explore_name(
             symbol.escapedName.toString(),
-            symbol.getDeclarations()![0].parent,
+            symbol.getDeclarations()?.[0]?.parent,
         );
     }
 
@@ -111,8 +111,9 @@ export namespace ImportAnalyzer {
         // SPECIALIZATION
         //----
         const name: string = get_name(symbol);
-        const sourceFile: ts.SourceFile =
-            symbol.declarations![0].getSourceFile();
+        const sourceFile: ts.SourceFile | undefined =
+            symbol.declarations?.[0]?.getSourceFile();
+        if (sourceFile === undefined) return name;
 
         if (sourceFile.fileName.indexOf("typescript/lib") === -1) {
             const set: HashSet<string> = importDict.take(
@@ -147,8 +148,8 @@ export namespace ImportAnalyzer {
             : name;
     }
 
-    function explore_name(name: string, decl: ts.Node): string {
-        return ts.isModuleBlock(decl)
+    function explore_name(name: string, decl?: ts.Node): string {
+        return decl && ts.isModuleBlock(decl)
             ? explore_name(
                   `${decl.parent.name.getFullText().trim()}.${name}`,
                   decl.parent.parent,

--- a/test/package.json
+++ b/test/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@nestia/test",
-  "version": "2.3.7",
+  "version": "2.3.8",
   "description": "Test program of Nestia",
   "main": "index.js",
   "scripts": {
@@ -37,9 +37,9 @@
     "typia": "^5.2.6",
     "uuid": "^9.0.0",
     "nestia": "^4.5.0",
-    "@nestia/core": "^2.3.7",
+    "@nestia/core": "^2.3.8",
     "@nestia/e2e": "^0.3.6",
-    "@nestia/fetcher": "^2.3.7",
-    "@nestia/sdk": "^2.3.7"
+    "@nestia/fetcher": "^2.3.8",
+    "@nestia/sdk": "^2.3.8"
   }
 }


### PR DESCRIPTION
When invalid type being used in SDK or swagger generation, non-nullish coalesced codes had caused errors.

To fix it, make them to be safe through the nullish coalescing statements with `?` symbol.