### PR TITLE
Adjust nonara/ts-patch#138

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://nestia.io",
   "dependencies": {
     "@nestia/core": "^2.4.0",
-    "typia": "^5.3.1"
+    "typia": "^5.3.4"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.1.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,9 +1,14 @@
 {
   "name": "@nestia/core",
-  "version": "2.4.1",
+  "version": "0.0.0-dev.20991231",
   "description": "Super-fast validation decorators of NestJS",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
+  "tsp": {
+    "tscOptions": {
+      "parseAllJsDoc": true
+    }
+  },
   "scripts": {
     "build": "rimraf lib && tsc",
     "dev": "npm run build -- --watch",
@@ -34,7 +39,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^2.4.1",
+    "@nestia/fetcher": "D:\\github\\samchon\\nestia\\packages\\fetcher\\nestia-fetcher-0.0.0-dev.20991231.tgz",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "@nestjs/platform-express": ">=7.0.1",
@@ -44,10 +49,10 @@
     "raw-body": ">=2.0.0",
     "reflect-metadata": ">=0.1.12",
     "rxjs": ">=6.0.0",
-    "typia": "^5.3.1"
+    "typia": "^5.3.4"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">=2.4.1",
+    "@nestia/fetcher": ">=0.0.0-dev.20991231",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "@nestjs/platform-express": ">=7.0.1",
@@ -56,7 +61,7 @@
     "reflect-metadata": ">=0.1.12",
     "rxjs": ">=6.0.0",
     "typescript": ">=4.8.0 <5.4.0",
-    "typia": ">=5.3.1 <6.0.0"
+    "typia": ">=5.3.4 <6.0.0"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.0.0",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -40,7 +40,7 @@
     "ts-node": "^10.9.1",
     "ts-patch": "^3.0.2",
     "typescript": "^5.3.2",
-    "typia": "^5.3.1"
+    "typia": "^5.3.4"
   },
   "dependencies": {
     "chalk": "^4.1.2",

--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/fetcher",
-  "version": "2.4.1",
+  "version": "0.0.0-dev.20991231",
   "description": "Fetcher library of Nestia SDK",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -48,7 +48,7 @@
     "typescript-transform-paths": "^3.4.6"
   },
   "dependencies": {
-    "typia": "^5.3.1"
+    "typia": "^5.3.4"
   },
   "files": [
     "lib",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/sdk",
-  "version": "2.4.1",
+  "version": "0.0.0-dev.20991231",
   "description": "Nestia SDK and Swagger generator",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -35,7 +35,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^2.4.1",
+    "@nestia/fetcher": "D:\\github\\samchon\\nestia\\packages\\fetcher\\nestia-fetcher-0.0.0-dev.20991231.tgz",
     "cli": "^1.0.1",
     "get-function-location": "^2.0.0",
     "glob": "^7.2.0",
@@ -44,16 +44,16 @@
     "tsconfck": "^2.0.1",
     "tsconfig-paths": "^4.1.1",
     "tstl": "^2.5.13",
-    "typia": "^5.3.1"
+    "typia": "^5.3.4"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">=2.4.1",
+    "@nestia/fetcher": ">=0.0.0-dev.20991231",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "reflect-metadata": ">=0.1.12",
     "ts-node": ">=10.6.0",
     "typescript": ">=4.8.0 <5.4.0",
-    "typia": ">=5.3.1 <6.0.0"
+    "typia": ">=5.3.4 <6.0.0"
   },
   "devDependencies": {
     "@nestia/e2e": "^0.3.7",
@@ -74,7 +74,7 @@
     "rimraf": "^3.0.2",
     "ts-node": "^10.9.1",
     "ts-patch": "v3.0.2",
-    "typescript": "^5.3.1-beta",
+    "typescript": "^5.3.2",
     "typescript-transform-paths": "^3.4.4",
     "uuid": "^9.0.0"
   },

--- a/packages/sdk/src/generates/internal/SwaggerSchemaGenerator.ts
+++ b/packages/sdk/src/generates/internal/SwaggerSchemaGenerator.ts
@@ -438,10 +438,10 @@ const any = new Singleton(() =>
             maps: [],
         },
         {
-            aliases: [],
-            arrays: [],
-            tuples: [],
-            objects: [],
+            aliases: new Map(),
+            arrays: new Map(),
+            tuples: new Map(),
+            objects: new Map(),
         },
     ),
 );

--- a/test/features/distribute-assert/packages/api/package.json
+++ b/test/features/distribute-assert/packages/api/package.json
@@ -34,6 +34,6 @@
   },
   "dependencies": {
     "@nestia/fetcher": "^2.4.1",
-    "typia": "^5.3.1"
+    "typia": "^5.3.4"
   }
 }

--- a/test/features/distribute-json/packages/api/package.json
+++ b/test/features/distribute-json/packages/api/package.json
@@ -34,6 +34,6 @@
   },
   "dependencies": {
     "@nestia/fetcher": "^2.4.1",
-    "typia": "^5.3.1"
+    "typia": "^5.3.4"
   }
 }

--- a/test/features/distribute/packages/api/package.json
+++ b/test/features/distribute/packages/api/package.json
@@ -34,6 +34,6 @@
   },
   "dependencies": {
     "@nestia/fetcher": "^2.4.1",
-    "typia": "^5.3.1"
+    "typia": "^5.3.4"
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@nestia/test",
-  "version": "2.4.1",
+  "version": "0.0.0-dev.20991231",
   "description": "Test program of Nestia",
   "main": "index.js",
   "scripts": {
@@ -32,14 +32,14 @@
     "@types/uuid": "^9.0.0",
     "ts-node": "^10.9.1",
     "ts-patch": "v3.0.2",
-    "typescript": "^5.3.1-beta",
+    "typescript": "^5.3.2",
     "typescript-transform-paths": "^3.4.4",
-    "typia": "^5.3.1",
+    "typia": "^5.3.4",
     "uuid": "^9.0.0",
     "nestia": "^4.5.0",
-    "@nestia/core": "^2.4.1",
+    "@nestia/core": "D:\\github\\samchon\\nestia\\packages\\core\\nestia-core-0.0.0-dev.20991231.tgz",
     "@nestia/e2e": "^0.3.6",
-    "@nestia/fetcher": "^2.4.1",
-    "@nestia/sdk": "^2.4.1"
+    "@nestia/fetcher": "D:\\github\\samchon\\nestia\\packages\\fetcher\\nestia-fetcher-0.0.0-dev.20991231.tgz",
+    "@nestia/sdk": "D:\\github\\samchon\\nestia\\packages\\sdk\\nestia-sdk-0.0.0-dev.20991231.tgz"
   }
 }

--- a/website/pages/docs/sdk/sdk.mdx
+++ b/website/pages/docs/sdk/sdk.mdx
@@ -1068,7 +1068,7 @@ Also, if your SDK library utilize special alias `paths`, you also need to custom
   },
   "dependencies": {
     "@nestia/fetcher": "^2.3.4",
-    "typia": "^5.3.1"
+    "typia": "^5.3.4"
   },
   "files": [
     "lib",


### PR DESCRIPTION
Since TypeScript v5.3 update, `tsc` no more parses `JSDocComment`s. Therefore, `typia` also cannot utilize those `JSDocComment` related features too, especially "Comment Tags" and "JSON schema generator".

To reflect such TypeScript v5.3 update, `typia` has newly added a  temporary CLI command `npx typia patch` that is hacking the TypeScript module to turning on the `JSDocComment` parsing. Also, `nestia` has adopted the CLI when running the `npx nestia setup` command.

  - samchon/typia#883
  - samchon/nestia#696

In today, `ts-patch` has started supporting the TypeScript v5.3 update by reading `package.json` of transformer libraries. Therefore, the temporary CLI command no more required. Following the `ts-patch` guide, this PR has configured the `package.json` file for `ts-patch`, and `JSDocComment` parsing would be turned on by the `ts-patch`.

For reference, the temporary CLI command `npx typia patch` would be kept for a while, due to there can be some users using previous version of `ts-patch`. It would be deprecated after the next major update.
