### PR TITLE
Change programmer method once more

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@nestia/station",
-  "version": "7.2.4",
+  "version": "7.2.5",
   "description": "Nestia station",
   "scripts": {
     "build": "node deploy build",

--- a/packages/migrate/src/programmers/NestiaMigrateNestControllerProgrammer.ts
+++ b/packages/migrate/src/programmers/NestiaMigrateNestControllerProgrammer.ts
@@ -41,7 +41,10 @@ export namespace NestiaMigrateNestControllerProgrammer {
       props.controller.routes
         .map((route, index) => [
           ...(index !== 0 ? [FilePrinter.newLine() as any] : []),
-          NestiaMigrateNestMethodProgrammer.write({
+          (
+            props.config.programmer?.controllerMethod ??
+            NestiaMigrateNestMethodProgrammer.write
+          )({
             config: props.config,
             components: props.components,
             controller: props.controller,

--- a/packages/migrate/src/programmers/NestiaMigrateNestMethodProgrammer.ts
+++ b/packages/migrate/src/programmers/NestiaMigrateNestMethodProgrammer.ts
@@ -42,38 +42,37 @@ export namespace NestiaMigrateNestMethodProgrammer {
       undefined,
       writeParameters(ctx),
       ts.factory.createTypeReferenceNode("Promise", [output]),
-      ctx.config.programmer?.controllerMethod?.(ctx) ??
-        ts.factory.createBlock(
-          [
-            ...[
-              ...ctx.route.parameters.map((p) => p.key),
-              ...(ctx.route.headers ? ["headers"] : []),
-              ...(ctx.route.query ? ["query"] : []),
-              ...(ctx.route.body ? ["body"] : []),
-            ].map((str) =>
-              ts.factory.createExpressionStatement(
-                ts.factory.createIdentifier(str),
-              ),
+      ts.factory.createBlock(
+        [
+          ...[
+            ...ctx.route.parameters.map((p) => p.key),
+            ...(ctx.route.headers ? ["headers"] : []),
+            ...(ctx.route.query ? ["query"] : []),
+            ...(ctx.route.body ? ["body"] : []),
+          ].map((str) =>
+            ts.factory.createExpressionStatement(
+              ts.factory.createIdentifier(str),
             ),
-            ts.factory.createReturnStatement(
-              ts.factory.createCallExpression(
-                IdentifierFactory.access(
-                  ts.factory.createIdentifier(
-                    ctx.importer.external({
-                      type: "default",
-                      library: "typia",
-                      name: "typia",
-                    }),
-                  ),
-                  "random",
+          ),
+          ts.factory.createReturnStatement(
+            ts.factory.createCallExpression(
+              IdentifierFactory.access(
+                ts.factory.createIdentifier(
+                  ctx.importer.external({
+                    type: "default",
+                    library: "typia",
+                    name: "typia",
+                  }),
                 ),
-                [output],
-                undefined,
+                "random",
               ),
+              [output],
+              undefined,
             ),
-          ],
-          true,
-        ),
+          ),
+        ],
+        true,
+      ),
     );
     return FilePrinter.description(
       method,

--- a/packages/migrate/src/structures/INestiaMigrateConfig.ts
+++ b/packages/migrate/src/structures/INestiaMigrateConfig.ts
@@ -14,6 +14,6 @@ export interface INestiaMigrateConfig {
   programmer?: {
     controllerMethod?: (
       ctx: NestiaMigrateNestMethodProgrammer.IContext,
-    ) => ts.Block;
+    ) => ts.MethodDeclaration;
   };
 }


### PR DESCRIPTION
This pull request introduces updates to versioning, enhances configurability in the migration programmer, and refines type definitions for improved flexibility. The most significant changes include updating the package version, adding support for custom controller method programmers, and modifying type definitions for programmer configuration.

### Versioning Update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4): Updated the version from `7.2.4` to `7.2.5`.

### Enhancements to Migration Programmer Configurability:
* [`packages/migrate/src/programmers/NestiaMigrateNestControllerProgrammer.ts`](diffhunk://#diff-942e7c6253aa3a0ff15f10b58d3b4f12fc7207ab8312fe517d91e87c3536193eL44-R47): Added support for custom controller method programmers by invoking `props.config.programmer?.controllerMethod` if defined, otherwise falling back to `NestiaMigrateNestMethodProgrammer.write`.
* [`packages/migrate/src/programmers/NestiaMigrateNestMethodProgrammer.ts`](diffhunk://#diff-f1e99926dfd3ccda6c85d3229ccbbdfe3fa70438546002a48aa56ff1eb58e2d0L45): Removed redundant fallback logic for `controllerMethod` invocation, simplifying the code.

### Type Definition Refinement:
* [`packages/migrate/src/structures/INestiaMigrateConfig.ts`](diffhunk://#diff-68fb008bf245a8926aab6a9f81f1998f973ebe8adf68f5581971c360a1aa3a40L17-R17): Changed the type of `controllerMethod` in the `programmer` configuration from `ts.Block` to `ts.MethodDeclaration`, allowing more precise customization of method declarations.