### PR TITLE
feat(e2e): add context about test program for count test list

### DIFF
--- a/packages/e2e/test/index.ts
+++ b/packages/e2e/test/index.ts
@@ -9,7 +9,7 @@ async function main(): Promise<void> {
       const elapsed: number =
         new Date(exec.completed_at).getTime() -
         new Date(exec.started_at).getTime();
-      console.log(` - ${exec.name}: ${elapsed.toLocaleString()} ms`);
+      console.log(` - ${exec.context.executed}/${exec.context.total} ${exec.name}: ${elapsed.toLocaleString()} ms`);
     },
     simultaneous: 1,
   });


### PR DESCRIPTION
This pull request introduces enhancements to the `DynamicExecutor` namespace in `packages/e2e/src/DynamicExecutor.ts` to improve test execution tracking and filtering. Key changes include adding a new `IContext` interface for test execution context, modifying the executor logic to utilize this context, and introducing a utility function for filtering executable targets. Additionally, logging has been updated in `packages/e2e/test/index.ts` to include execution progress.

### Enhancements to test execution tracking:

* Added a new `IContext` interface to track the total, executed, succeeded, and failed test functions, as well as the test program's start time. This context is now part of the execution results. (`[packages/e2e/src/DynamicExecutor.tsR167-R204](diffhunk://#diff-b0df7fe1fe55993907695fe0a83790aebea7ae1505d17ad0397178b133a9fd47R167-R204)`)
* Updated the `iterate` function to initialize and manage the `IContext` object, passing it to the executor for tracking test execution progress. (`[packages/e2e/src/DynamicExecutor.tsL229-R280](diffhunk://#diff-b0df7fe1fe55993907695fe0a83790aebea7ae1505d17ad0397178b133a9fd47L229-R280)`)

### Improvements to executor logic:

* Modified the executor to accept the `IContext` object and update it with execution metrics (e.g., succeeded, failed, executed) for each test function. (`[packages/e2e/src/DynamicExecutor.tsL255-L263](diffhunk://#diff-b0df7fe1fe55993907695fe0a83790aebea7ae1505d17ad0397178b133a9fd47L255-L263)`)
* Added the `isExecuteTarget` utility function to filter test functions based on the execution prefix, type, or custom filter logic. This function is now used in the iteration process to determine executable targets. (`[[1]](diffhunk://#diff-b0df7fe1fe55993907695fe0a83790aebea7ae1505d17ad0397178b133a9fd47R246-R254)`, `[[2]](diffhunk://#diff-b0df7fe1fe55993907695fe0a83790aebea7ae1505d17ad0397178b133a9fd47L244-R298)`)

### Logging updates:

* Enhanced the logging in `packages/e2e/test/index.ts` to display the number of executed and total test functions alongside the test name and elapsed time. (`[packages/e2e/test/index.tsL12-R12](diffhunk://#diff-081e28f030f9a82ce37616c4a786d91ee02d4773f5bb1a5b8c623fd3a5308c52L12-R12)`)

### Preview

![스크린샷 2025-06-23 오후 4 14 23](https://github.com/user-attachments/assets/5e46ee16-7549-46eb-ab39-f6a32efd4508)
