### PR TITLE
Change `INestiaMigrateConfig`'s programmer type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@nestia/station",
-  "version": "7.2.3",
+  "version": "7.2.4",
   "description": "Nestia station",
   "scripts": {
     "build": "node deploy build",

--- a/packages/migrate/src/programmers/NestiaMigrateNestMethodProgrammer.ts
+++ b/packages/migrate/src/programmers/NestiaMigrateNestMethodProgrammer.ts
@@ -42,7 +42,7 @@ export namespace NestiaMigrateNestMethodProgrammer {
       undefined,
       writeParameters(ctx),
       ts.factory.createTypeReferenceNode("Promise", [output]),
-      ctx.config.programmer?.controllerMethod?.(ctx.route) ??
+      ctx.config.programmer?.controllerMethod?.(ctx) ??
         ts.factory.createBlock(
           [
             ...[

--- a/packages/migrate/src/structures/INestiaMigrateConfig.ts
+++ b/packages/migrate/src/structures/INestiaMigrateConfig.ts
@@ -1,5 +1,6 @@
-import { IHttpMigrateRoute } from "@samchon/openapi";
 import ts from "typescript";
+
+import { NestiaMigrateNestMethodProgrammer } from "../programmers/NestiaMigrateNestMethodProgrammer";
 
 export interface INestiaMigrateConfig {
   simulate: boolean;
@@ -11,6 +12,8 @@ export interface INestiaMigrateConfig {
     value: string;
   };
   programmer?: {
-    controllerMethod?: (route: IHttpMigrateRoute) => ts.Block;
+    controllerMethod?: (
+      ctx: NestiaMigrateNestMethodProgrammer.IContext,
+    ) => ts.Block;
   };
 }


### PR DESCRIPTION
This pull request refines the migration logic in the `NestiaMigrate` package by improving type definitions and enhancing the flexibility of the `controllerMethod` configuration. The most important changes include updating the `controllerMethod` signature to accept a broader context and removing an unused import.

### Enhancements to `controllerMethod` logic:

* [`packages/migrate/src/programmers/NestiaMigrateNestMethodProgrammer.ts`](diffhunk://#diff-f1e99926dfd3ccda6c85d3229ccbbdfe3fa70438546002a48aa56ff1eb58e2d0L45-R45): Updated the `controllerMethod` invocation to pass the full `ctx` object instead of just `ctx.route`, enabling more comprehensive access to context data.
* [`packages/migrate/src/structures/INestiaMigrateConfig.ts`](diffhunk://#diff-68fb008bf245a8926aab6a9f81f1998f973ebe8adf68f5581971c360a1aa3a40L14-R17): Modified the `controllerMethod` signature in the `INestiaMigrateConfig` interface to accept `NestiaMigrateNestMethodProgrammer.IContext` instead of `IHttpMigrateRoute`, allowing for richer context handling.

### Code cleanup:

* [`packages/migrate/src/structures/INestiaMigrateConfig.ts`](diffhunk://#diff-68fb008bf245a8926aab6a9f81f1998f973ebe8adf68f5581971c360a1aa3a40L1-R4): Removed an unused import of `IHttpMigrateRoute` from `@samchon/openapi`, reducing unnecessary dependencies.