### PR TITLE
Fix #862: `@TypedFormData.Body()` in `fastify`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@nestia/station",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Nestia station",
   "scripts": {
     "build": "node build/index.js",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -18,8 +18,8 @@ Nestia is a set of helper libraries for NestJS, supporting below features:
     - SDK library generator for clients
     - Mockup Simulator for client applications
     - Automatic E2E test functions generator
-  - `@nestia/migrate`: Migration from Swagger to NestJS
-  - `@nestia/editor`: Online TypeScript Swagger Editor
+  - `@nestia/migrate`: OpenAPI generator from Swagger to NestJS
+  - `@nestia/editor`: Swagger-UI with Online TypeScript Editor
   - `nestia`: Just CLI (command line interface) tool
 
 > **Note**

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/core",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Super-fast validation decorators of NestJS",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -36,7 +36,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "D:\\github\\samchon\\nestia\\packages\\fetcher\\nestia-fetcher-3.1.1.tgz",
+    "@nestia/fetcher": "^3.1.2",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "@samchon/openapi": "^0.1.21",
@@ -52,7 +52,7 @@
     "ws": "^7.5.3"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">=3.1.1",
+    "@nestia/fetcher": ">=3.1.2",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "reflect-metadata": ">=0.1.12",

--- a/packages/fetcher/README.md
+++ b/packages/fetcher/README.md
@@ -18,8 +18,8 @@ Nestia is a set of helper libraries for NestJS, supporting below features:
     - SDK library generator for clients
     - Mockup Simulator for client applications
     - Automatic E2E test functions generator
-  - `@nestia/migrate`: Migration from Swagger to NestJS
-  - `@nestia/editor`: Online TypeScript Swagger Editor
+  - `@nestia/migrate`: OpenAPI generator from Swagger to NestJS
+  - `@nestia/editor`: Swagger-UI with Online TypeScript Editor
   - `nestia`: Just CLI (command line interface) tool
 
 > **Note**

--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/fetcher",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Fetcher library of Nestia SDK",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -18,8 +18,8 @@ Nestia is a set of helper libraries for NestJS, supporting below features:
     - SDK library generator for clients
     - Mockup Simulator for client applications
     - Automatic E2E test functions generator
-  - `@nestia/migrate`: Migration from Swagger to NestJS
-  - `@nestia/editor`: Online TypeScript Swagger Editor
+  - `@nestia/migrate`: OpenAPI generator from Swagger to NestJS
+  - `@nestia/editor`: Swagger-UI with Online TypeScript Editor
   - `nestia`: Just CLI (command line interface) tool
 
 > **Note**

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/sdk",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Nestia SDK and Swagger generator",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -32,7 +32,7 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "D:\\github\\samchon\\nestia\\packages\\fetcher\\nestia-fetcher-3.1.1.tgz",
+    "@nestia/fetcher": "^3.1.2",
     "@samchon/openapi": "^0.1.21",
     "cli": "^1.0.1",
     "get-function-location": "^2.0.0",
@@ -46,7 +46,7 @@
     "typia": "^6.0.3"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">=3.1.1",
+    "@nestia/fetcher": ">=3.1.2",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "reflect-metadata": ">=0.1.12",

--- a/test/features/multipart-form-data-fastify/src/api/structures/IMultipart.ts
+++ b/test/features/multipart-form-data-fastify/src/api/structures/IMultipart.ts
@@ -1,6 +1,9 @@
 export interface IMultipart {
+  title: string;
   blob: Blob;
   blobs: Blob[];
+  description: null | string;
   file: File;
   files: File[];
+  notes?: string[];
 }

--- a/test/features/multipart-form-data-fastify/src/test/features/api/test_api_multipart.ts
+++ b/test/features/multipart-form-data-fastify/src/test/features/api/test_api_multipart.ts
@@ -4,13 +4,16 @@ export const test_api_multipart = async (
   connection: api.IConnection,
 ): Promise<void> => {
   await api.functional.multipart.post(connection, {
+    title: "something",
     blob: new Blob([new Uint8Array(999).fill(0)]),
     blobs: new Array(10)
       .fill(0)
       .map((_, i) => new Blob([new Uint8Array(999).fill(i)])),
+    description: "nothing",
     file: new File([new Uint8Array(999).fill(1)], "first.png"),
     files: new Array(10)
       .fill(0)
       .map((_, i) => new File([new Uint8Array(999).fill(i)], `${i}.png`)),
+    notes: ["note1", "note2"],
   });
 };

--- a/test/features/multipart-form-data-fastify/swagger.json
+++ b/test/features/multipart-form-data-fastify/swagger.json
@@ -7,7 +7,7 @@
     }
   ],
   "info": {
-    "version": "3.1.0-dev.20240426",
+    "version": "3.1.1",
     "title": "@nestia/test",
     "description": "Test program of Nestia",
     "license": {
@@ -71,6 +71,9 @@
       "IMultipart": {
         "type": "object",
         "properties": {
+          "title": {
+            "type": "string"
+          },
           "blob": {
             "type": "string",
             "format": "binary"
@@ -82,6 +85,16 @@
               "format": "binary"
             }
           },
+          "description": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
           "file": {
             "type": "string",
             "format": "binary"
@@ -92,11 +105,19 @@
               "type": "string",
               "format": "binary"
             }
+          },
+          "notes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "required": [
+          "title",
           "blob",
           "blobs",
+          "description",
           "file",
           "files"
         ]

--- a/test/features/multipart-form-data/src/api/structures/IMultipart.ts
+++ b/test/features/multipart-form-data/src/api/structures/IMultipart.ts
@@ -1,6 +1,9 @@
 export interface IMultipart {
+  title: string;
   blob: Blob;
   blobs: Blob[];
+  description: null | string;
   file: File;
   files: File[];
+  notes?: string[];
 }

--- a/test/features/multipart-form-data/src/test/features/api/test_api_multipart.ts
+++ b/test/features/multipart-form-data/src/test/features/api/test_api_multipart.ts
@@ -4,13 +4,16 @@ export const test_api_multipart = async (
   connection: api.IConnection,
 ): Promise<void> => {
   await api.functional.multipart.post(connection, {
+    title: "something",
     blob: new Blob([new Uint8Array(999).fill(0)]),
     blobs: new Array(10)
       .fill(0)
       .map((_, i) => new Blob([new Uint8Array(999).fill(i)])),
+    description: "nothing",
     file: new File([new Uint8Array(999).fill(1)], "first.png"),
     files: new Array(10)
       .fill(0)
       .map((_, i) => new File([new Uint8Array(999).fill(i)], `${i}.png`)),
+    notes: ["note1", "note2"],
   });
 };

--- a/test/features/multipart-form-data/swagger.json
+++ b/test/features/multipart-form-data/swagger.json
@@ -7,7 +7,7 @@
     }
   ],
   "info": {
-    "version": "3.1.0-dev.20240426",
+    "version": "3.1.1",
     "title": "@nestia/test",
     "description": "Test program of Nestia",
     "license": {
@@ -71,6 +71,9 @@
       "IMultipart": {
         "type": "object",
         "properties": {
+          "title": {
+            "type": "string"
+          },
           "blob": {
             "type": "string",
             "format": "binary"
@@ -82,6 +85,16 @@
               "format": "binary"
             }
           },
+          "description": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
           "file": {
             "type": "string",
             "format": "binary"
@@ -92,11 +105,19 @@
               "type": "string",
               "format": "binary"
             }
+          },
+          "notes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "required": [
+          "title",
           "blob",
           "blobs",
+          "description",
           "file",
           "files"
         ]

--- a/test/package.json
+++ b/test/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@nestia/test",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Test program of Nestia",
   "main": "index.js",
   "scripts": {
@@ -26,7 +26,7 @@
   },
   "homepage": "https://nestia.io",
   "devDependencies": {
-    "@nestia/sdk": "D:\\github\\samchon\\nestia\\packages\\sdk\\nestia-sdk-3.1.1.tgz",
+    "@nestia/sdk": "^3.1.2",
     "@nestjs/swagger": "^7.1.2",
     "@samchon/openapi": "^0.1.21",
     "@types/express": "^4.17.17",
@@ -40,9 +40,9 @@
   },
   "dependencies": {
     "@fastify/multipart": "^8.1.0",
-    "@nestia/core": "D:\\github\\samchon\\nestia\\packages\\core\\nestia-core-3.1.1.tgz",
+    "@nestia/core": "^3.1.2",
     "@nestia/e2e": "^0.3.6",
-    "@nestia/fetcher": "D:\\github\\samchon\\nestia\\packages\\fetcher\\nestia-fetcher-3.1.1.tgz",
+    "@nestia/fetcher": "^3.1.2",
     "@nestjs/common": "^10.3.5",
     "@nestjs/core": "^10.3.5",
     "@nestjs/platform-express": "^10.3.5",


### PR DESCRIPTION
When `@TypedFormData.Body()` being used with `fastify`, it could not compose non-binary properties.

It's because `@fastify/multipart` has totally different methodology, and I hadn't known it.

This PR fixes the bug, so that make non-binary properties to be propertly composed.
