### PR TITLE
Website playground button as menu

### DIFF
--- a/website/pages/_meta.js
+++ b/website/pages/_meta.js
@@ -13,7 +13,24 @@ export default {
   },
   playground: {
     title: "💻 Playground",
-    type: "page",
+    type: "menu",
+    items: {
+      boilerplate: {
+        title: "📦 Boilerplate",
+        href: "https://stackblitz.com/github/samchon/nestia-start?file=README.md&view=editor",
+        newWindow: true,
+      },
+      websocket: {
+        title: "📡 WebSocket",
+        href: "https://stackblitz.com/~/github.com/samchon/tgrid.example.nestjs?file=src/calculate.test.ts&view=editor",
+        newWindow: true,
+      },
+      chat: {
+        title: "📦 A.I. Chatbot",
+        href: "/chat/playground",
+        newWindow: true,
+      },
+    },
   },
   editor: {
     title: "🛠️ Nestia Editor",

--- a/website/pages/playground/index.mdx
+++ b/website/pages/playground/index.mdx
@@ -1,4 +1,0 @@
-<meta
-  http-equiv="refresh"
-  content="0; url=https://stackblitz.com/github/samchon/nestia-start?file=README.md&view=editor"
-/>


### PR DESCRIPTION
This pull request includes changes to enhance the `playground` section of the website. The main updates involve converting the `playground` type from a page to a menu and removing the automatic redirection from the `playground` index page.

Changes to `playground` section:

* [`website/pages/_meta.js`](diffhunk://#diff-54bc2d530749150030c3c846b56e6da49ed548e3523d5462ad8bd32ca608958dL16-R33): Changed the `playground` type from "page" to "menu" and added items for "Boilerplate", "WebSocket", and "A.I. Chatbot" with respective links that open in new windows.
* [`website/pages/playground/index.mdx`](diffhunk://#diff-98582dc10291b458365ec490c3f30d89034331e2ca84b5ae8d6203c77cc1e34aL1-L4): Removed the meta tag that automatically redirected the page to the "Boilerplate" link.