### PR TITLE
Make compatible with https://esm.sh

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@nestia/station",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Nestia station",
   "main": "prettier.config.js",
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/core",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Super-fast validation decorators of NestJS",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -36,7 +36,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^2.6.1",
+    "@nestia/fetcher": "^2.6.2",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "detect-ts-node": "^1.0.5",
@@ -48,7 +48,7 @@
     "typia": "^5.5.7"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">=2.6.1",
+    "@nestia/fetcher": ">=2.6.2",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "reflect-metadata": ">=0.1.12",

--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/fetcher",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Fetcher library of Nestia SDK",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/fetcher/src/internal/FetcherBase.ts
+++ b/packages/fetcher/src/internal/FetcherBase.ts
@@ -201,16 +201,22 @@ export namespace FetcherBase {
  * @internal
  */
 const polyfill = new Singleton(async (): Promise<typeof fetch> => {
-  if (
-    typeof global === "object" &&
-    typeof global.process === "object" &&
-    typeof global.process.versions === "object" &&
-    typeof global.process.versions.node !== undefined
-  ) {
-    global.fetch ??= ((await import2("node-fetch")) as any).default;
-    return (global as any).fetch;
+  function is_node_process(m: typeof global | null): boolean {
+    return (
+      m !== null &&
+      typeof m.process === "object" &&
+      m.process !== null &&
+      typeof m.process.versions === "object" &&
+      m.process.versions !== null &&
+      typeof m.process.versions.node !== "undefined"
+    );
   }
-  return window.fetch;
+  if (typeof global === "object" && is_node_process(global)) {
+    const m: any = global as any;
+    m.fetch ??= ((await import2("node-fetch")) as any).default;
+    return (m as any).fetch;
+  }
+  return self.fetch;
 });
 
 /**

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/migrate",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "Migration program from swagger to NestJS",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/sdk",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Nestia SDK and Swagger generator",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -32,7 +32,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^2.6.1",
+    "@nestia/fetcher": "^2.6.2",
     "cli": "^1.0.1",
     "get-function-location": "^2.0.0",
     "glob": "^7.2.0",
@@ -45,7 +45,7 @@
     "typia": "^5.5.7"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">=2.6.1",
+    "@nestia/fetcher": ">=2.6.2",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "reflect-metadata": ">=0.1.12",

--- a/test/features/app-globalPrefix/src/api/HttpError.ts
+++ b/test/features/app-globalPrefix/src/api/HttpError.ts
@@ -1,1 +1,0 @@
-export { HttpError } from "@nestia/fetcher";

--- a/test/package.json
+++ b/test/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@nestia/test",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Test program of Nestia",
   "main": "index.js",
   "scripts": {
@@ -26,7 +26,7 @@
   },
   "homepage": "https://nestia.io",
   "devDependencies": {
-    "@nestia/sdk": "^2.6.1",
+    "@nestia/sdk": "^2.6.2",
     "@nestjs/swagger": "^7.1.2",
     "@types/express": "^4.17.17",
     "@types/node": "20.11.16",
@@ -39,9 +39,9 @@
   },
   "dependencies": {
     "@fastify/multipart": "^8.1.0",
-    "@nestia/core": "^2.6.1",
+    "@nestia/core": "^2.6.2",
     "@nestia/e2e": "^0.3.6",
-    "@nestia/fetcher": "^2.6.1",
+    "@nestia/fetcher": "^2.6.2",
     "@nestjs/common": "^10.3.5",
     "@nestjs/core": "^10.3.5",
     "@nestjs/platform-express": "^10.3.5",


### PR DESCRIPTION
I'm making a cloud playground website that can import any library registered in the NPM registry with `esm.sh`.

By the way, as `esm.sh` has been published for `deno`, it is not possible to import `NodeJS` built-in libraries.

In such reason, this PR removes every direct import statements to the NodeJS built-in libraries, and performed indirect import through `import2` library, so that bundler cannot merge them.
