### PR TITLE
Erase ISwaggerComponents["x-nestia-namespace"] property.

### DIFF
--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/migrate",
-  "version": "0.11.7",
+  "version": "0.12.0",
   "description": "Migration program from swagger to NestJS",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/migrate/src/programmers/MigrateSchemaProgrammer.ts
+++ b/packages/migrate/src/programmers/MigrateSchemaProgrammer.ts
@@ -40,7 +40,7 @@ export namespace MigrateSchemaProgrammer {
         else if (SwaggerTypeChecker.isObject(schema))
           return writeObject(components)(importer)(schema);
         else if (SwaggerTypeChecker.isReference(schema))
-          return writeReference(components)(importer)(schema);
+          return writeReference(importer)(schema);
         // NESTED UNION
         else if (SwaggerTypeChecker.isAnyOf(schema))
           return writeUnion(components)(importer)(schema.anyOf);
@@ -229,7 +229,6 @@ export namespace MigrateSchemaProgrammer {
       );
 
   const writeReference =
-    (components: ISwaggerComponents) =>
     (importer: MigrateImportProgrammer) =>
     (
       schema: ISwaggerSchema.IReference,
@@ -239,10 +238,7 @@ export namespace MigrateSchemaProgrammer {
       const name: string = schema.$ref.split("/").at(-1)!;
       return name === ""
         ? TypeFactory.keyword("any")
-        : importer.dto(
-            schema.$ref.split("/").at(-1)!,
-            components["x-nestia-namespace"],
-          );
+        : importer.dto(schema.$ref.split("/").at(-1)!);
     };
 
   /* -----------------------------------------------------------

--- a/packages/migrate/src/structures/ISwaggerComponents.ts
+++ b/packages/migrate/src/structures/ISwaggerComponents.ts
@@ -10,5 +10,4 @@ export interface ISwaggerComponents {
   responses?: Record<string, ISwaggerRouteResponse>;
   schemas?: Record<string, ISwaggerSchema>;
   securitySchemes?: Record<string, ISwaggerSecurityScheme>;
-  "x-nestia-namespace"?: string;
 }

--- a/website/package.json
+++ b/website/package.json
@@ -23,7 +23,7 @@
     "@mui/icons-material": "5.15.6",
     "@mui/material": "5.15.6",
     "@mui/system": "5.15.6",
-    "@nestia/migrate": "^0.11.7",
+    "@nestia/migrate": "^0.12.0",
     "@stackblitz/sdk": "^1.9.0",
     "js-yaml": "^4.1.0",
     "next": "14.1.0",


### PR DESCRIPTION
It no more need from the 3rd party application, and even duplicated with `@nestia/sdk` and @nestia/migrate`.
