### PR TITLE
fix(ci): use `lts/*` instead of 20.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: lts/*
       - uses: pnpm/action-setup@v2
         with:
           version: 8

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,11 +11,14 @@ on:
 jobs:
   Ubuntu:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20.x, 22.x, lts/*]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          node-version: ${{ matrix.node-version }}
       - uses: pnpm/action-setup@v2
         with:
           version: 8

--- a/.github/workflows/migrate.yaml
+++ b/.github/workflows/migrate.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: lts/*
       - uses: pnpm/action-setup@v2
         with:
           version: 8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: lts/*
           registry-url: https://registry.npmjs.org/
       - uses: pnpm/action-setup@v2
         with:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: lts/*
       - uses: pnpm/action-setup@v2
         with:
           version: 8


### PR DESCRIPTION
Related to https://github.com/samchon/typia/pull/1414

- use `lts` instead of node20
- use matrix for use multiple node version for test