### PR TITLE
Fix samchon/typia@976 - wrong `ISwaggerRoute.summary` inference.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Check out the document in the [website](https://nestia.io/docs/):
     - [TypedException](https://nestia.io/docs/core/TypedException/)
   - Generators
     - [Swagger Documents](https://nestia.io/docs/sdk/swagger/)
-    - [SDK Library](https://nestia.io/docs/sdk/sdk/)
+    - [Software Development Kit](https://nestia.io/docs/sdk/sdk/)
     - [E2E Functions](https://nestia.io/docs/sdk/e2e/)
     - [Mockup Simulator](https://nestia.io/docs/sdk/simulator/)
   - [Swagger to NestJS](https://nestia.io/docs/migrate/)

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://nestia.io",
   "dependencies": {
     "@nestia/core": "^2.4.3",
-    "typia": "^5.4.5"
+    "typia": "^5.4.12"
   },
   "devDependencies": {
     "@types/autocannon": "^7.9.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@nestia/station",
-  "version": "2.5.9",
+  "version": "2.5.10",
   "description": "Nestia station",
   "main": "prettier.config.js",
   "scripts": {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -66,7 +66,7 @@ Check out the document in the [website](https://nestia.io/docs/):
     - [TypedException](https://nestia.io/docs/core/TypedException/)
   - Generators
     - [Swagger Documents](https://nestia.io/docs/sdk/swagger/)
-    - [SDK Library](https://nestia.io/docs/sdk/sdk/)
+    - [Software Development Kit](https://nestia.io/docs/sdk/sdk/)
     - [E2E Functions](https://nestia.io/docs/sdk/e2e/)
     - [Mockup Simulator](https://nestia.io/docs/sdk/simulator/)
   - [Swagger to NestJS](https://nestia.io/docs/migrate/)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/core",
-  "version": "2.5.9",
+  "version": "2.5.10",
   "description": "Super-fast validation decorators of NestJS",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -36,7 +36,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^2.5.9",
+    "@nestia/fetcher": "^2.5.10",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "detect-ts-node": "^1.0.5",
@@ -45,15 +45,15 @@
     "raw-body": "^2.0.0",
     "reflect-metadata": ">=0.1.12",
     "rxjs": ">=6.0.0",
-    "typia": "^5.4.5"
+    "typia": "^5.4.12"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">=2.5.9",
+    "@nestia/fetcher": ">=2.5.10",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "reflect-metadata": ">=0.1.12",
     "rxjs": ">=6.0.0",
-    "typia": ">=5.4.5 <6.0.0"
+    "typia": ">=5.4.12 <6.0.0"
   },
   "devDependencies": {
     "@fastify/multipart": "^8.1.0",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -38,7 +38,7 @@
     "ts-node": "^10.9.1",
     "ts-patch": "^3.1.0",
     "typescript": "^5.3.2",
-    "typia": "^5.4.5"
+    "typia": "^5.4.12"
   },
   "dependencies": {
     "chalk": "^4.1.2",

--- a/packages/fetcher/README.md
+++ b/packages/fetcher/README.md
@@ -66,7 +66,7 @@ Check out the document in the [website](https://nestia.io/docs/):
     - [TypedException](https://nestia.io/docs/core/TypedException/)
   - Generators
     - [Swagger Documents](https://nestia.io/docs/sdk/swagger/)
-    - [SDK Library](https://nestia.io/docs/sdk/sdk/)
+    - [Software Development Kit](https://nestia.io/docs/sdk/sdk/)
     - [E2E Functions](https://nestia.io/docs/sdk/e2e/)
     - [Mockup Simulator](https://nestia.io/docs/sdk/simulator/)
   - [Swagger to NestJS](https://nestia.io/docs/migrate/)

--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/fetcher",
-  "version": "2.5.9",
+  "version": "2.5.10",
   "description": "Fetcher library of Nestia SDK",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -66,7 +66,7 @@ Check out the document in the [website](https://nestia.io/docs/):
     - [TypedException](https://nestia.io/docs/core/TypedException/)
   - Generators
     - [Swagger Documents](https://nestia.io/docs/sdk/swagger/)
-    - [SDK Library](https://nestia.io/docs/sdk/sdk/)
+    - [Software Development Kit](https://nestia.io/docs/sdk/sdk/)
     - [E2E Functions](https://nestia.io/docs/sdk/e2e/)
     - [Mockup Simulator](https://nestia.io/docs/sdk/simulator/)
   - [Swagger to NestJS](https://nestia.io/docs/migrate/)

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/sdk",
-  "version": "2.5.9",
+  "version": "2.5.10",
   "description": "Nestia SDK and Swagger generator",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -32,7 +32,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^2.5.9",
+    "@nestia/fetcher": "^2.5.10",
     "cli": "^1.0.1",
     "get-function-location": "^2.0.0",
     "glob": "^7.2.0",
@@ -42,15 +42,15 @@
     "tsconfig-paths": "^4.1.1",
     "ts-node": ">=10.6.0",
     "tstl": "^2.5.13",
-    "typia": "^5.4.5"
+    "typia": "^5.4.12"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">=2.5.9",
+    "@nestia/fetcher": ">=2.5.10",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "reflect-metadata": ">=0.1.12",
     "ts-node": ">=10.6.0",
-    "typia": ">=5.4.5 <6.0.0"
+    "typia": ">=5.4.12 <6.0.0"
   },
   "devDependencies": {
     "@nestia/e2e": "^0.4.1",

--- a/packages/sdk/src/generates/SwaggerGenerator.ts
+++ b/packages/sdk/src/generates/SwaggerGenerator.ts
@@ -354,11 +354,11 @@ export namespace SwaggerGenerator {
         const [explicit] = getJsDocTexts("summary");
         if (explicit?.length) return explicit;
 
-        const index: number = description.indexOf(".");
-        if (index <= 0) return undefined;
-
-        const str: string = description.substring(0, index).trim();
-        return str.length && str.includes("\n") === false ? str : undefined;
+        const index: number = description.indexOf("\n");
+        const top: string = (
+          index === -1 ? description : description.substring(0, index)
+        ).trim();
+        return top.endsWith(".") ? top.substring(0, top.length - 1) : undefined;
       })();
       const deprecated = route.jsDocTags.find(
         (tag) => tag.name === "deprecated",

--- a/test/features/all/nestia.config.ts
+++ b/test/features/all/nestia.config.ts
@@ -11,6 +11,7 @@ export const NESTIA_CONFIG: INestiaConfig = {
         type: "apiKey",
       },
     },
+    beautify: true,
   },
 };
 export default NESTIA_CONFIG;

--- a/test/features/all/src/api/functional/all/index.ts
+++ b/test/features/all/src/api/functional/all/index.ts
@@ -12,6 +12,8 @@ import type { IBbsArticle } from "../../structures/IBbsArticle";
 /**
  * Store an article.
  *
+ * Create an article, and returns it.
+ *
  * @param input Content to store
  * @returns Newly archived article
  * @author Samchon

--- a/test/features/all/src/controllers/AllController.ts
+++ b/test/features/all/src/controllers/AllController.ts
@@ -9,6 +9,8 @@ export class AllController {
   /**
    * Store an article.
    *
+   * Create an article, and returns it.
+   *
    * @param request Request object from express. Must be disappeared in SDK
    * @param input Content to store
    * @returns Newly archived article

--- a/test/features/all/swagger.json
+++ b/test/features/all/swagger.json
@@ -1,1 +1,313 @@
-{"openapi":"3.0.1","servers":[{"url":"https://github.com/samchon/nestia","description":"insert your server url"}],"info":{"version":"2.5.8","title":"@nestia/test","description":"Test program of Nestia","license":{"name":"MIT"}},"paths":{"/all":{"post":{"tags":[],"parameters":[],"requestBody":{"description":"Content to store","content":{"application/json":{"schema":{"$ref":"#/components/schemas/IBbsArticle.IStore"}}},"required":true},"responses":{"201":{"description":"Newly archived article","content":{"application/json":{"schema":{"$ref":"#/components/schemas/IBbsArticle"}}}}},"summary":"Store an article","description":"Store an article."}},"/health":{"get":{"tags":[],"parameters":[],"responses":{"200":{"description":""}}}},"/performance":{"get":{"tags":[],"parameters":[],"responses":{"200":{"description":"","content":{"application/json":{"schema":{"$ref":"#/components/schemas/IPerformance"}}}}}}}},"components":{"schemas":{"IBbsArticle.IStore":{"type":"object","properties":{"title":{"type":"string","maxLength":50,"minLength":3},"body":{"type":"string"},"files":{"type":"array","items":{"$ref":"#/components/schemas/IAttachmentFile"}}},"nullable":false,"required":["title","body","files"]},"IAttachmentFile":{"type":"object","properties":{"name":{"type":"string","maxLength":255,"nullable":true},"extension":{"type":"string","maxLength":8,"minLength":1,"nullable":true},"url":{"type":"string","format":"uri"}},"nullable":false,"required":["name","extension","url"]},"IBbsArticle":{"type":"object","properties":{"id":{"type":"string","format":"uuid"},"created_at":{"type":"string","format":"date-time"},"title":{"type":"string","maxLength":50,"minLength":3},"body":{"type":"string"},"files":{"type":"array","items":{"$ref":"#/components/schemas/IAttachmentFile"}}},"nullable":false,"required":["id","created_at","title","body","files"]},"IPerformance":{"type":"object","properties":{"cpu":{"$ref":"#/components/schemas/process.global.NodeJS.CpuUsage"},"memory":{"$ref":"#/components/schemas/process.global.NodeJS.MemoryUsage"},"resource":{"$ref":"#/components/schemas/process.global.NodeJS.ResourceUsage"}},"nullable":false,"required":["cpu","memory","resource"],"description":"Performance info."},"process.global.NodeJS.CpuUsage":{"type":"object","properties":{"user":{"type":"number"},"system":{"type":"number"}},"nullable":false,"required":["user","system"]},"process.global.NodeJS.MemoryUsage":{"type":"object","properties":{"rss":{"type":"number"},"heapTotal":{"type":"number"},"heapUsed":{"type":"number"},"external":{"type":"number"},"arrayBuffers":{"type":"number"}},"nullable":false,"required":["rss","heapTotal","heapUsed","external","arrayBuffers"]},"process.global.NodeJS.ResourceUsage":{"type":"object","properties":{"fsRead":{"type":"number"},"fsWrite":{"type":"number"},"involuntaryContextSwitches":{"type":"number"},"ipcReceived":{"type":"number"},"ipcSent":{"type":"number"},"majorPageFault":{"type":"number"},"maxRSS":{"type":"number"},"minorPageFault":{"type":"number"},"sharedMemorySize":{"type":"number"},"signalsCount":{"type":"number"},"swappedOut":{"type":"number"},"systemCPUTime":{"type":"number"},"unsharedDataSize":{"type":"number"},"unsharedStackSize":{"type":"number"},"userCPUTime":{"type":"number"},"voluntaryContextSwitches":{"type":"number"}},"nullable":false,"required":["fsRead","fsWrite","involuntaryContextSwitches","ipcReceived","ipcSent","majorPageFault","maxRSS","minorPageFault","sharedMemorySize","signalsCount","swappedOut","systemCPUTime","unsharedDataSize","unsharedStackSize","userCPUTime","voluntaryContextSwitches"]}},"securitySchemes":{"bearer":{"type":"apiKey","in":"header","name":"Authorization"}}}}
+{
+  "openapi": "3.0.1",
+  "servers": [
+    {
+      "url": "https://github.com/samchon/nestia",
+      "description": "insert your server url"
+    }
+  ],
+  "info": {
+    "version": "2.5.10",
+    "title": "@nestia/test",
+    "description": "Test program of Nestia",
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "paths": {
+    "/all": {
+      "post": {
+        "tags": [],
+        "parameters": [],
+        "requestBody": {
+          "description": "Content to store",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IBbsArticle.IStore"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Newly archived article",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IBbsArticle"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Store an article",
+        "description": "Store an article.\n\nCreate an article, and returns it."
+      }
+    },
+    "/health": {
+      "get": {
+        "tags": [],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/performance": {
+      "get": {
+        "tags": [],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IPerformance"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "IBbsArticle.IStore": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "maxLength": 50,
+            "minLength": 3
+          },
+          "body": {
+            "type": "string"
+          },
+          "files": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IAttachmentFile"
+            }
+          }
+        },
+        "nullable": false,
+        "required": [
+          "title",
+          "body",
+          "files"
+        ]
+      },
+      "IAttachmentFile": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 255,
+            "nullable": true
+          },
+          "extension": {
+            "type": "string",
+            "maxLength": 8,
+            "minLength": 1,
+            "nullable": true
+          },
+          "url": {
+            "type": "string",
+            "format": "uri"
+          }
+        },
+        "nullable": false,
+        "required": [
+          "name",
+          "extension",
+          "url"
+        ]
+      },
+      "IBbsArticle": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string",
+            "maxLength": 50,
+            "minLength": 3
+          },
+          "body": {
+            "type": "string"
+          },
+          "files": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IAttachmentFile"
+            }
+          }
+        },
+        "nullable": false,
+        "required": [
+          "id",
+          "created_at",
+          "title",
+          "body",
+          "files"
+        ]
+      },
+      "IPerformance": {
+        "type": "object",
+        "properties": {
+          "cpu": {
+            "$ref": "#/components/schemas/process.global.NodeJS.CpuUsage"
+          },
+          "memory": {
+            "$ref": "#/components/schemas/process.global.NodeJS.MemoryUsage"
+          },
+          "resource": {
+            "$ref": "#/components/schemas/process.global.NodeJS.ResourceUsage"
+          }
+        },
+        "nullable": false,
+        "required": [
+          "cpu",
+          "memory",
+          "resource"
+        ],
+        "description": "Performance info."
+      },
+      "process.global.NodeJS.CpuUsage": {
+        "type": "object",
+        "properties": {
+          "user": {
+            "type": "number"
+          },
+          "system": {
+            "type": "number"
+          }
+        },
+        "nullable": false,
+        "required": [
+          "user",
+          "system"
+        ]
+      },
+      "process.global.NodeJS.MemoryUsage": {
+        "type": "object",
+        "properties": {
+          "rss": {
+            "type": "number"
+          },
+          "heapTotal": {
+            "type": "number"
+          },
+          "heapUsed": {
+            "type": "number"
+          },
+          "external": {
+            "type": "number"
+          },
+          "arrayBuffers": {
+            "type": "number"
+          }
+        },
+        "nullable": false,
+        "required": [
+          "rss",
+          "heapTotal",
+          "heapUsed",
+          "external",
+          "arrayBuffers"
+        ]
+      },
+      "process.global.NodeJS.ResourceUsage": {
+        "type": "object",
+        "properties": {
+          "fsRead": {
+            "type": "number"
+          },
+          "fsWrite": {
+            "type": "number"
+          },
+          "involuntaryContextSwitches": {
+            "type": "number"
+          },
+          "ipcReceived": {
+            "type": "number"
+          },
+          "ipcSent": {
+            "type": "number"
+          },
+          "majorPageFault": {
+            "type": "number"
+          },
+          "maxRSS": {
+            "type": "number"
+          },
+          "minorPageFault": {
+            "type": "number"
+          },
+          "sharedMemorySize": {
+            "type": "number"
+          },
+          "signalsCount": {
+            "type": "number"
+          },
+          "swappedOut": {
+            "type": "number"
+          },
+          "systemCPUTime": {
+            "type": "number"
+          },
+          "unsharedDataSize": {
+            "type": "number"
+          },
+          "unsharedStackSize": {
+            "type": "number"
+          },
+          "userCPUTime": {
+            "type": "number"
+          },
+          "voluntaryContextSwitches": {
+            "type": "number"
+          }
+        },
+        "nullable": false,
+        "required": [
+          "fsRead",
+          "fsWrite",
+          "involuntaryContextSwitches",
+          "ipcReceived",
+          "ipcSent",
+          "majorPageFault",
+          "maxRSS",
+          "minorPageFault",
+          "sharedMemorySize",
+          "signalsCount",
+          "swappedOut",
+          "systemCPUTime",
+          "unsharedDataSize",
+          "unsharedStackSize",
+          "userCPUTime",
+          "voluntaryContextSwitches"
+        ]
+      }
+    },
+    "securitySchemes": {
+      "bearer": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "Authorization"
+      }
+    }
+  }
+}

--- a/test/features/app-routerModule/src/api/IConnection.ts
+++ b/test/features/app-routerModule/src/api/IConnection.ts
@@ -1,1 +1,0 @@
-export type { IConnection } from "@nestia/fetcher";

--- a/test/package.json
+++ b/test/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@nestia/test",
-  "version": "2.5.9",
+  "version": "2.5.10",
   "description": "Test program of Nestia",
   "main": "index.js",
   "scripts": {
@@ -26,7 +26,7 @@
   },
   "homepage": "https://nestia.io",
   "devDependencies": {
-    "@nestia/sdk": "^2.5.9",
+    "@nestia/sdk": "^2.5.10",
     "@nestjs/swagger": "^7.1.2",
     "@types/express": "^4.17.17",
     "@types/node": "20.11.16",
@@ -39,9 +39,9 @@
   },
   "dependencies": {
     "@fastify/multipart": "^8.1.0",
-    "@nestia/core": "^2.5.9",
+    "@nestia/core": "^2.5.10",
     "@nestia/e2e": "^0.3.6",
-    "@nestia/fetcher": "^2.5.9",
+    "@nestia/fetcher": "^2.5.10",
     "@nestjs/common": "^10.3.0",
     "@nestjs/core": "^10.3.0",
     "@nestjs/platform-express": "^10.3.0",

--- a/website/pages/docs/sdk/sdk.mdx
+++ b/website/pages/docs/sdk/sdk.mdx
@@ -1251,7 +1251,7 @@ Also, if your SDK library utilize special alias `paths`, you also need to custom
   },
   "dependencies": {
     "@nestia/fetcher": "^2.3.4",
-    "typia": "^5.4.5"
+    "typia": "^5.4.12"
   },
   "files": [
     "lib",


### PR DESCRIPTION
When dot character is not placed on the last position of the first line, `@nestia/sdk` could not catch it exactly.

This PR fixes the problem, so that inference the exact `summary` property of the swagger endpoint data.
