### PR TITLE
Adapt new cli command `npx typia patch`.

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -7,7 +7,7 @@
     "build": "rimraf bin && tsc",
     "generate": "ts-node src/generate",
     "start": "npm run build && node bin",
-    "prepare": "ts-patch install"
+    "prepare": "ts-patch install && typia patch"
   },
   "repository": {
     "type": "git",
@@ -24,8 +24,8 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/core": "^2.2.1-dev.20231012",
-    "typia": "^5.2.6"
+    "@nestia/core": "^2.4.0",
+    "typia": "^5.3.0"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.1.1",
@@ -47,6 +47,6 @@
     "ts-node": "^10.9.1",
     "ts-patch": "^3.0.2",
     "tstl": "^2.5.13",
-    "typescript": "^5.2.2"
+    "typescript": "^5.3.2"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestia",
-  "version": "5.0.3",
+  "version": "5.1.0",
   "description": "Nestia CLI tool",
   "main": "bin/index.js",
   "bin": {
@@ -37,14 +37,14 @@
     "inquirer": "^8.2.5"
   },
   "devDependencies": {
-    "@nestia/core": "^2.3.4",
-    "@nestia/sdk": "^2.3.4",
+    "@nestia/core": "^2.4.0",
+    "@nestia/sdk": "^2.4.0",
     "@trivago/prettier-plugin-sort-imports": "^4.1.1",
     "@types/inquirer": "^9.0.3",
     "@types/node": "^18.11.16",
     "prettier": "^2.8.7",
     "rimraf": "^3.0.2",
-    "typescript": "^5.2.2"
+    "typescript": "^5.3.2"
   },
   "files": [
     "bin",

--- a/packages/cli/src/internal/PackageManager.ts
+++ b/packages/cli/src/internal/PackageManager.ts
@@ -38,7 +38,7 @@ export class PackageManager {
     public install(props: {
         dev: boolean;
         modulo: string;
-        version: `latest` | `${number}.${number}.${number}`;
+        version?: `latest` | `next` | `${number}.${number}.${number}`;
     }): boolean {
         const middle: string =
             this.manager === "yarn"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/core",
-  "version": "2.3.12",
+  "version": "2.4.0",
   "description": "Super-fast validation decorators of NestJS",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -12,7 +12,7 @@
     "package:latest": "npm run build && npm publish --access public",
     "package:next": "npm run package:latest -- --tag next",
     "prettier": "prettier ./**/*.ts --write",
-    "prepare": "ts-patch install"
+    "prepare": "ts-patch install && typia patch"
   },
   "repository": {
     "type": "git",
@@ -34,7 +34,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^2.3.12",
+    "@nestia/fetcher": "^2.4.0",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "@nestjs/platform-express": ">=7.0.1",
@@ -44,10 +44,10 @@
     "raw-body": ">=2.0.0",
     "reflect-metadata": ">=0.1.12",
     "rxjs": ">=6.0.0",
-    "typia": "^5.2.6"
+    "typia": "^5.3.0"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">=2.3.12",
+    "@nestia/fetcher": ">=2.4.0",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "@nestjs/platform-express": ">=7.0.1",
@@ -55,8 +55,8 @@
     "raw-body": ">=2.0.0",
     "reflect-metadata": ">=0.1.12",
     "rxjs": ">=6.0.0",
-    "typescript": ">=4.8.0 <5.3.0",
-    "typia": ">=5.2.6 <6.0.0"
+    "typescript": ">=4.8.0 <5.4.0",
+    "typia": ">=5.3.0 <6.0.0"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.0.0",
@@ -76,7 +76,7 @@
     "ts-node": "^10.9.1",
     "ts-patch": "^3.0.2",
     "tstl": "^2.5.13",
-    "typescript": "^5.2.2",
+    "typescript": "^5.3.2",
     "typescript-transform-paths": "^3.4.6"
   },
   "files": [

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -8,7 +8,7 @@
     "dev": "npm run build -- --watch",
     "eslint": "eslint src",
     "prettier": "prettier --write ./src/**/*.ts",
-    "prepare": "ts-patch install",
+    "prepare": "ts-patch install && typia patch",
     "test": "node lib/test"
   },
   "repository": {
@@ -39,8 +39,8 @@
     "rimraf": "^4.1.2",
     "ts-node": "^10.9.1",
     "ts-patch": "^3.0.2",
-    "typescript": "^5.2.2",
-    "typia": "^5.2.6"
+    "typescript": "^5.3.2",
+    "typia": "^5.3.0"
   },
   "dependencies": {
     "chalk": "^4.1.2",

--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/fetcher",
-  "version": "2.3.12",
+  "version": "2.4.0",
   "description": "Fetcher library of Nestia SDK",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -32,7 +32,7 @@
     "@typescript-eslint/parser": "^5.46.1",
     "prettier": "^2.8.1",
     "rimraf": "^3.0.2",
-    "typescript": "^5.2.2"
+    "typescript": "^5.3.2"
   },
   "peerDependencies": {
     "typescript": ">= 4.8.0"

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -44,11 +44,11 @@
     "ts-node": "^10.9.1",
     "ts-patch": "^3.0.2",
     "tstl": "^2.5.13",
-    "typescript": "^5.2.2",
+    "typescript": "^5.3.2",
     "typescript-transform-paths": "^3.4.6"
   },
   "dependencies": {
-    "typia": "^5.2.6"
+    "typia": "^5.3.0"
   },
   "files": [
     "lib",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/sdk",
-  "version": "2.3.12",
+  "version": "2.4.0",
   "description": "Nestia SDK and Swagger generator",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -13,7 +13,7 @@
     "eslint": "eslint ./**/*.ts",
     "package:latest": "npm run build && npm publish --access public",
     "package:next": "npm run package:latest -- --tag next",
-    "prepare": "ts-patch install",
+    "prepare": "ts-patch install && typia patch",
     "prettier": "prettier --write ./**/*.ts"
   },
   "repository": {
@@ -35,7 +35,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^2.3.12",
+    "@nestia/fetcher": "^2.4.0",
     "cli": "^1.0.1",
     "get-function-location": "^2.0.0",
     "glob": "^7.2.0",
@@ -44,16 +44,16 @@
     "tsconfck": "^2.0.1",
     "tsconfig-paths": "^4.1.1",
     "tstl": "^2.5.13",
-    "typia": "^5.2.6"
+    "typia": "^5.3.0"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">=2.3.12",
+    "@nestia/fetcher": ">=2.4.0",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "reflect-metadata": ">=0.1.12",
     "ts-node": ">=10.6.0",
-    "typescript": ">=4.8.0 <5.3.0",
-    "typia": ">=5.2.6 <6.0.0"
+    "typescript": ">=4.8.0 <5.4.0",
+    "typia": ">=5.3.0 <6.0.0"
   },
   "devDependencies": {
     "@nestia/e2e": "^0.3.7",

--- a/test/features/distribute-assert/packages/api/package.json
+++ b/test/features/distribute-assert/packages/api/package.json
@@ -9,7 +9,7 @@
     "build:sdk": "rimraf ../../src/api/functional && cd ../.. && npx nestia sdk && cd packages/api",
     "compile": "rimraf lib && tsc",
     "deploy": "npm run build && npm publish",
-    "prepare": "ts-patch install"
+    "prepare": "ts-patch install && typia patch"
   },
   "repository": {
     "type": "git",
@@ -30,10 +30,10 @@
     "rimraf": "^5.0.5",
     "ts-node": "^10.9.1",
     "ts-patch": "^3.0.2",
-    "typescript": "^5.2.2"
+    "typescript": "^5.3.2"
   },
   "dependencies": {
     "@nestia/fetcher": "file:../../../../../packages/fetcher/nestia-fetcher-0.0.0-dev.20991231.tgz",
-    "typia": "^5.2.6"
+    "typia": "^5.3.0"
   }
 }

--- a/test/features/distribute-json/packages/api/package.json
+++ b/test/features/distribute-json/packages/api/package.json
@@ -9,7 +9,7 @@
     "build:sdk": "rimraf ../../src/api/functional && cd ../.. && npx nestia sdk && cd packages/api",
     "compile": "rimraf lib && tsc",
     "deploy": "npm run build && npm publish",
-    "prepare": "ts-patch install"
+    "prepare": "ts-patch install && typia patch"
   },
   "repository": {
     "type": "git",
@@ -30,10 +30,10 @@
     "rimraf": "^5.0.5",
     "ts-node": "^10.9.1",
     "ts-patch": "^3.0.2",
-    "typescript": "^5.2.2"
+    "typescript": "^5.3.2"
   },
   "dependencies": {
     "@nestia/fetcher": "file:../../../../../packages/fetcher/nestia-fetcher-0.0.0-dev.20991231.tgz",
-    "typia": "^5.2.6"
+    "typia": "^5.3.0"
   }
 }

--- a/test/features/distribute/packages/api/package.json
+++ b/test/features/distribute/packages/api/package.json
@@ -9,7 +9,7 @@
     "build:sdk": "rimraf ../../src/api/functional && cd ../.. && npx nestia sdk && cd packages/api",
     "compile": "rimraf lib && tsc",
     "deploy": "npm run build && npm publish",
-    "prepare": "ts-patch install"
+    "prepare": "ts-patch install && typia patch"
   },
   "repository": {
     "type": "git",
@@ -30,10 +30,10 @@
     "rimraf": "^5.0.5",
     "ts-node": "^10.9.1",
     "ts-patch": "^3.0.2",
-    "typescript": "^5.2.2"
+    "typescript": "^5.3.2"
   },
   "dependencies": {
     "@nestia/fetcher": "file:../../../../../packages/fetcher/nestia-fetcher-0.0.0-dev.20991231.tgz",
-    "typia": "^5.2.6"
+    "typia": "^5.3.0"
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@nestia/test",
-  "version": "2.3.12",
+  "version": "2.4.0",
   "description": "Test program of Nestia",
   "main": "index.js",
   "scripts": {
@@ -9,7 +9,7 @@
     "errors": "node executable/errors",
     "generate": "node executable/generate",
     "start": "node executable/start",
-    "prepare": "ts-patch install"
+    "prepare": "ts-patch install && typia patch"
   },
   "repository": {
     "type": "git",
@@ -34,12 +34,12 @@
     "ts-patch": "v3.0.2",
     "typescript": "^5.3.0-beta",
     "typescript-transform-paths": "^3.4.4",
-    "typia": "^5.2.6",
+    "typia": "^5.3.0",
     "uuid": "^9.0.0",
     "nestia": "^4.5.0",
-    "@nestia/core": "^2.3.12",
+    "@nestia/core": "^2.4.0",
     "@nestia/e2e": "^0.3.6",
-    "@nestia/fetcher": "^2.3.12",
-    "@nestia/sdk": "^2.3.12"
+    "@nestia/fetcher": "^2.4.0",
+    "@nestia/sdk": "^2.4.0"
   }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -33,6 +33,6 @@
     "gh-pages": "^5.0.0",
     "next-sitemap": "^4.0.7",
     "rimraf": "^5.0.0",
-    "typescript": "^4.9.3"
+    "typescript": "^5.3.2"
   }
 }

--- a/website/pages/docs/sdk/sdk.mdx
+++ b/website/pages/docs/sdk/sdk.mdx
@@ -1063,12 +1063,12 @@ Also, if your SDK library utilize special alias `paths`, you also need to custom
   "homepage": "https://nestia.io",
   "devDependencies": {
     "rimraf": "^5.0.0",
-    "typescript": "^5.2.2",
+    "typescript": "^5.3.2",
     "ts-patch": "^3.0.2"
   },
   "dependencies": {
     "@nestia/fetcher": "^2.3.4",
-    "typia": "^5.2.6"
+    "typia": "^5.3.0"
   },
   "files": [
     "lib",

--- a/website/pages/docs/setup.mdx
+++ b/website/pages/docs/setup.mdx
@@ -1,6 +1,7 @@
 import { Tabs, Tab } from 'nextra-theme-docs'
 
 import Alert from '@mui/material/Alert';
+import AlertTitle from '@mui/material/AlertTitle';
 import Stack from '@mui/material/Stack';
 
 # Setup
@@ -417,7 +418,7 @@ Also, never forget to configure `strict` (or `strictNullChecks`) as `true`. It i
 ```json filename="package.json" showLineNumbers copy
 {
     "scripts": {
-        "prepare": "ts-patch install"
+        "prepare": "ts-patch install && typia patch"
     }
 }
 ```
@@ -447,11 +448,19 @@ Of course, you've to run the `npm run prepare` command after configuration.
 For reference, [`ts-patch`](https://github.com/nonara/ts-patch) is an helper library of TypeScript compiler that supporting custom transformations by plugins. With the [`ts-patch`](https://github.com/nonara/ts-patch) setup and plugin configurations, whenever you run `tsc` command, your `@nestia/core` decorator function call statements would be transformed to the optimal operation codes in the compiled JavaScript files.
 
 <br/>
-<Stack>
-    <Alert severity="warning">
-If manual setup is difficult, just use the [Setup Wizard](#setup-wizard) \o/.
-    </Alert>
-</Stack>
+<Alert severity="warning">
+
+    <AlertTitle>
+        **`npx typia patch`** 
+    </AlertTitle> 
+
+Since TypeScript v5.3 update, `tsc` no more parses `JSDocComment`s. Therefore, (`@nestia/core`) `typia` also cannot utilize those `JSDocComment` related features too, especially ["Comment Tags"](https://typia.io/docs/validators/tags/#comment-tags) and ["JSON schema generator"](https://typia.io/docs/json/schema). 
+
+The `npx typia patch` command has been developed to revive the `JSDocComment` parsing feature of `tsc`. It is temporary solution for the TypeScript v5.3 update instead of [`ts-patch`](https://github.com/nonara/ts-patch), and will be disabled after [`ts-patch`](https://github.com/nonara/ts-patch) starts supporting such TypeScript v5.3 update.
+
+Of course, if you don't use any ["Comment Tags"](https://typia.io/docs/validators/tags/#comment-tags) and ["JSON schema generator"](https://typia.io/docs/json/schema), you don't need to run `npx typia patch` command. This is not mandatory command, but just optional command.
+
+</Alert>
 
 
 

--- a/website/public/sitemap-0.xml
+++ b/website/public/sitemap-0.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://nestia.io/</loc><lastmod>2023-11-17T07:07:56.058Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://nestia.io/docs/</loc><lastmod>2023-11-17T07:07:56.059Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://nestia.io/docs/core/TypedBody/</loc><lastmod>2023-11-17T07:07:56.059Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://nestia.io/docs/core/TypedException/</loc><lastmod>2023-11-17T07:07:56.059Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://nestia.io/docs/core/TypedHeaders/</loc><lastmod>2023-11-17T07:07:56.059Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://nestia.io/docs/core/TypedParam/</loc><lastmod>2023-11-17T07:07:56.059Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://nestia.io/docs/core/TypedQuery/</loc><lastmod>2023-11-17T07:07:56.059Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://nestia.io/docs/core/TypedRoute/</loc><lastmod>2023-11-17T07:07:56.059Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://nestia.io/docs/migrate/</loc><lastmod>2023-11-17T07:07:56.059Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://nestia.io/docs/pure/</loc><lastmod>2023-11-17T07:07:56.059Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://nestia.io/docs/sdk/e2e/</loc><lastmod>2023-11-17T07:07:56.059Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://nestia.io/docs/sdk/sdk/</loc><lastmod>2023-11-17T07:07:56.059Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://nestia.io/docs/sdk/simulator/</loc><lastmod>2023-11-17T07:07:56.059Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://nestia.io/docs/sdk/swagger/</loc><lastmod>2023-11-17T07:07:56.059Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://nestia.io/docs/setup/</loc><lastmod>2023-11-17T07:07:56.059Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://nestia.io/playground/</loc><lastmod>2023-11-17T07:07:56.059Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://nestia.io/</loc><lastmod>2023-11-26T18:27:07.060Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://nestia.io/docs/</loc><lastmod>2023-11-26T18:27:07.061Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://nestia.io/docs/core/TypedBody/</loc><lastmod>2023-11-26T18:27:07.061Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://nestia.io/docs/core/TypedException/</loc><lastmod>2023-11-26T18:27:07.061Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://nestia.io/docs/core/TypedHeaders/</loc><lastmod>2023-11-26T18:27:07.061Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://nestia.io/docs/core/TypedParam/</loc><lastmod>2023-11-26T18:27:07.061Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://nestia.io/docs/core/TypedQuery/</loc><lastmod>2023-11-26T18:27:07.061Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://nestia.io/docs/core/TypedRoute/</loc><lastmod>2023-11-26T18:27:07.061Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://nestia.io/docs/migrate/</loc><lastmod>2023-11-26T18:27:07.061Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://nestia.io/docs/pure/</loc><lastmod>2023-11-26T18:27:07.061Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://nestia.io/docs/sdk/e2e/</loc><lastmod>2023-11-26T18:27:07.061Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://nestia.io/docs/sdk/sdk/</loc><lastmod>2023-11-26T18:27:07.061Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://nestia.io/docs/sdk/simulator/</loc><lastmod>2023-11-26T18:27:07.061Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://nestia.io/docs/sdk/swagger/</loc><lastmod>2023-11-26T18:27:07.061Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://nestia.io/docs/setup/</loc><lastmod>2023-11-26T18:27:07.061Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://nestia.io/playground/</loc><lastmod>2023-11-26T18:27:07.061Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>


### PR DESCRIPTION
Since TypeScript v5.3 update, `tsc` no more parses `JSDocComment`s. Therefore, Therefore, `typia` and `@nestia/core` also cannot utilize those `JSDocComment` related features too, especially "Comment Tags" and "JSON schema generator".

However, in relation to this, the upgrade of `ts-patch` continues to be delayed, and I still don't know how long the delay would be continue. Furthermore, there're some `typia`/`nestia` users urging to resolve the `peerDependencies` of `typia`/`nestia` that blocking the TypeScript v5.3 update. Therefore, before the `ts-patch` being prepared, I've decoded to provide `typia`'s own solution for a while. It is the new CLI command `npx typia patch`, and `nestia` also adapts it (`npx nestia setup` command performs it).

Also, if the `defaultJSDocParsingMode` value not being patched, `typia` will generate an warning message of TypeScript compiler API. For reference, as it is an warning message, it does not interrupt the TypeScript compilation like the compilation error case. If there're some `typia`/`nestia` users never using "Comment Tags" or "JSON schema generator" at all, they don't need to run the CLI command. This is not mandatory command, but just optional command.

Of course, when `ts-patch` being updated, this CLI command would be disabled immediately, if the installed `ts-patch` version is the latest one.

Related issues:
  - https://github.com/samchon/typia/pull/883
  - https://github.com/microsoft/TypeScript/pull/55739
  - https://github.com/nonara/ts-patch/issues/134
