### PR TITLE
Bump up `@samchon/openapi` version for `@SwaggerExample()`.

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -42,7 +42,7 @@
     "reflect-metadata": "^0.2.2",
     "tgrid": "^1.0.2",
     "tstl": "^3.0.0",
-    "typia": "^6.4.3"
+    "typia": "^6.5.0"
   },
   "devDependencies": {
     "@types/autocannon": "^7.9.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@nestia/station",
-  "version": "3.7.0-dev.20240712",
+  "version": "3.7.0",
   "description": "Nestia station",
   "scripts": {
     "build": "node build/index.js",

--- a/packages/benchmark/package.json
+++ b/packages/benchmark/package.json
@@ -34,7 +34,7 @@
     "ts-patch": "^3.2.1",
     "typescript": "^5.5.3",
     "typescript-transform-paths": "^3.4.7",
-    "typia": "^6.4.3",
+    "typia": "^6.5.0",
     "uuid": "^10.0.0"
   },
   "dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/core",
-  "version": "3.7.0-dev.20240712",
+  "version": "3.7.0",
   "description": "Super-fast validation decorators of NestJS",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -36,10 +36,10 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^3.7.0-dev.20240712",
+    "@nestia/fetcher": "^3.7.0",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
-    "@samchon/openapi": "^0.3.4",
+    "@samchon/openapi": "^0.4.1",
     "detect-ts-node": "^1.0.5",
     "get-function-location": "^2.0.0",
     "glob": "^7.2.0",
@@ -49,16 +49,16 @@
     "reflect-metadata": ">=0.1.12",
     "rxjs": ">=6.0.3",
     "tgrid": "^1.0.0",
-    "typia": "^6.4.3",
+    "typia": "^6.5.0",
     "ws": "^7.5.3"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">=3.7.0-dev.20240712",
+    "@nestia/fetcher": ">=3.7.0",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "reflect-metadata": ">=0.1.12",
     "rxjs": ">=6.0.3",
-    "typia": ">=6.4.3 <7.0.0"
+    "typia": ">=6.5.0 <7.0.0"
   },
   "devDependencies": {
     "@fastify/multipart": "^8.1.0",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -41,7 +41,7 @@
     "ts-patch": "^3.2.1",
     "typescript": "^5.5.3",
     "typescript-transform-paths": "^3.4.7",
-    "typia": "^6.4.3"
+    "typia": "^6.5.0"
   },
   "files": [
     "lib",

--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/fetcher",
-  "version": "3.7.0-dev.20240712",
+  "version": "3.7.0",
   "description": "Fetcher library of Nestia SDK",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -43,6 +43,6 @@
     "src"
   ],
   "dependencies": {
-    "@samchon/openapi": "^0.3.4"
+    "@samchon/openapi": "^0.4.1"
   }
 }

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -71,7 +71,7 @@
     "prettier": "^3.2.5",
     "tstl": "^3.0.0",
     "typescript": "^5.5.3",
-    "typia": "^6.4.3"
+    "typia": "^6.5.0"
   },
   "files": [
     "lib",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/sdk",
-  "version": "3.7.0-dev.20240712",
+  "version": "3.7.0",
   "description": "Nestia SDK and Swagger generator",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -32,9 +32,9 @@
   },
   "homepage": "https://nestia.io",
   "dependencies": {
-    "@nestia/fetcher": "^3.7.0-dev.20240712",
-    "@nestia/core": "^3.7.0-dev.20240712",
-    "@samchon/openapi": "^0.3.4",
+    "@nestia/fetcher": "^3.7.0",
+    "@nestia/core": "^3.7.0",
+    "@samchon/openapi": "^0.4.1",
     "cli": "^1.0.1",
     "get-function-location": "^2.0.0",
     "glob": "^7.2.0",
@@ -44,16 +44,16 @@
     "tsconfck": "^2.0.1",
     "tsconfig-paths": "^4.1.1",
     "tstl": "^3.0.0",
-    "typia": "^6.4.3"
+    "typia": "^6.5.0"
   },
   "peerDependencies": {
-    "@nestia/fetcher": ">=3.7.0-dev.20240712",
-    "@nestia/core": ">=3.7.0-dev.20240712",
+    "@nestia/fetcher": ">=3.7.0",
+    "@nestia/core": ">=3.7.0",
     "@nestjs/common": ">=7.0.1",
     "@nestjs/core": ">=7.0.1",
     "reflect-metadata": ">=0.1.12",
     "ts-node": ">=10.6.0",
-    "typia": ">=6.4.3 <7.0.0"
+    "typia": ">=6.5.0 <7.0.0"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",

--- a/test/features/distribute-assert-json/packages/api/package.json
+++ b/test/features/distribute-assert-json/packages/api/package.json
@@ -33,6 +33,6 @@
   },
   "dependencies": {
     "@nestia/fetcher": "^3.5.0",
-    "typia": "^6.4.3"
+    "typia": "^6.5.0"
   }
 }

--- a/test/features/distribute-assert/packages/api/package.json
+++ b/test/features/distribute-assert/packages/api/package.json
@@ -33,6 +33,6 @@
   },
   "dependencies": {
     "@nestia/fetcher": "^3.5.0",
-    "typia": "^6.4.3"
+    "typia": "^6.5.0"
   }
 }

--- a/test/features/distribute-json/packages/api/package.json
+++ b/test/features/distribute-json/packages/api/package.json
@@ -33,6 +33,6 @@
   },
   "dependencies": {
     "@nestia/fetcher": "^3.5.0",
-    "typia": "^6.4.3"
+    "typia": "^6.5.0"
   }
 }

--- a/test/features/distribute/packages/api/package.json
+++ b/test/features/distribute/packages/api/package.json
@@ -33,6 +33,6 @@
   },
   "dependencies": {
     "@nestia/fetcher": "^3.5.0",
-    "typia": "^6.4.3"
+    "typia": "^6.5.0"
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@samchon/nestia-test",
-  "version": "3.7.0-dev.20240712",
+  "version": "3.7.0",
   "description": "Test program of Nestia",
   "main": "index.js",
   "scripts": {
@@ -26,9 +26,9 @@
   },
   "homepage": "https://nestia.io",
   "devDependencies": {
-    "@nestia/sdk": "^3.7.0-dev.20240712",
+    "@nestia/sdk": "^3.7.0",
     "@nestjs/swagger": "^7.1.2",
-    "@samchon/openapi": "^0.3.4",
+    "@samchon/openapi": "^0.4.1",
     "@types/express": "^4.17.17",
     "@types/node": "20.11.16",
     "@types/uuid": "^9.0.8",
@@ -40,16 +40,16 @@
   },
   "dependencies": {
     "@fastify/multipart": "^8.1.0",
-    "@nestia/core": "^3.7.0-dev.20240712",
+    "@nestia/core": "^3.7.0",
     "@nestia/e2e": "^0.7.0",
-    "@nestia/fetcher": "^3.7.0-dev.20240712",
+    "@nestia/fetcher": "^3.7.0",
     "@nestjs/common": "^10.3.5",
     "@nestjs/core": "^10.3.5",
     "@nestjs/platform-express": "^10.3.5",
     "@nestjs/platform-fastify": "^10.3.5",
     "tgrid": "^1.0.2",
     "tstl": "^3.0.0",
-    "typia": "^6.4.3",
+    "typia": "^6.5.0",
     "uuid": "^9.0.1"
   }
 }


### PR DESCRIPTION
To support `@SwaggerExample()` in the type level - #954