### PR TITLE
feat: add wrapper parameters

### DIFF
--- a/packages/e2e/src/DynamicExecutor.ts
+++ b/packages/e2e/src/DynamicExecutor.ts
@@ -68,7 +68,11 @@ export namespace DynamicExecutor {
      * @param closure Function to be executed
      * @returns Wrapper function
      */
-    wrapper?: (name: string, closure: Closure<Parameters, Ret>) => Promise<any>;
+    wrapper?: (
+      name: string,
+      closure: Closure<Parameters, Ret>,
+      paramters: Parameters,
+    ) => Promise<any>;
 
     /**
      * Whether to show elapsed time on `console` or not.
@@ -228,7 +232,7 @@ export namespace DynamicExecutor {
 
         const func = async () => {
           if (options.wrapper !== undefined)
-            await options.wrapper(key, closure);
+            await options.wrapper(key, closure, options.parameters(key));
           else await closure(...options.parameters(key));
         };
         const label: string = chalk.greenBright(key);

--- a/packages/e2e/src/DynamicExecutor.ts
+++ b/packages/e2e/src/DynamicExecutor.ts
@@ -66,7 +66,7 @@ export namespace DynamicExecutor {
      *
      * @param name Function name
      * @param closure Function to be executed
-     * @param parameters Parameters that get from options.parameters function.
+     * @param parameters Parameters, result of options.parameters function.
      * @returns Wrapper function
      */
     wrapper?: (

--- a/packages/e2e/src/DynamicExecutor.ts
+++ b/packages/e2e/src/DynamicExecutor.ts
@@ -66,6 +66,7 @@ export namespace DynamicExecutor {
      *
      * @param name Function name
      * @param closure Function to be executed
+     * @param parameters Parameters that get from options.parameters function.
      * @returns Wrapper function
      */
     wrapper?: (


### PR DESCRIPTION
in last version, nestia e2e wrapper can't use options.parameters function (but parameters function is required)

so, it is more good that wrapper function get options.parameters at 3rd function parameters.
