### PR TITLE
Publish benchmark v0.4.3

### DIFF
--- a/packages/benchmark/deploy/publish.js
+++ b/packages/benchmark/deploy/publish.js
@@ -1,0 +1,46 @@
+const cp = require("child_process");
+const fs = require("fs");
+
+const main = async () => {
+  const load = async () =>
+    JSON.parse(await fs.promises.readFile(`${__dirname}/../package.json`));
+  const original = await load();
+  const updated = await load();
+
+  const { version } = JSON.parse(
+    await fs.promises.readFile(`${__dirname}/../../../package.json`, "utf8"),
+  );
+  const { version: cliVersion } = JSON.parse(
+    await fs.promises.readFile(`${__dirname}/../../cli/package.json`, "utf8"),
+  );
+
+  delete updated.private;
+  for (const dict of [updated.dependencies, updated.devDependencies])
+    for (const [key, value] of Object.entries(dict))
+      if (value === "workspace:^")
+        dict[key] = key === "nestia" ? `^${cliVersion}` : `^${version}`;
+
+  try {
+    await fs.promises.writeFile(
+      `${__dirname}/../package.json`,
+      JSON.stringify(updated, null, 2),
+      "utf8",
+    );
+    cp.execSync("npm publish", {
+      cwd: `${__dirname}/..`,
+      stdio: "inherit",
+    });
+  } catch (error) {
+    throw error;
+  } finally {
+    await fs.promises.writeFile(
+      `${__dirname}/../package.json`,
+      JSON.stringify(original, null, 2),
+      "utf8",
+    );
+  }
+};
+main().catch((error) => {
+  console.log(error);
+  process.exit(-1);
+});

--- a/packages/benchmark/package.json
+++ b/packages/benchmark/package.json
@@ -1,6 +1,7 @@
 {
+  "private": true,
   "name": "@nestia/benchmark",
-  "version": "0.4.0",
+  "version": "0.4.3",
   "description": "NestJS Performance Benchmark Program",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -21,6 +22,11 @@
   ],
   "author": "Jeongho Nam",
   "license": "MIT",
+  "dependencies": {
+    "@nestia/fetcher": "workspace:^",
+    "tgrid": "^1.1.0",
+    "tstl": "^3.0.0"
+  },
   "devDependencies": {
     "@nestia/core": "workspace:^",
     "@nestia/e2e": "workspace:^",
@@ -36,11 +42,6 @@
     "typescript-transform-paths": "^3.4.7",
     "typia": "^8.0.0",
     "uuid": "^10.0.0"
-  },
-  "dependencies": {
-    "@nestia/fetcher": "workspace:^",
-    "tgrid": "^1.1.0",
-    "tstl": "^3.0.0"
   },
   "files": [
     "lib",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -729,7 +729,7 @@ importers:
         version: 3.0.0
       typia:
         specifier: ^8.0.0
-        version: 8.0.0(@samchon/openapi@3.0.0)(typescript@5.7.3)
+        version: 8.0.0(@samchon/openapi@3.0.0)(typescript@5.8.2)
       uuid:
         specifier: ^9.0.1
         version: 9.0.1
@@ -760,16 +760,16 @@ importers:
         version: link:../packages/cli
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@20.11.16)(typescript@5.7.3)
+        version: 10.9.2(@types/node@20.11.16)(typescript@5.8.2)
       ts-patch:
         specifier: ~3.3.0
         version: 3.3.0
       typescript:
-        specifier: ~5.7.3
-        version: 5.7.3
+        specifier: ~5.8.2
+        version: 5.8.2
       typescript-transform-paths:
         specifier: ^3.5.3
-        version: 3.5.3(typescript@5.7.3)
+        version: 3.5.3(typescript@5.8.2)
 
 packages:
 
@@ -4030,11 +4030,6 @@ packages:
     resolution: {integrity: sha512-5y2l2iPKNHKOj08/1i+02+ljBVUhWcXQLXomiOXCmNpiTuSxIkj0dM1LUE7OOAt53+/6KidY+sFTCP781J64Eg==}
     peerDependencies:
       typescript: '>=3.6.5'
-
-  typescript@5.7.3:
-    resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
 
   typescript@5.8.2:
     resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
@@ -7855,24 +7850,6 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  ts-node@10.9.2(@types/node@20.11.16)(typescript@5.7.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.11
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 20.11.16
-      acorn: 8.14.0
-      acorn-walk: 8.3.4
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.7.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-
   ts-node@10.9.2(@types/node@20.11.16)(typescript@5.8.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -7972,17 +7949,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  typescript-transform-paths@3.5.3(typescript@5.7.3):
-    dependencies:
-      minimatch: 9.0.5
-      typescript: 5.7.3
-
   typescript-transform-paths@3.5.3(typescript@5.8.2):
     dependencies:
       minimatch: 9.0.5
       typescript: 5.8.2
-
-  typescript@5.7.3: {}
 
   typescript@5.8.2: {}
 
@@ -7995,16 +7965,6 @@ snapshots:
       package-manager-detector: 0.2.10
       randexp: 0.5.3
       typescript: 5.8.2
-
-  typia@8.0.0(@samchon/openapi@3.0.0)(typescript@5.7.3):
-    dependencies:
-      '@samchon/openapi': 3.0.0
-      commander: 10.0.0
-      comment-json: 4.2.5
-      inquirer: 8.2.5
-      package-manager-detector: 0.2.10
-      randexp: 0.5.3
-      typescript: 5.7.3
 
   typia@8.0.0(@samchon/openapi@3.0.0)(typescript@5.8.2):
     dependencies:


### PR DESCRIPTION
This pull request includes several changes to the `packages/benchmark` and `pnpm-lock.yaml` files, focusing on updating dependencies and improving the deployment script. The most important changes include adding a new deployment script, updating the package version, and modifying dependency versions in the `pnpm-lock.yaml`.

### Deployment Script Update:
* [`packages/benchmark/deploy/publish.js`](diffhunk://#diff-9329c85263dc9d7dc857bcb5fe6fcb0e48b3cf03c77298ff2b9f7df20946d99dR1-R46): Added a new deployment script to handle the publishing process, including updating package versions and managing dependencies.

### Package Version Update:
* [`packages/benchmark/package.json`](diffhunk://#diff-03d34ead8faa24fcf5b6d74b52eaf57db4400f375b60698e3f5024e28b29b0e1R2-R4): Updated the package version from `0.4.0` to `0.4.3` and added the `private` field.

### Dependency Management:
* [`packages/benchmark/package.json`](diffhunk://#diff-03d34ead8faa24fcf5b6d74b52eaf57db4400f375b60698e3f5024e28b29b0e1R25-R29): Moved dependencies from `dependencies` to `devDependencies` and added new dependencies with the `workspace:^` specifier. [[1]](diffhunk://#diff-03d34ead8faa24fcf5b6d74b52eaf57db4400f375b60698e3f5024e28b29b0e1R25-R29) [[2]](diffhunk://#diff-03d34ead8faa24fcf5b6d74b52eaf57db4400f375b60698e3f5024e28b29b0e1L40-L44)

### `pnpm-lock.yaml` Updates:
* Updated TypeScript version from `5.7.3` to `5.8.2` in various sections, ensuring compatibility with the latest changes. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL732-R732) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL763-R772) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL4034-L4038) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7858-L7875) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7975-L7986) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7999-L8008)