### PR TITLE
`TestValidator.equals()` to consider function type

### DIFF
--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestia/e2e",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "E2E test utilify functions",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/e2e/src/internal/json_equal_to.ts
+++ b/packages/e2e/src/internal/json_equal_to.ts
@@ -7,7 +7,8 @@ export const json_equal_to =
       (accessor: string) =>
       (x: any) =>
       (y: any): void => {
-        if (typeof x !== typeof y) container.push(accessor);
+        if (typeof x === "function" || typeof y === "function") return;
+        else if (typeof x !== typeof y) container.push(accessor);
         else if (x instanceof Array)
           if (!(y instanceof Array)) container.push(accessor);
           else array(accessor)(x)(y);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -728,8 +728,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       typia:
-        specifier: ^8.0.0
-        version: 8.0.0(@samchon/openapi@3.0.0)(typescript@5.8.2)
+        specifier: ^8.0.2
+        version: 8.0.2(@samchon/openapi@3.0.0)(typescript@5.8.2)
       uuid:
         specifier: ^9.0.1
         version: 9.0.1
@@ -768,8 +768,8 @@ importers:
         specifier: ~5.8.2
         version: 5.8.2
       typescript-transform-paths:
-        specifier: ^3.5.3
-        version: 3.5.3(typescript@5.8.2)
+        specifier: ^3.5.4
+        version: 3.5.4(typescript@5.8.2)
 
 packages:
 
@@ -4031,6 +4031,11 @@ packages:
     peerDependencies:
       typescript: '>=3.6.5'
 
+  typescript-transform-paths@3.5.4:
+    resolution: {integrity: sha512-Yw/cLiwAlaTIYvO3wbCqiBIppTzsY45CBi1y+oedjtgcGMIy4xmI9ylkFiDlX2jqMqA1SY58vFPI4Y8VKkBCpA==}
+    peerDependencies:
+      typescript: '>=3.6.5'
+
   typescript@5.8.2:
     resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
     engines: {node: '>=14.17'}
@@ -4045,6 +4050,13 @@ packages:
 
   typia@8.0.0:
     resolution: {integrity: sha512-ulYqugl0rXStArmFBxTxwC796gW4KkRas7wy7hOYwtRulxfBOJlurZMZ9MA8lN9LrgOpX/bnW0bW3w75ws6wIA==}
+    hasBin: true
+    peerDependencies:
+      '@samchon/openapi': '>=3.0.0 <4.0.0'
+      typescript: '>=4.8.0 <5.9.0'
+
+  typia@8.0.2:
+    resolution: {integrity: sha512-xDacELBticuXx17TtPWhSd1thyE2MF74LZhhDoCFkpCKhiElnB40X/Jb3zMLRx86WUkqCH60rwm3ghaJdBs7hA==}
     hasBin: true
     peerDependencies:
       '@samchon/openapi': '>=3.0.0 <4.0.0'
@@ -7954,6 +7966,11 @@ snapshots:
       minimatch: 9.0.5
       typescript: 5.8.2
 
+  typescript-transform-paths@3.5.4(typescript@5.8.2):
+    dependencies:
+      minimatch: 9.0.5
+      typescript: 5.8.2
+
   typescript@5.8.2: {}
 
   typia@7.6.4(@samchon/openapi@3.0.0)(typescript@5.8.2):
@@ -7967,6 +7984,16 @@ snapshots:
       typescript: 5.8.2
 
   typia@8.0.0(@samchon/openapi@3.0.0)(typescript@5.8.2):
+    dependencies:
+      '@samchon/openapi': 3.0.0
+      commander: 10.0.0
+      comment-json: 4.2.5
+      inquirer: 8.2.5
+      package-manager-detector: 0.2.10
+      randexp: 0.5.3
+      typescript: 5.8.2
+
+  typia@8.0.2(@samchon/openapi@3.0.0)(typescript@5.8.2):
     dependencies:
       '@samchon/openapi': 3.0.0
       commander: 10.0.0


### PR DESCRIPTION
This pull request includes version updates for several dependencies and a minor fix in the `json_equal_to` function to handle function types properly.

Dependency updates:

* Updated `@nestia/e2e` version from `0.8.2` to `0.8.3` in `packages/e2e/package.json`.
* Updated `typia` version from `8.0.0` to `8.0.2` in `pnpm-lock.yaml`. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL731-R732) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4058-R4064) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR7996-R8005)
* Updated `typescript-transform-paths` version from `3.5.3` to `3.5.4` in `pnpm-lock.yaml`. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL771-R772) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4034-R4038) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR7969-R7973)

Code fix:

* Improved the `json_equal_to` function in `packages/e2e/src/internal/json_equal_to.ts` to handle cases where either `x` or `y` is a function, preventing incorrect type comparisons.