### PR TITLE
feat(migrate): support keyword mode in generator.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@nestia/station",
-  "version": "6.0.6",
+  "version": "7.0.0-dev.20250604",
   "description": "Nestia station",
   "scripts": {
     "build": "node deploy build",

--- a/packages/migrate/src/NestiaMigrateApplication.ts
+++ b/packages/migrate/src/NestiaMigrateApplication.ts
@@ -65,11 +65,7 @@ export class NestiaMigrateApplication {
     const context: INestiaMigrateContext = createContext(
       "nest",
       this.document,
-      {
-        simulate: config.simulate,
-        e2e: config.e2e,
-        author: config.author,
-      },
+      config,
     );
     const files: Record<string, string> = {
       ...Object.fromEntries(

--- a/packages/migrate/src/executable/NestiaMigrateCommander.ts
+++ b/packages/migrate/src/executable/NestiaMigrateCommander.ts
@@ -19,11 +19,12 @@ export namespace NestiaMigrateCommander {
 
     // VALIDATE OUTPUT DIRECTORY
     const parent: string = resolve(options.output + "/..")!;
-    if (fs.existsSync(options.output)) halt("Output directory already exists.");
+    if (fs.existsSync(options.output))
+      halt("Response directory already exists.");
     else if (fs.existsSync(parent) === false)
-      halt("Output directory's parent directory does not exist.");
+      halt("Response directory's parent directory does not exist.");
     else if (fs.statSync(parent).isDirectory() === false)
-      halt("Output directory's parent is not a directory.");
+      halt("Response directory's parent is not a directory.");
 
     // READ SWAGGER
     const document:

--- a/packages/migrate/src/executable/NestiaMigrateInquirer.ts
+++ b/packages/migrate/src/executable/NestiaMigrateInquirer.ts
@@ -70,7 +70,7 @@ export namespace NestiaMigrateInquirer {
         (value) => (value === "NestJS" ? "nest" : "sdk"),
       );
       partial.input ??= await input("input")("Swagger file location");
-      partial.output ??= await input("output")("Output directory path");
+      partial.output ??= await input("output")("Response directory path");
       partial.package ??= await input("package")("Package name");
       if (partial.simulate)
         partial.simulate = (partial.simulate as any) === "true";

--- a/packages/migrate/src/programmers/MigrateApiFileProgrammer.ts
+++ b/packages/migrate/src/programmers/MigrateApiFileProgrammer.ts
@@ -15,6 +15,7 @@ export namespace MigrateApiFileProgrammer {
     routes: IHttpMigrateRoute[];
     children: Set<string>;
   }
+
   export const write = (props: IProps): ts.Statement[] => {
     const importer: MigrateImportProgrammer = new MigrateImportProgrammer();
     const statements: ts.Statement[] = props.routes

--- a/packages/migrate/src/programmers/MigrateApiSimulationProgrammer.ts
+++ b/packages/migrate/src/programmers/MigrateApiSimulationProgrammer.ts
@@ -104,7 +104,7 @@ export namespace MigrateApiSimulationProgrammer {
         undefined,
         MigrateApiFunctionProgrammer.writeParameterDeclarations(ctx),
         ts.factory.createTypeReferenceNode(
-          ctx.route.success ? "Output" : "void",
+          ctx.route.success ? "Response" : "void",
         ),
         undefined,
         ts.factory.createBlock(
@@ -116,6 +116,13 @@ export namespace MigrateApiSimulationProgrammer {
   };
 
   const assert = (ctx: IContext): ts.Statement[] => {
+    const property = (key: string) =>
+      ctx.config.keyword === true
+        ? ts.factory.createPropertyAccessExpression(
+            ts.factory.createIdentifier("props"),
+            key,
+          )
+        : ts.factory.createIdentifier(key);
     const parameters = [
       ...ctx.route.parameters.map((p) => ({
         category: "param",
@@ -183,6 +190,7 @@ export namespace MigrateApiSimulationProgrammer {
               ts.factory.createPropertyAssignment(
                 "path",
                 MigrateApiNamespaceProgrammer.writePathCallExpression(
+                  ctx.config,
                   ctx.route,
                 ),
               ),
@@ -232,9 +240,9 @@ export namespace MigrateApiSimulationProgrammer {
                 ),
                 undefined,
                 [
-                  ts.factory.createIdentifier(
-                    p.category === "headers" ? "connection.headers" : p.name,
-                  ),
+                  p.category === "headers"
+                    ? ts.factory.createIdentifier("connection.headers")
+                    : property(p.name),
                 ],
               ),
             ),

--- a/packages/migrate/src/programmers/MigrateApiStartProgrammer.ts
+++ b/packages/migrate/src/programmers/MigrateApiStartProgrammer.ts
@@ -65,6 +65,7 @@ export namespace MigrateApiStartProgrammer {
           [
             writeConnection(ctx, importer),
             ...MigrateE2eFunctionProgrammer.writeBody({
+              config: ctx.config,
               components: ctx.document.components,
               importer,
               route,

--- a/packages/migrate/src/programmers/MigrateE2eProgrammer.ts
+++ b/packages/migrate/src/programmers/MigrateE2eProgrammer.ts
@@ -1,6 +1,7 @@
 import { IHttpMigrateRoute, OpenApi } from "@samchon/openapi";
 import ts from "typescript";
 
+import { INestiaMigrateConfig } from "../structures/INestiaMigrateConfig";
 import { INestiaMigrateContext } from "../structures/INestiaMigrateContext";
 import { INestiaMigrateFile } from "../structures/INestiaMigrateFile";
 import { FilePrinter } from "../utils/FilePrinter";
@@ -8,21 +9,21 @@ import { MigrateE2eFunctionProgrammer } from "./MigrateE2eFileProgrammer";
 import { MigrateImportProgrammer } from "./MigrateImportProgrammer";
 
 export namespace MigrateE2eProgrammer {
-  export const write = (
-    program: INestiaMigrateContext,
-  ): Record<string, string> =>
+  export const write = (ctx: INestiaMigrateContext): Record<string, string> =>
     Object.fromEntries(
-      program.routes
-        .map((r) => writeFile(program.document.components, r))
+      ctx.routes
+        .map((r) => writeFile(ctx.config, ctx.document.components, r))
         .map((r) => [`${r.location}/${r.file}`, r.content]),
     );
 
   const writeFile = (
+    config: INestiaMigrateConfig,
     components: OpenApi.IComponents,
     route: IHttpMigrateRoute,
   ): INestiaMigrateFile => {
     const importer: MigrateImportProgrammer = new MigrateImportProgrammer();
     const func: ts.FunctionDeclaration = MigrateE2eFunctionProgrammer.write({
+      config,
       components,
       importer,
       route,

--- a/packages/migrate/src/test/index.ts
+++ b/packages/migrate/src/test/index.ts
@@ -26,9 +26,10 @@ const execute = (
   config: INestiaMigrateConfig,
   project: string,
   document: SwaggerV2.IDocument | OpenApiV3.IDocument | OpenApiV3_1.IDocument,
-): Promise<number> =>
-  measure(`${project}-${mode}-${config.simulate}-${config.e2e}`)(async () => {
-    const directory = `${OUTPUT}/${project}-${mode}-${config.simulate}-${config.e2e}`;
+): Promise<number> => {
+  const title: string = `${project}-${mode}-${config.keyword ? "keyword" : "positional"}`;
+  return measure(title)(async () => {
+    const directory = `${OUTPUT}/${title}`;
     const result: IValidation<NestiaMigrateApplication> =
       await NestiaMigrateApplication.validate(document);
     if (result.success === false)
@@ -68,6 +69,7 @@ const execute = (
       cwd: directory,
     });
   });
+};
 
 const iterate = async (directory: string): Promise<void> => {
   const filter = (() => {
@@ -91,14 +93,16 @@ const iterate = async (directory: string): Promise<void> => {
       );
       for (const [mode, flag] of [
         ["nest", true],
+        ["nest", false],
         ["sdk", true],
         ["sdk", false],
       ] as const)
         await execute(
           mode,
           {
-            simulate: flag,
-            e2e: flag,
+            keyword: flag,
+            simulate: true,
+            e2e: true,
           },
           project,
           document,


### PR DESCRIPTION
This pull request introduces significant updates to the `Nestia` migration system, including a version bump, refactoring for improved code clarity, and changes to naming conventions. The most notable changes involve adjustments to how configuration and route-related data are handled, as well as updates to naming conventions for better semantic alignment.

### Version Update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4): Updated the package version from `6.0.6` to `7.0.0-dev.20250604`, signaling a major version upgrade and a development build.

### Refactoring for Configuration Handling:
* [`packages/migrate/src/NestiaMigrateApplication.ts`](diffhunk://#diff-0a5ce7730972391752dacee1705655af2b015a121715381435acb11a2925bd0dL68-R68): Simplified the creation of the migration context by passing the entire `config` object directly instead of destructuring individual properties.

### Naming Convention Updates:
* [`packages/migrate/src/executable/NestiaMigrateCommander.ts`](diffhunk://#diff-00d4f75241b886ca8dba6790ae86f43c5a60b9271a3ecd7d49ba06a5068c4f90L22-R27): Changed error messages to replace "Output directory" with "Response directory" for consistency.
* [`packages/migrate/src/executable/NestiaMigrateInquirer.ts`](diffhunk://#diff-0d7855107ddab348d1b6072274bd00bdbfd36f9948285537593bfedb411da66eL73-R73): Updated user input prompts to reflect the new naming convention, changing "Output directory path" to "Response directory path."
* [`packages/migrate/src/programmers/MigrateApiFunctionProgrammer.ts`](diffhunk://#diff-fa3f9722dc90ad9a8f4b90e7afaf58b2a0f7504cb8d7d258c379bd53135e8398L86-R107): Renamed route-related identifiers such as `Input` to `RequestBody`, `Output` to `Response`, and adjusted logic to use `props` for parameter grouping when `keyword` is enabled. [[1]](diffhunk://#diff-fa3f9722dc90ad9a8f4b90e7afaf58b2a0f7504cb8d7d258c379bd53135e8398L86-R107) [[2]](diffhunk://#diff-fa3f9722dc90ad9a8f4b90e7afaf58b2a0f7504cb8d7d258c379bd53135e8398L112-R141) [[3]](diffhunk://#diff-fa3f9722dc90ad9a8f4b90e7afaf58b2a0f7504cb8d7d258c379bd53135e8398L170-R199)
* [`packages/migrate/src/programmers/MigrateApiNamespaceProgrammer.ts`](diffhunk://#diff-d4b8a91d23acd7e08120451737c5657e992f32df9748ab94f830c577bac314b1R80-R107): Updated type alias names (`Input` → `RequestBody`, `Output` → `Response`) and added support for grouped properties (`IProps`) when `keyword` is enabled. [[1]](diffhunk://#diff-d4b8a91d23acd7e08120451737c5657e992f32df9748ab94f830c577bac314b1R80-R107) [[2]](diffhunk://#diff-d4b8a91d23acd7e08120451737c5657e992f32df9748ab94f830c577bac314b1L85-R119) [[3]](diffhunk://#diff-d4b8a91d23acd7e08120451737c5657e992f32df9748ab94f830c577bac314b1L94-R128)

### Codebase Simplification:
* [`packages/migrate/src/programmers/MigrateApiFunctionProgrammer.ts`](diffhunk://#diff-fa3f9722dc90ad9a8f4b90e7afaf58b2a0f7504cb8d7d258c379bd53135e8398R60-R81): Refactored parameter declaration logic to dynamically return grouped properties (`props`) when `keyword` is enabled, simplifying argument handling and reducing redundancy. [[1]](diffhunk://#diff-fa3f9722dc90ad9a8f4b90e7afaf58b2a0f7504cb8d7d258c379bd53135e8398R60-R81) [[2]](diffhunk://#diff-fa3f9722dc90ad9a8f4b90e7afaf58b2a0f7504cb8d7d258c379bd53135e8398L205-R254)
* [`packages/migrate/src/programmers/MigrateApiNamespaceProgrammer.ts`](diffhunk://#diff-d4b8a91d23acd7e08120451737c5657e992f32df9748ab94f830c577bac314b1L169-R244): Refactored path-related logic to dynamically handle grouped properties (`props`) based on configuration, improving flexibility and readability. [[1]](diffhunk://#diff-d4b8a91d23acd7e08120451737c5657e992f32df9748ab94f830c577bac314b1L169-R244) [[2]](diffhunk://#diff-d4b8a91d23acd7e08120451737c5657e992f32df9748ab94f830c577bac314b1L217-R285)

These changes collectively enhance the maintainability, readability, and semantic clarity of the codebase while introducing new features aligned with the updated version.