### PR TITLE
Re-writing chatbot page

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           version: 8
       - name: Root Setup
-        run: pnpm install && npm run build
+        run: pnpm install && pnpm run build
       - name: Build
         working-directory: website 
         run: npm install && npm run build

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,8 +75,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       typia:
-        specifier: ^8.0.0-dev.20250301
-        version: 8.0.0-dev.20250301(@samchon/openapi@3.0.0-dev.20250301)(typescript@5.7.3)
+        specifier: ^8.0.0
+        version: 8.0.0(@samchon/openapi@3.0.0)(typescript@5.8.2)
     devDependencies:
       '@types/autocannon':
         specifier: ^7.9.0
@@ -98,13 +98,13 @@ importers:
         version: 6.0.1
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(@types/node@20.11.16)(typescript@5.7.3)
+        version: 10.9.2(@types/node@20.11.16)(typescript@5.8.2)
       ts-patch:
         specifier: ^3.3.0
         version: 3.3.0
       typescript:
-        specifier: ~5.7.2
-        version: 5.7.3
+        specifier: ~5.8.2
+        version: 5.8.2
 
   packages/benchmark:
     dependencies:
@@ -144,19 +144,19 @@ importers:
         version: link:../cli
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.13.8)(typescript@5.7.3)
+        version: 10.9.2(@types/node@22.13.8)(typescript@5.8.2)
       ts-patch:
         specifier: ^3.3.0
         version: 3.3.0
       typescript:
-        specifier: ~5.7.2
-        version: 5.7.3
+        specifier: ~5.8.2
+        version: 5.8.2
       typescript-transform-paths:
         specifier: ^3.4.7
-        version: 3.5.3(typescript@5.7.3)
+        version: 3.5.3(typescript@5.8.2)
       typia:
-        specifier: ^8.0.0-dev.20250301
-        version: 8.0.0-dev.20250301(@samchon/openapi@3.0.0-dev.20250301)(typescript@5.7.3)
+        specifier: ^8.0.0
+        version: 8.0.0(@samchon/openapi@3.0.0)(typescript@5.8.2)
       uuid:
         specifier: ^10.0.0
         version: 10.0.0
@@ -192,8 +192,8 @@ importers:
         specifier: ^6.0.1
         version: 6.0.1
       typescript:
-        specifier: ~5.7.2
-        version: 5.7.3
+        specifier: ~5.8.2
+        version: 5.8.2
 
   packages/core:
     dependencies:
@@ -207,8 +207,8 @@ importers:
         specifier: '>=7.0.1'
         version: 11.0.11(@nestjs/common@11.0.11(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.0.11)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@samchon/openapi':
-        specifier: ^3.0.0-dev.20250301
-        version: 3.0.0-dev.20250301
+        specifier: ^3.0.0
+        version: 3.0.0
       detect-ts-node:
         specifier: ^1.0.5
         version: 1.0.5
@@ -234,8 +234,8 @@ importers:
         specifier: ^1.1.0
         version: 1.1.0
       typia:
-        specifier: ^8.0.0-dev.20250301
-        version: 8.0.0-dev.20250301(@samchon/openapi@3.0.0-dev.20250301)(typescript@5.7.3)
+        specifier: ^8.0.0
+        version: 8.0.0(@samchon/openapi@3.0.0)(typescript@5.8.2)
       ws:
         specifier: ^7.5.3
         version: 7.5.10
@@ -260,10 +260,10 @@ importers:
         version: 8.5.14
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.46.1
-        version: 5.62.0(@typescript-eslint/parser@5.62.0(eslint@9.21.0)(typescript@5.7.3))(eslint@9.21.0)(typescript@5.7.3)
+        version: 5.62.0(@typescript-eslint/parser@5.62.0(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(typescript@5.8.2)
       '@typescript-eslint/parser':
         specifier: ^5.46.1
-        version: 5.62.0(eslint@9.21.0)(typescript@5.7.3)
+        version: 5.62.0(eslint@9.21.0)(typescript@5.8.2)
       commander:
         specifier: ^10.0.0
         version: 10.0.0
@@ -272,7 +272,7 @@ importers:
         version: 4.2.5
       eslint-plugin-deprecation:
         specifier: ^1.4.1
-        version: 1.6.0(eslint@9.21.0)(typescript@5.7.3)
+        version: 1.6.0(eslint@9.21.0)(typescript@5.8.2)
       fastify:
         specifier: ^4.28.1
         version: 4.29.0
@@ -287,7 +287,7 @@ importers:
         version: 6.0.1
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(@types/node@22.13.8)(typescript@5.7.3)
+        version: 10.9.2(@types/node@22.13.8)(typescript@5.8.2)
       ts-patch:
         specifier: ^3.3.0
         version: 3.3.0
@@ -295,8 +295,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       typescript:
-        specifier: ~5.7.2
-        version: 5.7.3
+        specifier: ~5.8.2
+        version: 5.8.2
 
   packages/e2e:
     devDependencies:
@@ -308,28 +308,28 @@ importers:
         version: 18.19.78
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.57.0
-        version: 5.62.0(@typescript-eslint/parser@5.62.0(eslint@9.21.0)(typescript@5.7.3))(eslint@9.21.0)(typescript@5.7.3)
+        version: 5.62.0(@typescript-eslint/parser@5.62.0(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(typescript@5.8.2)
       '@typescript-eslint/parser':
         specifier: ^5.57.0
-        version: 5.62.0(eslint@9.21.0)(typescript@5.7.3)
+        version: 5.62.0(eslint@9.21.0)(typescript@5.8.2)
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(@types/node@18.19.78)(typescript@5.7.3)
+        version: 10.9.2(@types/node@18.19.78)(typescript@5.8.2)
       ts-patch:
         specifier: ^3.3.0
         version: 3.3.0
       typescript:
-        specifier: ~5.7.2
-        version: 5.7.3
+        specifier: ~5.8.2
+        version: 5.8.2
       typescript-transform-paths:
         specifier: ^3.4.7
-        version: 3.5.3(typescript@5.7.3)
+        version: 3.5.3(typescript@5.8.2)
       typia:
-        specifier: ^8.0.0-dev.20250301
-        version: 8.0.0-dev.20250301(@samchon/openapi@3.0.0-dev.20250301)(typescript@5.7.3)
+        specifier: ^8.0.0
+        version: 8.0.0(@samchon/openapi@3.0.0)(typescript@5.8.2)
 
   packages/editor:
     dependencies:
@@ -340,8 +340,8 @@ importers:
         specifier: workspace:^
         version: link:../migrate
       '@samchon/openapi':
-        specifier: ^3.0.0-dev.20250301
-        version: 3.0.0-dev.20250301
+        specifier: ^3.0.0
+        version: 3.0.0
       '@stackblitz/sdk':
         specifier: ^1.11.0
         version: 1.11.0
@@ -356,7 +356,7 @@ importers:
         version: 0.5.2(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@mui/icons-material@5.16.14(@mui/material@5.16.14(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@mui/material@5.16.14(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.18)(prop-types@15.8.1)
       typia:
         specifier: ^7.6.0
-        version: 7.6.4(@samchon/openapi@3.0.0-dev.20250301)(typescript@5.7.3)
+        version: 7.6.4(@samchon/openapi@3.0.0)(typescript@5.8.2)
     devDependencies:
       '@eslint/js':
         specifier: ^9.13.0
@@ -378,7 +378,7 @@ importers:
         version: 0.4.4(rollup@4.34.9)
       '@rollup/plugin-typescript':
         specifier: ^12.1.1
-        version: 12.1.2(rollup@4.34.9)(tslib@2.8.1)(typescript@5.7.3)
+        version: 12.1.2(rollup@4.34.9)(tslib@2.8.1)(typescript@5.8.2)
       '@types/js-yaml':
         specifier: ^4.0.9
         version: 4.0.9
@@ -417,13 +417,13 @@ importers:
         version: 4.34.9
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.13.8)(typescript@5.7.3)
+        version: 10.9.2(@types/node@22.13.8)(typescript@5.8.2)
       typescript:
-        specifier: ~5.7.2
-        version: 5.7.3
+        specifier: ~5.8.2
+        version: 5.8.2
       typescript-eslint:
         specifier: ^8.10.0
-        version: 8.25.0(eslint@9.21.0)(typescript@5.7.3)
+        version: 8.25.0(eslint@9.21.0)(typescript@5.8.2)
       vite:
         specifier: ^5.4.9
         version: 5.4.14(@types/node@22.13.8)(terser@5.39.0)
@@ -431,33 +431,33 @@ importers:
   packages/fetcher:
     dependencies:
       '@samchon/openapi':
-        specifier: ^3.0.0-dev.20250301
-        version: 3.0.0-dev.20250301
+        specifier: ^3.0.0
+        version: 3.0.0
       typia:
-        specifier: ^8.0.0-dev.20250301
-        version: 8.0.0-dev.20250301(@samchon/openapi@3.0.0-dev.20250301)(typescript@5.7.3)
+        specifier: ^8.0.0
+        version: 8.0.0(@samchon/openapi@3.0.0)(typescript@5.8.2)
     devDependencies:
       '@types/node':
         specifier: ^18.11.14
         version: 18.19.78
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.46.1
-        version: 5.62.0(@typescript-eslint/parser@5.62.0(eslint@9.21.0)(typescript@5.7.3))(eslint@9.21.0)(typescript@5.7.3)
+        version: 5.62.0(@typescript-eslint/parser@5.62.0(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(typescript@5.8.2)
       '@typescript-eslint/parser':
         specifier: ^5.46.1
-        version: 5.62.0(eslint@9.21.0)(typescript@5.7.3)
+        version: 5.62.0(eslint@9.21.0)(typescript@5.8.2)
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1
       typescript:
-        specifier: ~5.7.2
-        version: 5.7.3
+        specifier: ~5.8.2
+        version: 5.8.2
 
   packages/migrate:
     dependencies:
       '@samchon/openapi':
-        specifier: ^3.0.0-dev.20250301
-        version: 3.0.0-dev.20250301
+        specifier: ^3.0.0
+        version: 3.0.0
       commander:
         specifier: 10.0.0
         version: 10.0.0
@@ -471,11 +471,11 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       typescript:
-        specifier: ~5.7.2
-        version: 5.7.3
+        specifier: ~5.8.2
+        version: 5.8.2
       typia:
-        specifier: ^8.0.0-dev.20250301
-        version: 8.0.0-dev.20250301(@samchon/openapi@3.0.0-dev.20250301)(typescript@5.7.3)
+        specifier: ^8.0.0
+        version: 8.0.0(@samchon/openapi@3.0.0)(typescript@5.8.2)
     devDependencies:
       '@nestia/benchmark':
         specifier: workspace:^
@@ -509,7 +509,7 @@ importers:
         version: 0.4.4(rollup@4.34.9)
       '@rollup/plugin-typescript':
         specifier: ^12.1.1
-        version: 12.1.2(rollup@4.34.9)(tslib@2.8.1)(typescript@5.7.3)
+        version: 12.1.2(rollup@4.34.9)(tslib@2.8.1)(typescript@5.8.2)
       '@trivago/prettier-plugin-sort-imports':
         specifier: ^4.3.0
         version: 4.3.0(prettier@3.3.3)
@@ -569,13 +569,13 @@ importers:
         version: 1.1.0
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(@types/node@20.11.16)(typescript@5.7.3)
+        version: 10.9.2(@types/node@20.11.16)(typescript@5.8.2)
       ts-patch:
         specifier: ^3.3.0
         version: 3.3.0
       typescript-transform-paths:
         specifier: ^3.5.2
-        version: 3.5.3(typescript@5.7.3)
+        version: 3.5.3(typescript@5.8.2)
 
   packages/sdk:
     dependencies:
@@ -586,8 +586,8 @@ importers:
         specifier: workspace:^
         version: link:../fetcher
       '@samchon/openapi':
-        specifier: ^3.0.0-dev.20250301
-        version: 3.0.0-dev.20250301
+        specifier: ^3.0.0
+        version: 3.0.0
       cli:
         specifier: ^1.0.1
         version: 1.0.1
@@ -608,10 +608,10 @@ importers:
         version: 0.2.2
       ts-node:
         specifier: '>=10.6.0'
-        version: 10.9.2(@types/node@18.19.78)(typescript@5.7.3)
+        version: 10.9.2(@types/node@18.19.78)(typescript@5.8.2)
       tsconfck:
         specifier: ^2.1.2
-        version: 2.1.2(typescript@5.7.3)
+        version: 2.1.2(typescript@5.8.2)
       tsconfig-paths:
         specifier: ^4.1.1
         version: 4.2.0
@@ -619,8 +619,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       typia:
-        specifier: ^8.0.0-dev.20250301
-        version: 8.0.0-dev.20250301(@samchon/openapi@3.0.0-dev.20250301)(typescript@5.7.3)
+        specifier: ^8.0.0
+        version: 8.0.0(@samchon/openapi@3.0.0)(typescript@5.8.2)
     devDependencies:
       '@nestjs/common':
         specifier: ^11.0.2
@@ -651,16 +651,16 @@ importers:
         version: 9.0.8
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.46.1
-        version: 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3)
+        version: 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(typescript@5.8.2)
       '@typescript-eslint/parser':
         specifier: ^5.46.1
-        version: 5.62.0(eslint@8.57.1)(typescript@5.7.3)
+        version: 5.62.0(eslint@8.57.1)(typescript@5.8.2)
       eslint:
         specifier: ^8.29.0
         version: 8.57.1
       eslint-plugin-deprecation:
         specifier: ^1.4.1
-        version: 1.6.0(eslint@8.57.1)(typescript@5.7.3)
+        version: 1.6.0(eslint@8.57.1)(typescript@5.8.2)
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1
@@ -671,11 +671,11 @@ importers:
         specifier: ^3.3.0
         version: 3.3.0
       typescript:
-        specifier: ~5.7.2
-        version: 5.7.3
+        specifier: ~5.8.2
+        version: 5.8.2
       typescript-transform-paths:
         specifier: ^3.4.4
-        version: 3.5.3(typescript@5.7.3)
+        version: 3.5.3(typescript@5.8.2)
       uuid:
         specifier: ^9.0.0
         version: 9.0.1
@@ -707,8 +707,8 @@ importers:
         specifier: ^11.0.10
         version: 11.0.11(@nestjs/common@11.0.11(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.0.11)
       '@samchon/openapi':
-        specifier: ^3.0.0-dev.20250301
-        version: 3.0.0-dev.20250301
+        specifier: ^3.0.0
+        version: 3.0.0
       express:
         specifier: ^4.21.1
         version: 4.21.2
@@ -728,8 +728,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       typia:
-        specifier: ^8.0.0-dev.20250301
-        version: 8.0.0-dev.20250301(@samchon/openapi@3.0.0-dev.20250301)(typescript@5.7.3)
+        specifier: ^8.0.0
+        version: 8.0.0(@samchon/openapi@3.0.0)(typescript@5.7.3)
       uuid:
         specifier: ^9.0.1
         version: 9.0.1
@@ -738,7 +738,7 @@ importers:
         specifier: workspace:^
         version: link:../packages/sdk
       '@nestjs/swagger':
-        specifier: ^11.0.4
+        specifier: ^11.0.5
         version: 11.0.6(@nestjs/common@11.0.11(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.0.11)(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)
       '@types/express':
         specifier: ^4.17.17
@@ -1563,8 +1563,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@samchon/openapi@3.0.0-dev.20250301':
-    resolution: {integrity: sha512-1Lt4u/cNzRJm5dUNTiMKRNChJulfFN8bkNGmMv5rNFu1+fKpJ9PJiVm+YBRA3/PccURH8GHfw0VaZltnnTlp6w==}
+  '@samchon/openapi@3.0.0':
+    resolution: {integrity: sha512-eVQlyKRYv1/C2Mikc1xZr7c0jMjg1vjPkeY/gheKB4c5WOOWyTNZ1uvnXR+ETpPHwaQ54I9NrQZhoNk6BEGuuw==}
 
   '@scarf/scarf@1.4.0':
     resolution: {integrity: sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==}
@@ -4036,6 +4036,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@5.8.2:
+    resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   typia@7.6.4:
     resolution: {integrity: sha512-Z3AcvGBjS7Dc7+iAG2VhsT0NIv3HMoXVTJ3F7Pgth8z7rhQu1JnyS8GGqqWdKk5ROvOgALEVEWmWv3Lym2eBIg==}
     hasBin: true
@@ -4043,8 +4048,8 @@ packages:
       '@samchon/openapi': '>=2.4.2 <3.0.0'
       typescript: '>=4.8.0 <5.8.0'
 
-  typia@8.0.0-dev.20250301:
-    resolution: {integrity: sha512-1EqAOmOjd+yKMxk3uygywCGb2OjGefW/I2/v0cYDA9BrWKbPj6OG23SnHDmv+b+l4NCS8QpRNW3xketFSbbgIg==}
+  typia@8.0.0:
+    resolution: {integrity: sha512-ulYqugl0rXStArmFBxTxwC796gW4KkRas7wy7hOYwtRulxfBOJlurZMZ9MA8lN9LrgOpX/bnW0bW3w75ws6wIA==}
     hasBin: true
     peerDependencies:
       '@samchon/openapi': '>=3.0.0 <4.0.0'
@@ -4951,11 +4956,11 @@ snapshots:
     optionalDependencies:
       rollup: 4.34.9
 
-  '@rollup/plugin-typescript@12.1.2(rollup@4.34.9)(tslib@2.8.1)(typescript@5.7.3)':
+  '@rollup/plugin-typescript@12.1.2(rollup@4.34.9)(tslib@2.8.1)(typescript@5.8.2)':
     dependencies:
       '@rollup/pluginutils': 5.1.4(rollup@4.34.9)
       resolve: 1.22.10
-      typescript: 5.7.3
+      typescript: 5.8.2
     optionalDependencies:
       rollup: 4.34.9
       tslib: 2.8.1
@@ -5025,7 +5030,7 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.34.9':
     optional: true
 
-  '@samchon/openapi@3.0.0-dev.20250301': {}
+  '@samchon/openapi@3.0.0': {}
 
   '@scarf/scarf@1.4.0': {}
 
@@ -5333,94 +5338,94 @@ snapshots:
     dependencies:
       '@types/node': 18.19.78
 
-  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3)':
+  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(typescript@5.8.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@5.8.2)
       '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/type-utils': 5.62.0(eslint@8.57.1)(typescript@5.7.3)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/type-utils': 5.62.0(eslint@8.57.1)(typescript@5.8.2)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.8.2)
       debug: 4.4.0
       eslint: 8.57.1
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare-lite: 1.4.0
       semver: 7.7.1
-      tsutils: 3.21.0(typescript@5.7.3)
+      tsutils: 3.21.0(typescript@5.8.2)
     optionalDependencies:
-      typescript: 5.7.3
+      typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@9.21.0)(typescript@5.7.3))(eslint@9.21.0)(typescript@5.7.3)':
+  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(typescript@5.8.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 5.62.0(eslint@9.21.0)(typescript@5.7.3)
+      '@typescript-eslint/parser': 5.62.0(eslint@9.21.0)(typescript@5.8.2)
       '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/type-utils': 5.62.0(eslint@9.21.0)(typescript@5.7.3)
-      '@typescript-eslint/utils': 5.62.0(eslint@9.21.0)(typescript@5.7.3)
+      '@typescript-eslint/type-utils': 5.62.0(eslint@9.21.0)(typescript@5.8.2)
+      '@typescript-eslint/utils': 5.62.0(eslint@9.21.0)(typescript@5.8.2)
       debug: 4.4.0
       eslint: 9.21.0
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare-lite: 1.4.0
       semver: 7.7.1
-      tsutils: 3.21.0(typescript@5.7.3)
+      tsutils: 3.21.0(typescript@5.8.2)
     optionalDependencies:
-      typescript: 5.7.3
+      typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.25.0(@typescript-eslint/parser@8.25.0(eslint@9.21.0)(typescript@5.7.3))(eslint@9.21.0)(typescript@5.7.3)':
+  '@typescript-eslint/eslint-plugin@8.25.0(@typescript-eslint/parser@8.25.0(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(typescript@5.8.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.25.0(eslint@9.21.0)(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.25.0(eslint@9.21.0)(typescript@5.8.2)
       '@typescript-eslint/scope-manager': 8.25.0
-      '@typescript-eslint/type-utils': 8.25.0(eslint@9.21.0)(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.25.0(eslint@9.21.0)(typescript@5.7.3)
+      '@typescript-eslint/type-utils': 8.25.0(eslint@9.21.0)(typescript@5.8.2)
+      '@typescript-eslint/utils': 8.25.0(eslint@9.21.0)(typescript@5.8.2)
       '@typescript-eslint/visitor-keys': 8.25.0
       eslint: 9.21.0
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
-      ts-api-utils: 2.0.1(typescript@5.7.3)
-      typescript: 5.7.3
+      ts-api-utils: 2.0.1(typescript@5.8.2)
+      typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.7.3)':
+  '@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.8.2)
       debug: 4.4.0
       eslint: 8.57.1
     optionalDependencies:
-      typescript: 5.7.3
+      typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@5.62.0(eslint@9.21.0)(typescript@5.7.3)':
+  '@typescript-eslint/parser@5.62.0(eslint@9.21.0)(typescript@5.8.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.8.2)
       debug: 4.4.0
       eslint: 9.21.0
     optionalDependencies:
-      typescript: 5.7.3
+      typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.25.0(eslint@9.21.0)(typescript@5.7.3)':
+  '@typescript-eslint/parser@8.25.0(eslint@9.21.0)(typescript@5.8.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.25.0
       '@typescript-eslint/types': 8.25.0
-      '@typescript-eslint/typescript-estree': 8.25.0(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.25.0(typescript@5.8.2)
       '@typescript-eslint/visitor-keys': 8.25.0
       debug: 4.4.0
       eslint: 9.21.0
-      typescript: 5.7.3
+      typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
 
@@ -5439,38 +5444,38 @@ snapshots:
       '@typescript-eslint/types': 8.25.0
       '@typescript-eslint/visitor-keys': 8.25.0
 
-  '@typescript-eslint/type-utils@5.62.0(eslint@8.57.1)(typescript@5.7.3)':
+  '@typescript-eslint/type-utils@5.62.0(eslint@8.57.1)(typescript@5.8.2)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.7.3)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.8.2)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.8.2)
       debug: 4.4.0
       eslint: 8.57.1
-      tsutils: 3.21.0(typescript@5.7.3)
+      tsutils: 3.21.0(typescript@5.8.2)
     optionalDependencies:
-      typescript: 5.7.3
+      typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@5.62.0(eslint@9.21.0)(typescript@5.7.3)':
+  '@typescript-eslint/type-utils@5.62.0(eslint@9.21.0)(typescript@5.8.2)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.7.3)
-      '@typescript-eslint/utils': 5.62.0(eslint@9.21.0)(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.8.2)
+      '@typescript-eslint/utils': 5.62.0(eslint@9.21.0)(typescript@5.8.2)
       debug: 4.4.0
       eslint: 9.21.0
-      tsutils: 3.21.0(typescript@5.7.3)
+      tsutils: 3.21.0(typescript@5.8.2)
     optionalDependencies:
-      typescript: 5.7.3
+      typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@8.25.0(eslint@9.21.0)(typescript@5.7.3)':
+  '@typescript-eslint/type-utils@8.25.0(eslint@9.21.0)(typescript@5.8.2)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 8.25.0(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.25.0(eslint@9.21.0)(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.25.0(typescript@5.8.2)
+      '@typescript-eslint/utils': 8.25.0(eslint@9.21.0)(typescript@5.8.2)
       debug: 4.4.0
       eslint: 9.21.0
-      ts-api-utils: 2.0.1(typescript@5.7.3)
-      typescript: 5.7.3
+      ts-api-utils: 2.0.1(typescript@5.8.2)
+      typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
 
@@ -5480,7 +5485,7 @@ snapshots:
 
   '@typescript-eslint/types@8.25.0': {}
 
-  '@typescript-eslint/typescript-estree@5.62.0(typescript@5.7.3)':
+  '@typescript-eslint/typescript-estree@5.62.0(typescript@5.8.2)':
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
@@ -5488,13 +5493,13 @@ snapshots:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.7.1
-      tsutils: 3.21.0(typescript@5.7.3)
+      tsutils: 3.21.0(typescript@5.8.2)
     optionalDependencies:
-      typescript: 5.7.3
+      typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@6.21.0(typescript@5.7.3)':
+  '@typescript-eslint/typescript-estree@6.21.0(typescript@5.8.2)':
     dependencies:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/visitor-keys': 6.21.0
@@ -5503,13 +5508,13 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.3
       semver: 7.7.1
-      ts-api-utils: 1.4.3(typescript@5.7.3)
+      ts-api-utils: 1.4.3(typescript@5.8.2)
     optionalDependencies:
-      typescript: 5.7.3
+      typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.25.0(typescript@5.7.3)':
+  '@typescript-eslint/typescript-estree@8.25.0(typescript@5.8.2)':
     dependencies:
       '@typescript-eslint/types': 8.25.0
       '@typescript-eslint/visitor-keys': 8.25.0
@@ -5518,19 +5523,19 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.7.1
-      ts-api-utils: 2.0.1(typescript@5.7.3)
-      typescript: 5.7.3
+      ts-api-utils: 2.0.1(typescript@5.8.2)
+      typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@5.62.0(eslint@8.57.1)(typescript@5.7.3)':
+  '@typescript-eslint/utils@5.62.0(eslint@8.57.1)(typescript@5.8.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.1(eslint@8.57.1)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.5.8
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.8.2)
       eslint: 8.57.1
       eslint-scope: 5.1.1
       semver: 7.7.1
@@ -5538,14 +5543,14 @@ snapshots:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@5.62.0(eslint@9.21.0)(typescript@5.7.3)':
+  '@typescript-eslint/utils@5.62.0(eslint@9.21.0)(typescript@5.8.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.1(eslint@9.21.0)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.5.8
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.8.2)
       eslint: 9.21.0
       eslint-scope: 5.1.1
       semver: 7.7.1
@@ -5553,42 +5558,42 @@ snapshots:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@6.21.0(eslint@8.57.1)(typescript@5.7.3)':
+  '@typescript-eslint/utils@6.21.0(eslint@8.57.1)(typescript@5.8.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.1(eslint@8.57.1)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.5.8
       '@typescript-eslint/scope-manager': 6.21.0
       '@typescript-eslint/types': 6.21.0
-      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.8.2)
       eslint: 8.57.1
       semver: 7.7.1
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@6.21.0(eslint@9.21.0)(typescript@5.7.3)':
+  '@typescript-eslint/utils@6.21.0(eslint@9.21.0)(typescript@5.8.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.1(eslint@9.21.0)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.5.8
       '@typescript-eslint/scope-manager': 6.21.0
       '@typescript-eslint/types': 6.21.0
-      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.8.2)
       eslint: 9.21.0
       semver: 7.7.1
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@8.25.0(eslint@9.21.0)(typescript@5.7.3)':
+  '@typescript-eslint/utils@8.25.0(eslint@9.21.0)(typescript@5.8.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.1(eslint@9.21.0)
       '@typescript-eslint/scope-manager': 8.25.0
       '@typescript-eslint/types': 8.25.0
-      '@typescript-eslint/typescript-estree': 8.25.0(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.25.0(typescript@5.8.2)
       eslint: 9.21.0
-      typescript: 5.7.3
+      typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
 
@@ -6271,23 +6276,23 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-plugin-deprecation@1.6.0(eslint@8.57.1)(typescript@5.7.3):
+  eslint-plugin-deprecation@1.6.0(eslint@8.57.1)(typescript@5.8.2):
     dependencies:
-      '@typescript-eslint/utils': 6.21.0(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/utils': 6.21.0(eslint@8.57.1)(typescript@5.8.2)
       eslint: 8.57.1
       tslib: 2.8.1
-      tsutils: 3.21.0(typescript@5.7.3)
-      typescript: 5.7.3
+      tsutils: 3.21.0(typescript@5.8.2)
+      typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-deprecation@1.6.0(eslint@9.21.0)(typescript@5.7.3):
+  eslint-plugin-deprecation@1.6.0(eslint@9.21.0)(typescript@5.8.2):
     dependencies:
-      '@typescript-eslint/utils': 6.21.0(eslint@9.21.0)(typescript@5.7.3)
+      '@typescript-eslint/utils': 6.21.0(eslint@9.21.0)(typescript@5.8.2)
       eslint: 9.21.0
       tslib: 2.8.1
-      tsutils: 3.21.0(typescript@5.7.3)
-      typescript: 5.7.3
+      tsutils: 3.21.0(typescript@5.8.2)
+      typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
 
@@ -7822,17 +7827,17 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  ts-api-utils@1.4.3(typescript@5.7.3):
+  ts-api-utils@1.4.3(typescript@5.8.2):
     dependencies:
-      typescript: 5.7.3
+      typescript: 5.8.2
 
-  ts-api-utils@2.0.1(typescript@5.7.3):
+  ts-api-utils@2.0.1(typescript@5.8.2):
     dependencies:
-      typescript: 5.7.3
+      typescript: 5.8.2
 
   ts-expose-internals@5.4.5: {}
 
-  ts-node@10.9.2(@types/node@18.19.78)(typescript@5.7.3):
+  ts-node@10.9.2(@types/node@18.19.78)(typescript@5.8.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -7846,7 +7851,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.7.3
+      typescript: 5.8.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
@@ -7868,7 +7873,25 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  ts-node@10.9.2(@types/node@22.13.8)(typescript@5.7.3):
+  ts-node@10.9.2(@types/node@20.11.16)(typescript@5.8.2):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.11.16
+      acorn: 8.14.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.8.2
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+
+  ts-node@10.9.2(@types/node@22.13.8)(typescript@5.8.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -7882,7 +7905,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.7.3
+      typescript: 5.8.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
@@ -7895,9 +7918,9 @@ snapshots:
       semver: 7.7.1
       strip-ansi: 6.0.1
 
-  tsconfck@2.1.2(typescript@5.7.3):
+  tsconfck@2.1.2(typescript@5.8.2):
     optionalDependencies:
-      typescript: 5.7.3
+      typescript: 5.8.2
 
   tsconfig-paths@4.2.0:
     dependencies:
@@ -7911,10 +7934,10 @@ snapshots:
 
   tstl@3.0.0: {}
 
-  tsutils@3.21.0(typescript@5.7.3):
+  tsutils@3.21.0(typescript@5.8.2):
     dependencies:
       tslib: 1.14.1
-      typescript: 5.7.3
+      typescript: 5.8.2
 
   type-check@0.4.0:
     dependencies:
@@ -7939,13 +7962,13 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typescript-eslint@8.25.0(eslint@9.21.0)(typescript@5.7.3):
+  typescript-eslint@8.25.0(eslint@9.21.0)(typescript@5.8.2):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.25.0(@typescript-eslint/parser@8.25.0(eslint@9.21.0)(typescript@5.7.3))(eslint@9.21.0)(typescript@5.7.3)
-      '@typescript-eslint/parser': 8.25.0(eslint@9.21.0)(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.25.0(eslint@9.21.0)(typescript@5.7.3)
+      '@typescript-eslint/eslint-plugin': 8.25.0(@typescript-eslint/parser@8.25.0(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(typescript@5.8.2)
+      '@typescript-eslint/parser': 8.25.0(eslint@9.21.0)(typescript@5.8.2)
+      '@typescript-eslint/utils': 8.25.0(eslint@9.21.0)(typescript@5.8.2)
       eslint: 9.21.0
-      typescript: 5.7.3
+      typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
 
@@ -7954,11 +7977,28 @@ snapshots:
       minimatch: 9.0.5
       typescript: 5.7.3
 
+  typescript-transform-paths@3.5.3(typescript@5.8.2):
+    dependencies:
+      minimatch: 9.0.5
+      typescript: 5.8.2
+
   typescript@5.7.3: {}
 
-  typia@7.6.4(@samchon/openapi@3.0.0-dev.20250301)(typescript@5.7.3):
+  typescript@5.8.2: {}
+
+  typia@7.6.4(@samchon/openapi@3.0.0)(typescript@5.8.2):
     dependencies:
-      '@samchon/openapi': 3.0.0-dev.20250301
+      '@samchon/openapi': 3.0.0
+      commander: 10.0.0
+      comment-json: 4.2.5
+      inquirer: 8.2.5
+      package-manager-detector: 0.2.10
+      randexp: 0.5.3
+      typescript: 5.8.2
+
+  typia@8.0.0(@samchon/openapi@3.0.0)(typescript@5.7.3):
+    dependencies:
+      '@samchon/openapi': 3.0.0
       commander: 10.0.0
       comment-json: 4.2.5
       inquirer: 8.2.5
@@ -7966,15 +8006,15 @@ snapshots:
       randexp: 0.5.3
       typescript: 5.7.3
 
-  typia@8.0.0-dev.20250301(@samchon/openapi@3.0.0-dev.20250301)(typescript@5.7.3):
+  typia@8.0.0(@samchon/openapi@3.0.0)(typescript@5.8.2):
     dependencies:
-      '@samchon/openapi': 3.0.0-dev.20250301
+      '@samchon/openapi': 3.0.0
       commander: 10.0.0
       comment-json: 4.2.5
       inquirer: 8.2.5
       package-manager-detector: 0.2.10
       randexp: 0.5.3
-      typescript: 5.7.3
+      typescript: 5.8.2
 
   uid@2.0.2:
     dependencies:

--- a/website/build/chat.js
+++ b/website/build/chat.js
@@ -1,4 +1,3 @@
-import cp from "child_process";
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
@@ -6,38 +5,17 @@ import { fileURLToPath } from "url";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const AGENT = `${__dirname}/../../packages/agent`;
-const CHAT = `${__dirname}/../../packages/chat`;
-const PUBLIC = `${__dirname}/../public/chat`;
-
-const copy = async (src, dest) => {
-  try {
-    if (fs.existsSync(dest)) await fs.promises.rm(dest, { recursive: true });
-  } catch {}
-  try {
-    await fs.promises.mkdir(dest);
-  } catch {}
-
-  const directory = await fs.promises.readdir(src);
-  for (const file of directory) {
-    const x = path.join(src, file);
-    const y = path.join(dest, file);
-    const stat = await fs.promises.stat(x);
-    if (stat.isDirectory()) await copy(x, y);
-    else await fs.promises.writeFile(y, await fs.promises.readFile(x));
-  }
-};
-
 const main = async () => {
-  cp.execSync("npm run build", {
-    stdio: "ignore",
-    cwd: AGENT,
-  });
-  cp.execSync("npm run build:static", {
-    stdio: "ignore",
-    cwd: CHAT,
-  });
-  await copy(`${CHAT}/dist`, PUBLIC);
+  const dest = `${__dirname}/../public/chat`;
+  if (fs.existsSync(dest) === true)
+    await fs.promises.rm(dest, { recursive: true });
+  await fs.promises.cp(
+    `${__dirname}/../node_modules/@agentica/chat/dist`,
+    dest,
+    {
+      recursive: true,
+    },
+  );
 };
 main().catch((error) => {
   console.error(error);

--- a/website/package.json
+++ b/website/package.json
@@ -5,9 +5,10 @@
   "description": "Nestia Guide Documents",
   "private": true,
   "scripts": {
-    "build": "rimraf .next && rimraf .out && node build/editor && node build/typedoc && next build && node build/sitemap",
+    "build": "rimraf .next && rimraf .out && node build/chat && node build/editor && node build/typedoc && next build && node build/sitemap",
     "deploy": "node build/deploy",
-    "dev": "next dev"
+    "dev": "next dev",
+    "prepare": "node build/chat"
   },
   "repository": {
     "type": "git",
@@ -19,6 +20,7 @@
     "url": "https://github.com/samchon/nestia/issues"
   },
   "dependencies": {
+    "@agentica/chat": "latest",
     "@emotion/react": "^11.10.6",
     "@emotion/styled": "^11.10.6",
     "@mui/icons-material": "^6.4.0",

--- a/website/pages/docs/swagger/chat.mdx
+++ b/website/pages/docs/swagger/chat.mdx
@@ -3,7 +3,102 @@ title: Guide Documents > Swagger Document > AI Chatbot Development
 ---
 import { Callout, Tabs } from 'nextra/components'
 
-## Super A.I. Chatbot
+## Agentica
+![agentica-conceptual-diagram](https://github.com/user-attachments/assets/d7ebbd1f-04d3-4b0d-9e2a-234e29dd6c57)
+
+https://github.com/wrtnlabs/agentica
+
+The simplest **Agentic AI** framework, specialized in **LLM Function Calling**.
+
+With `@agentica`, you can build Agentic AI chatbot only with Swagger document built by [`@nestia/sdk`](/docs/swagger). Complex agent workflows and graphs required in conventional AI agent development are not necessary in `@agentica`. Only with the Swagger document, `@agentica` will do everything with the function calling.
+
+Look at below demonstration, and feel how `@agentica` is powerful. Now, you can let users to search and purchase products only with conversation texts. The backend API functions would be adequately called in the AI chatbot with LLM function calling.
+
+<Callout type="info">
+`@nestia/agent` had been migrated to `@agentica/*` for enhancements and separation to multiple packages extending the functionalities.
+</Callout>
+
+<Tabs items={["Pseudo Code", "Real Code"]}>
+  <Tabs.Tab>
+```typescript showLineNumbers {6-8}
+import { Agentica } from "@agentica/core";
+import typia from "typia";
+
+const agent = new Agentica({
+  controllers: [
+    await fetch(
+      "https://shopping-be.wrtn.ai/editor/swagger.json",
+    ).then(r => r.json()),
+    typia.llm.application<ShoppingCounselor>(),
+    typia.llm.application<ShoppingPolicy>(),
+    typia.llm.application<ShoppingSearchRag>(),
+  ],
+});
+await agent.conversate("I wanna buy MacBook Pro");
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```typescript showLineNumbers {16-23}
+import { Agentica } from "@agentica/core";
+import { OpenApi, HttpLlm } from "@samchon/openapi";
+import typia from "typia";
+
+const main = async (): Promise<void> => {
+  const agent = new Agentica({
+    model: "chatgpt",
+    vendor: {
+      api: new OpenAI({ secretKey: "*****" }),
+      model: "gpt-4o-mini",
+    },
+    controllers: [
+      {
+        protocol: "http",
+        name: "shopping",
+        application: HttpLlm.application({
+          model: "chatgpt",
+          document: OpenApi.convert(
+            await fetch(
+              "https://shopping-be.wrtn.ai/editor/swagger.json",
+            ).then(r => r.json()),
+          ),
+        }),
+        connection: {
+          host: "https://shopping-be.wrtn.ai",
+          headers: {
+            Authorization: "Bearer *****",
+          },
+        },
+      },
+      {
+        protocol: "class",
+        name: "counselor",
+        application: 
+          typia.llm.application<ShoppingCounselor, "chatgpt">(),
+        execute: new ShoppingCounselor(),
+      },
+      {
+        protocol: "class",
+        name: "policy",
+        application: 
+          typia.llm.application<ShoppingPolicy, "chatgpt">(),
+        execute: new ShoppingPolicy(),
+      },
+      {
+        protocol: "class",
+        name: "rag",
+        application: 
+          typia.llm.application<ShoppingSearchRag, "chatgpt">(),
+        execute: new ShoppingSearchRag(),
+      },
+    ],
+  });
+  await agent.conversate("I wanna buy MacBook Pro");
+};
+main().catch(console.error);
+```
+  </Tabs.Tab>
+</Tabs>
+
 <br/>
 <iframe src="https://www.youtube.com/embed/m47p4iJ90Ms?si=cvgfckN25GJhjLTB" 
         title="Shopping A.I. Chatbot built with Nestia" 
@@ -17,14 +112,6 @@ import { Callout, Tabs } from 'nextra/components'
   - Shopping Backend Repository: https://github.com/samchon/shopping-backend
   - Shopping Swagger Document (`@nestia/editor`): [https://nestia.io/editor/?url=...](https://nestia.io/editor/?simulate=true&e2e=true&url=https%3A%2F%2Fraw.githubusercontent.com%2Fsamchon%2Fshopping-backend%2Frefs%2Fheads%2Fmaster%2Fpackages%2Fapi%2Fswagger.json)
 
-The above demonstration video shows Shopping A.I. chatbot built with Nestia.
-
-As you can see, in the Shopping A.I. chatbot application, the user can do everything written in the Swagger documents just by conversation texts. Searching products, taking orders, checking delivery status, user can do these things by chatting texts.
-
-Just by delivering the Swagger document, Super A.I. chatbot performing the LLM (Large Language Model) function calling is automatically composed. The Super A.I. chatbot will select proper functions defined in the Swagger document by analyzing conversation contexts with the user. And then Super A.I. chatbot requests the user to write arguments for the selected functions by conversation texts, and actually calls the API function with the argument. This is the key concept of the Nestia A.I. chatbot.
-
-In other words, every backend servers providing Swagger documents can be conversed to the A.I. chatbot. In the new A.I. era, no more need to dedicate GUI (Graphical User Interface) application development like before. Prepare Swagger document, and let the A.I. chatbot to do the rest. Even though the A.I. chatbot can't conquer every frontend developments, it can replace many things, and more efficient and user-friendly than the traditional GUI applications.
-
 
 
 
@@ -33,166 +120,164 @@ In other words, every backend servers providing Swagger documents can be convers
 
 You can test your backend server's A.I. chatbot with the following playground.
 
-Upload your Swagger document file to the [playground website](https://nestia.io/chat/playground), and start conversation with your backend server. If your backend server's documentation is well written so that the A.I. chatbot quality is satisfiable, you can start your own A.I. chatbot service from the next section [#Application Setup](#application-setup).
+Upload your Swagger document file to the [playground website](https://nestia.io/chat/playground), and start conversation with your backend server. If your backend server's documentation is well written so that the A.I. chatbot quality is satisfiable, you can start your own A.I. chatbot service with `@agentica`.
 
 
 
 
-## Application Setup
-<Tabs items={['npm', 'pnpm', 'yarn']}>
-  <Tabs.Tab>
-```bash filename="Terminal"
-npm install @nestia/agent @nestia/chat @samchon/openapi openai
+## Principles
+### Agent Strategy
+```mermaid
+sequenceDiagram
+actor User
+actor Agent
+participant Selector
+participant Caller
+participant Describer
+activate User
+User-->>Agent: Conversate:<br/>user says
+activate Agent
+Agent->>Selector: Deliver conversation text
+activate Selector
+deactivate User
+Note over Selector: Select or remove candidate functions
+alt No candidate
+  Selector->>Agent: Talk like plain ChatGPT
+  deactivate Selector
+  Agent->>User: Conversate:<br/>agent says
+  activate User
+  deactivate User
+end
+deactivate Agent
+loop Candidate functions exist
+  activate Agent
+  Agent->>Caller: Deliver conversation text
+  activate Caller
+  alt Contexts are enough
+    Note over Caller: Call fulfilled functions
+    Caller->>Describer: Function call histories
+    deactivate Caller
+    activate Describer
+    Describer->>Agent: Describe function calls
+    deactivate Describer
+    Agent->>User: Conversate:<br/>agent describes
+    activate User
+    deactivate User
+  else Contexts are not enough
+    break
+      Caller->>Agent: Request more information
+    end
+    Agent->>User: Conversate:<br/>agent requests
+    activate User
+    deactivate User
+  end
+  deactivate Agent
+end
 ```
-  </Tabs.Tab>
-  <Tabs.Tab>
-```bash filename="Terminal"
-pnpm install @nestia/agent @nestia/chat @samchon/openapi openai
-```
-  </Tabs.Tab>
-  <Tabs.Tab>
-```bash filename="Terminal"
-yarn add @nestia/agent @nestia/chat @samchon/openapi openai
-```
-  </Tabs.Tab>
-</Tabs>
 
-Install `@nestia/chat` and its dependencies.
+When user says, `@agentica/core` delivers the conversation text to the `selector` agent, and let the `selector` agent to find (or cancel) candidate functions from the context. If the `selector` agent could not find any candidate function to call and there is not any candidate function previously selected either, the `selector` agent will work just like a plain ChatGPT.
 
-  - `@nestia/chat`
-  - `@nestia/agent`
-  - `@samchon/openapi`
-  - `openai`
+And `@agentica/core` enters to a loop statement until the candidate functions to be empty. In the loop statement, `caller` agent tries to LLM function calling by analyzing the user's conversation text. If context is enough to compose arguments of candidate functions, the `caller` agent actually calls the target functions, and let `decriber` agent to explain the function calling results. Otherwise the context is not enough to compose arguments, `caller` agent requests more information to user.
 
-To make the Super A.I. chatbot, you need to install the above libraries. All of them except `@nestia/chat` are in the dependencies of the `@nestia/chat`, but it would better to install them explicitly for the safe frontend application development.
+Such LLM (Large Language Model) function calling strategy separating `selector`, `caller`, and `describer` is the key logic of `@agentica/core`.
 
-```typescript filename="src/ShoppingChatApplication.tsx" showLineNumbers {20-27, 59}
-import { NestiaAgent } from "@nestia/agent";
-  import { NestiaChatApplication } from "@nestia/chat";
-import {
-  HttpLlm,
-  IHttpConnection,
-  IHttpLlmApplication,
-  OpenApi,
-} from "@samchon/openapi";
-import OpenAI from "openai";
-import { useEffect, useState } from "react";
+### Validation Feedback
+```typescript
+import { FunctionCall } from "pseudo";
+import { ILlmFunction, IValidation } from "typia";
 
-export const ShoppingChatApplication = (
-  props: ShoppingChatApplication.IProps,
-) => {
-  const [application, setApplication] =
-    useState<IHttpLlmApplication<"chatgpt"> | null>(null);
-  useEffect(() => {
-    (async () => {
-      setApplication(
-        HttpLlm.application({
-          model: "chatgpt",
-          document: OpenApi.convert(
-            await fetch(
-              "https://raw.githubusercontent.com/samchon/shopping-backend/refs/heads/master/packages/api/customer.swagger.json",
-            ).then((r) => r.json()),
-          ),
-        }),
-      );
-    })().catch(console.error);
-  }, []);
-  if (application === null)
-    return (
-      <div>
-        <h2>Loading Swagger document</h2>
-        <hr />
-        <p>Wait for a moment please.</p>
-        <p>Loading Swagger document...</p>
-      </div>
+export const correctFunctionCall = (p: {
+  call: FunctionCall;
+  functions: Array<ILlmFunction<"chatgpt">>;
+  retry: (reason: string, errors?: IValidation.IError[]) => Promise<unknown>;
+}): Promise<unknown> => {
+  // FIND FUNCTION
+  const func: ILlmFunction<"chatgpt"> | undefined =
+    p.functions.find((f) => f.name === p.call.name);
+  if (func === undefined) {
+    // never happened in my experience
+    return p.retry(
+      "Unable to find the matched function name. Try it again.",
     );
-
-  const agent: NestiaAgent = new NestiaAgent({
-    provider: {
-      type: "chatgpt",
-      api: props.api,
-      model: "gpt-4o-mini",
-    },
-    controllers: [
-      {
-        protocol: "http",
-        name: "main",
-        application,
-        connection: props.connection,
-      },
-    ],
-    config: {
-      locale: props.locale,
-    },
-  });
-  return <NestiaChatApplication agent={agent} />;
-};
-export namespace ShoppingChatApplication {
-  export interface IProps {
-    api: OpenAI;
-    connection: IHttpConnection;
-    name: string;
-    mobile: string;
-    locale?: string;
   }
+
+  // VALIDATE
+  const result: IValidation<unknown> = func.validate(p.call.arguments);
+  if (result.success === false) {
+    // 1st trial: 50% (gpt-4o-mini in shopping mall chatbot)
+    // 2nd trial with validation feedback: 99%
+    // 3nd trial with validation feedback again: never have failed
+    return p.retry(
+      "Type errors are detected. Correct it through validation errors",
+      {
+        errors: result.errors,
+      },
+    );
+  }
+  return result.data;
 }
 ```
 
-After setup, import and compose the A.I. chatbot like above.
+Is LLM function calling perfect? 
 
-The first thing you should do is composing `OpenApi.IDocument` typed object from your swagger document. The `OpenApi.IDocument` is an emended version of the OpenAPI v3.1 specification for the normalization. You can do it through `OpenApi.convert()` function.
+The answer is not, and LLM (Large Language Model) vendors like OpenAI take a lot of type level mistakes when composing the arguments of the target function to call. Even though an LLM function calling schema has defined an `Array<string>` type, LLM often fills it just by a `string` typed value.
 
-After that, you have to compose the `IHttpLlmApplication` typed object from the `HttpLlm.application()` function. The `IHttpLlmApplication` object is a schema for the LLM function calling. As current Nestia supports only the OpenAI (The type name is chatgpt to avoid confusion due to the similar names `openapi`/`openai`), you should set the `model` property to `"chatgpt"`.
+Therefore, when developing an LLM function calling agent, the validation feedback process is essentially required. If LLM takes a type level mistake on arguments composition, the agent must feedback the most detailed validation errors, and let the LLM to retry the function calling referencing the validation errors.
 
-At last, create an `NestiaAgent` instance. The `IHttpLlmApplication` is a type of controller to the `NestiaAgent`, and OpenAI client is a type of provider in the `NestiaAgent` concept. After composing the `NestiaAgent`, you can directly create the A.I. chatbot frontend application with the `<NestiaChatApplication agent={agent} />` statement.
+About the validation feedback, `@agentica/core` is utilizing [`typia.validate<T>()`](https://typia.io/docs/validators/validate) and [`typia.llm.application<Class, Model>()`](https://typia.io/docs/llm/application/#application) functions. They construct validation logic by analyzing TypeScript source codes and types in the compilation level, so that detailed and accurate than any other validators like below.
 
-<Callout type="info">
-**OpenAPI conversion process**
+Such validation feedback strategy and combination with `typia` runtime validator, `@agentica/core` has achieved the most ideal LLM function calling. In my experience, when using OpenAI's `gpt-4o-mini` model, it tends to construct invalid function calling arguments at the first trial about 50% of the time. By the way, if correct it through validation feedback with `typia`, success rate soars to 99%. And I've never had a failure when trying validation feedback twice.
 
-You can learn more about the schema conversion process in the [`@samchon/openapi`](https://github.com/samchon/openapi) repository. 
+Components               | `typia` | `TypeBox` | `ajv` | `io-ts` | `zod` | `C.V.`
+-------------------------|--------|-----------|-------|---------|-------|------------------
+**Easy to use**          | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ 
+[Object (simple)](https://github.com/samchon/typia/blob/master/test/src/structures/ObjectSimple.ts)          | ✔ | ✔ | ✔ | ✔ | ✔ | ✔
+[Object (hierarchical)](https://github.com/samchon/typia/blob/master/test/src/structures/ObjectHierarchical.ts)    | ✔ | ✔ | ✔ | ✔ | ✔ | ✔
+[Object (recursive)](https://github.com/samchon/typia/blob/master/test/src/structures/ObjectRecursive.ts)       | ✔ | ❌ | ✔ | ✔ | ✔ | ✔ | ✔
+[Object (union, implicit)](https://github.com/samchon/typia/blob/master/test/src/structures/ObjectUnionImplicit.ts) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
+[Object (union, explicit)](https://github.com/samchon/typia/blob/master/test/src/structures/ObjectUnionExplicit.ts) | ✔ | ✔ | ✔ | ✔ | ✔ | ❌
+[Object (additional tags)](https://github.com/samchon/typia/#comment-tags)        | ✔ | ✔ | ✔ | ✔ | ✔ | ✔
+[Object (template literal types)](https://github.com/samchon/typia/blob/master/test/src/structures/TemplateUnion.ts) | ✔ | ✔ | ✔ | ❌ | ❌ | ❌
+[Object (dynamic properties)](https://github.com/samchon/typia/blob/master/test/src/structures/DynamicTemplate.ts) | ✔ | ✔ | ✔ | ❌ | ❌ | ❌
+[Array (rest tuple)](https://github.com/samchon/typia/blob/master/test/src/structures/TupleRestAtomic.ts) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
+[Array (hierarchical)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayHierarchical.ts)     | ✔ | ✔ | ✔ | ✔ | ✔ | ✔
+[Array (recursive)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayRecursive.ts)        | ✔ | ✔ | ✔ | ✔ | ✔ | ❌
+[Array (recursive, union)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayRecursiveUnionExplicit.ts) | ✔ | ✔ | ❌ | ✔ | ✔ | ❌
+[Array (R+U, implicit)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayRecursiveUnionImplicit.ts)    | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
+[Array (repeated)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayRepeatedNullable.ts)    | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
+[Array (repeated, union)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayRepeatedUnionWithTuple.ts)    | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
+[**Ultimate Union Type**](https://github.com/samchon/typia/blob/master/test/src/structures/UltimateUnion.ts)  | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
 
+> `C.V.` means `class-validator`
+
+### OpenAPI Specification
 ```mermaid
 flowchart
   subgraph "OpenAPI Specification"
-    v20("Swagger v2.0") --upgrades--> emended[["<b><u>OpenAPI v3.1 (emended)</u></b>"]]
+    v20("Swagger v2.0") --upgrades--> emended[["OpenAPI v3.1 (emended)"]]
     v30("OpenAPI v3.0") --upgrades--> emended
     v31("OpenAPI v3.1") --emends--> emended
   end
   subgraph "OpenAPI Generator"
     emended --normalizes--> migration[["Migration Schema"]]
-    migration --"Artificial Intelligence"--> lfc{{"<b>LLM Function Calling</b>"}}
-    lfc --"OpenAI"--> chatgpt("<b><u>ChatGPT</u></b>")
+    migration --"Artificial Intelligence"--> lfc{{"LLM Function Calling"}}
+    lfc --"OpenAI"--> chatgpt("ChatGPT")
     lfc --"Anthropic"--> claude("Claude")
     lfc --"Google"--> gemini("Gemini")
     lfc --"Meta"--> llama("Llama")
   end
 ```
-</Callout>
 
+`@agentica/core` obtains LLM function calling schemas from both Swagger/OpenAPI documents and TypeScript class types. The TypeScript class type can be converted to LLM function calling schema by [`typia.llm.application<Class, Model>()`](https://typia.io/docs/llm/application#application) function. Then how about OpenAPI document? How Swagger document can be LLM function calling schema.
 
+The secret is in the above diagram. 
 
+In the OpenAPI specification, there are three versions with different definitions. And even in the same version, there are too much ambiguous and duplicated expressions. To resolve these problems, [`@samchon/openapi`](https://github.com/samchon/openapi) is transforming every OpenAPI documents to v3.1 emended specification. The `@samchon/openapi`'s emended v3.1 specification has removed every ambiguous and duplicated expressions for clarity.
 
-## Make Your A.I. Chatbot
-Above `@nestia/agent` and `@nestia/chat` libraries are just for testing and demonstration. I've made them to prove a conncept that every backend servers providing swagger documents can be conversed with the A.I. chatbot, and `nestia` is especially efficient for the A.I. chatbot development purpose.
+With the v3.1 emended OpenAPI document, `@samchon/openapi` converts it to a migration schema that is near to the function structure. And as the last step, the migration schema will be transformed to a specific LLM vendor's function calling schema. LLM function calling schemas are composed like this way.
 
-However, `@nestia/agent` support only OpenAI, and has not optimized for specific purpose. As it has not been optimized without any RAG (Retrieval Augmented Generation) models, it may consume a lot of LLM cost than what you may expected. Therefore, use the `@nestia/agent` for studying the A.I. chatbot development, or just demonstrating your backend server before production development.
-
-  - Source Codes:
-    - `@nestia/agent`: https://github.com/samchon/nestia/tree/master/packages/agent
-    - `@nestia/chat`: https://github.com/samchon/nestia/tree/master/packages/chat
-
-
-
-
-## Wrtn OS
-[![Wrtn Logo](/images/sponsors/wrtn-logo.png)](https://wrtnlabs.io)
-
-> https://wrtnlabs.io
-
-The new era of software development.
-
-If you are not familiar with LLM (Large Language Model) development or RAG implementation, you can take another option. Prepare your swagger document file, and visit WrtnLabs homepage https://wrtnlabs.io. You can create your own A.I. chatbot with "Wrtn OS", and re-distribute it as you want. The A.I. assistant in the Wrtn OS is much more optimized and cost efficient than the `@nestia/agent`, and it is fully open sourced.
-
-Also, you can sell your swagger document (backend API functions) in the "Wrtn Store", so that let other users to create their own A.I. chatbot with your backend API functions. Conversely, you can purchase the functions you need to create an A.I. chatbot from the store. If you have create an A.I. chatbot with only the functions purchased in the Wrtn Store, it is the no coding development.
-
-I think this is a new way of software development, and a new way of software distribution. It is a new era of software development, and I hope you to be a part of it.
+> **Why do not directly convert, but intermediate?**
+>
+> If directly convert from each version of OpenAPI specification to specific LLM's function calling schema, I have to make much more converters increased by cartesian product. In current models, number of converters would be 12 = 3 x 4.
+>
+> However, if define intermediate schema, number of converters are shrunk to plus operation. In current models, I just need to develop only (7 = 3 + 4) converters, and this is the reason why I've defined intermediate specification. This way is economic.

--- a/website/src/movies/home/HomeStrengthMovie.tsx
+++ b/website/src/movies/home/HomeStrengthMovie.tsx
@@ -148,7 +148,7 @@ const sections: HomeStrengthSectionMovie.Props[] = [
     title: "Super A.I. Chatbot",
     subTitle: (
       <React.Fragment>
-        <span style={{ color: BLUE }}>A.I. Chatbot</span>
+        <span style={{ color: BLUE }}>Agentic AI</span>
         {" by "}
         <span style={{ color: GREEN }}>Swagger Document</span>
       </React.Fragment>


### PR DESCRIPTION
This pull request includes updates to the build process and dependency versions, particularly focusing on the transition to TypeScript 5.8.2 and the stabilization of the `@samchon/openapi` and `typia` libraries.

### Build Process Update:
* [`.github/workflows/website.yml`](diffhunk://#diff-c7731b29de71fca225e1dfac88ebe31975a4cd9759ab13e91d86eeadafbddc10L26-R26): Changed the build command from `npm run build` to `pnpm run build` for consistency with the package manager used in the project.

### Dependency Updates:
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL101-R107): Updated TypeScript version from 5.7.3 to 5.8.2 across multiple dependencies and packages. This ensures compatibility and leverages the latest features and fixes provided by TypeScript 5.8.2. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL101-R107) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL147-R159) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL195-R196) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL290-R299) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL420-R460) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL674-R678)
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL210-R211): Updated `@samchon/openapi` from a development version to a stable release version 3.0.0. This transition indicates that the library has moved out of the development phase and is now stable for production use. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL210-R211) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL311-R332) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL474-R478) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL589-R590) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL654-R663)
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL237-R238): Updated `typia` from a development version to a stable release version 8.0.0. Similar to `@samchon/openapi`, this transition marks the library as stable and ready for production deployment. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL237-R238) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL359-R359) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL741-R741) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1566-R1567) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4039-R4052)

These updates collectively improve the stability, performance, and compatibility of the project by leveraging the latest stable versions of critical dependencies.