### PR TITLE
Simplify `PlainFetcher` and `EncryptedFetcher`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@nestia/station",
-  "version": "2.5.13",
+  "version": "2.5.14",
   "description": "Nestia station",
   "main": "prettier.config.js",
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/core",
-  "version": "2.5.13",
+  "version": "2.5.14",
   "description": "Super-fast validation decorators of NestJS",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -36,7 +36,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^2.5.13",
+    "@nestia/fetcher": "^2.5.14",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "detect-ts-node": "^1.0.5",
@@ -48,7 +48,7 @@
     "typia": "^5.4.12"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">=2.5.13",
+    "@nestia/fetcher": ">=2.5.14",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "reflect-metadata": ">=0.1.12",

--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/fetcher",
-  "version": "2.5.13",
+  "version": "2.5.14",
   "description": "Fetcher library of Nestia SDK",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/fetcher/src/EncryptedFetcher.ts
+++ b/packages/fetcher/src/EncryptedFetcher.ts
@@ -2,7 +2,6 @@ import { AesPkcs5 } from "./AesPkcs5";
 import { IConnection } from "./IConnection";
 import { IEncryptionPassword } from "./IEncryptionPassword";
 import { IPropagation } from "./IPropagation";
-import { Primitive } from "./Primitive";
 import { FetcherBase } from "./internal/FetcherBase";
 import { IFetchRoute } from "./internal/IFetchRoute";
 
@@ -43,7 +42,7 @@ export namespace EncryptedFetcher {
   export function fetch<Output>(
     connection: IConnection,
     route: IFetchRoute<"GET">,
-  ): Promise<Primitive<Output>>;
+  ): Promise<Output>;
 
   /**
    * Fetch function for the `POST`, `PUT`, `PATCH` and `DELETE` methods.
@@ -57,14 +56,14 @@ export namespace EncryptedFetcher {
     route: IFetchRoute<"POST" | "PUT" | "PATCH" | "DELETE">,
     input?: Input,
     stringify?: (input: Input) => string,
-  ): Promise<Primitive<Output>>;
+  ): Promise<Output>;
 
   export async function fetch<Input, Output>(
     connection: IConnection,
     route: IFetchRoute<"DELETE" | "GET" | "HEAD" | "PATCH" | "POST" | "PUT">,
     input?: Input,
     stringify?: (input: Input) => string,
-  ): Promise<Primitive<Output>> {
+  ): Promise<Output> {
     if (
       (route.request?.encrypted === true || route.response?.encrypted) &&
       connection.encryption === undefined

--- a/packages/fetcher/src/PlainFetcher.ts
+++ b/packages/fetcher/src/PlainFetcher.ts
@@ -1,6 +1,5 @@
 import { IConnection } from "./IConnection";
 import { IPropagation } from "./IPropagation";
-import { Primitive } from "./Primitive";
 import { FetcherBase } from "./internal/FetcherBase";
 import { IFetchRoute } from "./internal/IFetchRoute";
 
@@ -42,7 +41,7 @@ export namespace PlainFetcher {
   export function fetch<Output>(
     connection: IConnection,
     route: IFetchRoute<"GET">,
-  ): Promise<Primitive<Output>>;
+  ): Promise<Output>;
 
   /**
    * Fetch function for the `POST`, `PUT`, `PATCH` and `DELETE` methods.
@@ -56,14 +55,14 @@ export namespace PlainFetcher {
     route: IFetchRoute<"POST" | "PUT" | "PATCH" | "DELETE">,
     input?: Input,
     stringify?: (input: Input) => string,
-  ): Promise<Primitive<Output>>;
+  ): Promise<Output>;
 
   export async function fetch<Input, Output>(
     connection: IConnection,
     route: IFetchRoute<"DELETE" | "GET" | "HEAD" | "PATCH" | "POST" | "PUT">,
     input?: Input,
     stringify?: (input: Input) => string,
-  ): Promise<Primitive<Output>> {
+  ): Promise<Output> {
     if (route.request?.encrypted === true || route.response?.encrypted === true)
       throw new Error(
         "Error on PlainFetcher.fetch(): PlainFetcher doesn't have encryption ability. Use EncryptedFetcher instead.",

--- a/packages/fetcher/src/internal/FetcherBase.ts
+++ b/packages/fetcher/src/internal/FetcherBase.ts
@@ -3,7 +3,6 @@ import import2 from "import2";
 import { HttpError } from "../HttpError";
 import { IConnection } from "../IConnection";
 import { IPropagation } from "../IPropagation";
-import { Primitive } from "../Primitive";
 import { IFetchRoute } from "./IFetchRoute";
 import { Singleton } from "./Singleton";
 
@@ -27,7 +26,7 @@ export namespace FetcherBase {
       route: IFetchRoute<"DELETE" | "GET" | "HEAD" | "PATCH" | "POST" | "PUT">,
       input?: Input,
       stringify?: (input: Input) => string,
-    ): Promise<Primitive<Output>> => {
+    ): Promise<Output> => {
       const result = await _Propagate("fetch")(props)(
         connection,
         route,
@@ -42,7 +41,7 @@ export namespace FetcherBase {
           result.headers,
           result.data as string,
         );
-      return result.data as Primitive<Output>;
+      return result.data as Output;
     };
 
   export const propagate =

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/sdk",
-  "version": "2.5.13",
+  "version": "2.5.14",
   "description": "Nestia SDK and Swagger generator",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -32,7 +32,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^2.5.13",
+    "@nestia/fetcher": "^2.5.14",
     "cli": "^1.0.1",
     "get-function-location": "^2.0.0",
     "glob": "^7.2.0",
@@ -45,7 +45,7 @@
     "typia": "^5.4.12"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">=2.5.13",
+    "@nestia/fetcher": ">=2.5.14",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "reflect-metadata": ">=0.1.12",

--- a/test/package.json
+++ b/test/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@nestia/test",
-  "version": "2.5.13",
+  "version": "2.5.14",
   "description": "Test program of Nestia",
   "main": "index.js",
   "scripts": {
@@ -26,7 +26,7 @@
   },
   "homepage": "https://nestia.io",
   "devDependencies": {
-    "@nestia/sdk": "^2.5.13",
+    "@nestia/sdk": "^2.5.14",
     "@nestjs/swagger": "^7.1.2",
     "@types/express": "^4.17.17",
     "@types/node": "20.11.16",
@@ -39,9 +39,9 @@
   },
   "dependencies": {
     "@fastify/multipart": "^8.1.0",
-    "@nestia/core": "^2.5.13",
+    "@nestia/core": "^2.5.14",
     "@nestia/e2e": "^0.3.6",
-    "@nestia/fetcher": "^2.5.13",
+    "@nestia/fetcher": "^2.5.14",
     "@nestjs/common": "^10.3.0",
     "@nestjs/core": "^10.3.0",
     "@nestjs/platform-express": "^10.3.0",


### PR DESCRIPTION
Current `PlainFetcher` and `EncryptedFetcher` of `@nestia/fetcher` is wrapping return type to `Primitive` type.

By the way, actual return type of some controller method is complicate and the complicate type being exported to the SDK library, the `Primitive` type can make IDE slower.

This PR avoids such situation, by removing the `Primitive` type from both `PlainFetcher` and `EncryptedFetcher`.
