### PR TITLE
Fix `WebSocketAdaptor.d.ts` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@nestia/station",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "description": "Nestia station",
   "scripts": {
     "build": "node deploy build",

--- a/packages/core/src/adaptors/WebSocketAdaptor.ts
+++ b/packages/core/src/adaptors/WebSocketAdaptor.ts
@@ -38,7 +38,7 @@ export class WebSocketAdaptor {
       this.ws.close(() => resolve());
     });
 
-  protected constructor(app: INestApplication, operations: IOperator[]) {
+  private constructor(app: INestApplication, operations: IOperator[]) {
     this.operators = operations;
     this.ws = new WebSocket.Server({ noServer: true });
     this.http = app.getHttpServer();


### PR DESCRIPTION
This pull request includes a version bump for the `@nestia/station` package and a visibility change for the `WebSocketAdaptor` constructor to restrict its instantiation.

### Package Updates:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4): Updated the version from `6.0.2` to `6.0.3`.

### Codebase Changes:
* [`packages/core/src/adaptors/WebSocketAdaptor.ts`](diffhunk://#diff-65b576dc8cc421f86d1c43df9fcea5bd63a5534c39d041f945183361fbe9f7e0L41-R41): Changed the `WebSocketAdaptor` constructor from `protected` to `private`, limiting its accessibility and ensuring stricter control over its instantiation.