### PR TITLE
feat(migrate): path function also use 'Props' type.

### DIFF
--- a/packages/migrate/src/programmers/NestiaMigrateApiNamespaceProgrammer.ts
+++ b/packages/migrate/src/programmers/NestiaMigrateApiNamespaceProgrammer.ts
@@ -229,7 +229,7 @@ export namespace NestiaMigrateApiNamespaceProgrammer {
       ctx.route.parameters.length === 0 && ctx.route.query === null;
     const property = (key: string) =>
       ctx.config.keyword === true
-        ? IdentifierFactory.access(ts.factory.createIdentifier("p"), key)
+        ? IdentifierFactory.access(ts.factory.createIdentifier("props"), key)
         : ts.factory.createIdentifier(key);
     const out = (body: ts.ConciseBody) =>
       constant(
@@ -242,24 +242,15 @@ export namespace NestiaMigrateApiNamespaceProgrammer {
             : ctx.config.keyword === true
               ? [
                   IdentifierFactory.parameter(
-                    "p",
-                    NestiaMigrateSchemaProgrammer.write({
-                      components: ctx.components,
-                      importer: ctx.importer,
-                      schema: {
-                        type: "object",
-                        properties: Object.fromEntries([
-                          ...ctx.route.parameters.map((p) => [p.key, p.schema]),
-                          ...(ctx.route.query
-                            ? [[ctx.route.query.key, ctx.route.query.schema]]
-                            : []),
-                        ]),
-                        required: [
-                          ...ctx.route.parameters.map((p) => p.key),
-                          ...(ctx.route.query ? [ctx.route.query.key] : []),
-                        ],
-                      },
-                    }),
+                    "props",
+                    ctx.route.body
+                      ? ts.factory.createTypeReferenceNode("Omit", [
+                          ts.factory.createTypeReferenceNode("Props"),
+                          ts.factory.createLiteralTypeNode(
+                            ts.factory.createStringLiteral(ctx.route.body.key),
+                          ),
+                        ])
+                      : ts.factory.createTypeReferenceNode("Props"),
                   ),
                 ]
               : [


### PR DESCRIPTION
This pull request refactors the `NestiaMigrateApiNamespaceProgrammer` in `packages/migrate/src/programmers/NestiaMigrateApiNamespaceProgrammer.ts` to improve code readability and simplify parameter handling. The changes primarily involve replacing the identifier `p` with `props` and modifying the way schema-related parameters are handled.

### Refactoring for improved readability and parameter handling:

* Replaced the identifier `p` with `props` for better clarity in accessing properties. (`[packages/migrate/src/programmers/NestiaMigrateApiNamespaceProgrammer.tsL232-R232](diffhunk://#diff-74287fee092d719353a974c05dcca856d9fdaf8684a6c7c0661b8624a2fd587fL232-R232)`)
* Simplified schema-related parameter handling by replacing the detailed schema generation logic with a type reference to `Props`. Additionally, introduced conditional logic to handle cases where `ctx.route.body` exists, using `Omit` to exclude specific keys. (`[packages/migrate/src/programmers/NestiaMigrateApiNamespaceProgrammer.tsL245-R253](diffhunk://#diff-74287fee092d719353a974c05dcca856d9fdaf8684a6c7c0661b8624a2fd587fL245-R253)`)