### PR TITLE
Fix #1139: remove non-existing document link

### DIFF
--- a/website/pages/docs/sdk/swagger.mdx
+++ b/website/pages/docs/sdk/swagger.mdx
@@ -87,7 +87,7 @@ export default NESTIA_CONFIG;
 # BUILD SWAGGER DOCUUMET ONLY
 npx nestia swagger
 
-# BUILD SWAGGER/OPENAI/SDK/E2E AT THE SAME TIME
+# BUILD SWAGGER/SDK/E2E AT THE SAME TIME
 npx nestia all
 ```
   </Tab>
@@ -95,7 +95,7 @@ npx nestia all
 
 Otherwise you want to generate a swagger file by CLI (Command Line Interface), configure `nestia.config.ts` file and run the `npx nestia swagger` command. Then, `@nestia/sdk` will analyze your NestJS backend server code, and generate `swagger.json` file.
 
-When you want to build not only Swagger Document file, but also [OpenAI function calling schema](./openai), [SDK (Software Development Kit) library](./sdk) and [automated E2E (End-to-End) test functions](./e2e) at the same time, run `npx nestia all` command instead.
+When you want to build not only Swagger Document file, but also [SDK (Software Development Kit) library](./sdk) and [automated E2E (End-to-End) test functions](./e2e) at the same time, run `npx nestia all` command instead.
 
 
 


### PR DESCRIPTION
This pull request includes a minor update to the documentation in the `website/pages/docs/sdk/swagger.mdx` file. The change removes references to the OpenAI function calling schema in the command descriptions.

Documentation update:

* [`website/pages/docs/sdk/swagger.mdx`](diffhunk://#diff-eaca3d42c2f3f82134f28f4a6068a2b686a4521391149bba3a7993eb4ff02152L90-R98): Removed references to the OpenAI function calling schema in the command descriptions for building Swagger, SDK, and E2E test functions simultaneously.