### PR TITLE
Bump up TypeScript to v5.9.2

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -42,7 +42,7 @@
     "reflect-metadata": "^0.2.2",
     "tgrid": "^1.1.0",
     "tstl": "^3.0.0",
-    "typia": "^9.5.0"
+    "typia": "^9.6.1"
   },
   "devDependencies": {
     "@types/autocannon": "^7.9.0",
@@ -53,6 +53,6 @@
     "rimraf": "^6.0.1",
     "ts-node": "^10.9.1",
     "ts-patch": "^3.3.0",
-    "typescript": "~5.8.3"
+    "typescript": "~5.9.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@nestia/station",
-  "version": "7.3.1",
+  "version": "7.3.2",
   "description": "Nestia station",
   "scripts": {
     "build": "node deploy build",

--- a/packages/benchmark/package.json
+++ b/packages/benchmark/package.json
@@ -45,9 +45,9 @@
     "nestia": "workspace:^",
     "ts-node": "^10.9.2",
     "ts-patch": "^3.3.0",
-    "typescript": "~5.8.3",
+    "typescript": "~5.9.2",
     "typescript-transform-paths": "^3.4.7",
-    "typia": "^9.5.0",
+    "typia": "^9.6.1",
     "uuid": "^10.0.0"
   },
   "files": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -42,7 +42,7 @@
     "@types/inquirer": "^9.0.3",
     "@types/node": "^18.11.16",
     "rimraf": "^6.0.1",
-    "typescript": "~5.8.3"
+    "typescript": "~5.9.2"
   },
   "files": [
     "bin",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,7 +48,7 @@
     "reflect-metadata": ">=0.1.12",
     "rxjs": ">=6.0.3",
     "tgrid": "^1.1.0",
-    "typia": "^9.5.0",
+    "typia": "^9.6.1",
     "ws": "^7.5.3"
   },
   "peerDependencies": {
@@ -58,7 +58,7 @@
     "@samchon/openapi": ">=4.5.0 <5.0.0",
     "reflect-metadata": ">=0.1.12",
     "rxjs": ">=6.0.3",
-    "typia": ">=9.5.0 <10.0.0"
+    "typia": ">=9.6.1 <10.0.0"
   },
   "devDependencies": {
     "@nestjs/common": "^11.0.13",
@@ -80,7 +80,7 @@
     "ts-node": "^10.9.1",
     "ts-patch": "^3.3.0",
     "tstl": "^3.0.0",
-    "typescript": "~5.8.3"
+    "typescript": "~5.9.2"
   },
   "files": [
     "README.md",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -58,7 +58,7 @@
     "@samchon/openapi": ">=4.5.0 <5.0.0",
     "reflect-metadata": ">=0.1.12",
     "rxjs": ">=6.0.3",
-    "typia": ">=9.6.1 <10.0.0"
+    "typia": "^9.6.1"
   },
   "devDependencies": {
     "@nestjs/common": "^11.0.13",

--- a/packages/core/src/decorators/TypedFormData.ts
+++ b/packages/core/src/decorators/TypedFormData.ts
@@ -18,32 +18,34 @@ import { validate_request_form_data } from "./internal/validate_request_form_dat
  * `multipart/form-data` content type. It automatically casts property type
  * following its DTO definition, and performs the type validation too.
  *
- * Also, `TypedFormData.Body()` is much easier and type safer than `@nest.UploadFile()`.
- * If you're considering the [SDK library](https://nestia.io/docs/sdk/sdk) generation,
- * only `TypedFormData.Body()` can do it. Therefore, I recommend you to use
+ * Also, `TypedFormData.Body()` is much easier and type safer than
+ * `@nest.UploadFile()`. If you're considering the [SDK
+ * library](https://nestia.io/docs/sdk/sdk) generation, only
+ * `TypedFormData.Body()` can do it. Therefore, I recommend you to use
  * `TypedFormData.Body()` instead of the `@nest.UploadFile()` function.
  *
- * For reference, target type `T` must follow such restriction. Of course, if actual
- * form-data values are different with their promised type `T`,
+ * For reference, target type `T` must follow such restriction. Of course, if
+ * actual form-data values are different with their promised type `T`,
  * `BadRequestException` error (status code: 400) would be thrown.
  *
  * 1. Type `T` must be an object type
  * 2. Do not allow dynamic property
- * 3. Only `boolean`, `bigint`, `number`, `string`, `Blob`, `File` or their array types are allowed
+ * 3. Only `boolean`, `bigint`, `number`, `string`, `Blob`, `File` or their array
+ *    types are allowed
  * 4. By the way, union type never be not allowed
  *
- * By the way, if you're using `fastify`, you have to setup `fastify-multer`
- * and configure like below when composing the NestJS application. If you don't do
+ * By the way, if you're using `fastify`, you have to setup `fastify-multer` and
+ * configure like below when composing the NestJS application. If you don't do
  * that, `@TypedFormData.Body()` will not work properly, and throw 500 internal
  * server error when `Blob` or `File` type being utilized.
  *
  * ```typescript
- * import fastifyMulter from "fastify-multer";
  * import { NestFactory } from "@nestjs/core";
  * import {
  *   FastifyAdapter,
- *   NestFastifyApplication
+ *   NestFastifyApplication,
  * } from "@nestjs/platform-fastify";
+ * import fastifyMulter from "fastify-multer";
  *
  * export async function main() {
  *   const app = await NestFactory.create<NestFastifyApplication>(
@@ -55,8 +57,8 @@ import { validate_request_form_data } from "./internal/validate_request_form_dat
  * }
  * ```
  *
- * @todo Change to ReadableStream through configuring storage engine of multer
  * @author Jeongho Nam - https://github.com/samchon
+ * @todo Change to ReadableStream through configuring storage engine of multer
  */
 export namespace TypedFormData {
   /**
@@ -67,16 +69,14 @@ export namespace TypedFormData {
    * Much easier and type safer than `@nest.UploadFile()` decorator.
    *
    * @param factory Factory function ncreating the `multer` or `fastify-multer`
-   *                instance. In the factory function, you also can specify the
-   *                multer composition options like `storage` engine.
+   *   instance. In the factory function, you also can specify the multer
+   *   composition options like `storage` engine.
    */
   export function Body<Multer extends IMulterBase>(
     factory: () => Multer | Promise<Multer>,
   ): ParameterDecorator;
 
-  /**
-   * @internal
-   */
+  /** @internal */
   export function Body<T extends object>(
     factory: () => Promise<IMulterBase>,
     props?: IRequestFormDataProps<T> | undefined,
@@ -111,9 +111,7 @@ export namespace TypedFormData {
     })();
   }
 
-  /**
-   * Base type of the `multer` or `fastify-multer`.
-   */
+  /** Base type of the `multer` or `fastify-multer`. */
   export interface IMulterBase {
     single(fieldName: string): any;
     array(fieldName: string, maxCount?: number): any;
@@ -123,9 +121,7 @@ export namespace TypedFormData {
   }
 }
 
-/**
- * @internal
- */
+/** @internal */
 const decode = <T>(
   multer: ExpressMulter.Multer,
   props: IRequestFormDataProps<T>,
@@ -159,9 +155,7 @@ const decode = <T>(
   };
 };
 
-/**
- * @internal
- */
+/** @internal */
 const parseFiles =
   (data: FormData) =>
   (files: Express.Multer.File[] | Record<string, Express.Multer.File[]>) => {
@@ -169,24 +163,30 @@ const parseFiles =
       for (const file of files)
         data.append(
           file.fieldname,
-          new File([file.buffer], file.originalname, {
-            type: file.mimetype,
-          }),
+          new File(
+            [file.buffer satisfies Uint8Array as any],
+            file.originalname,
+            {
+              type: file.mimetype,
+            },
+          ),
         );
     else
       for (const [key, value] of Object.entries(files))
         for (const file of value)
           data.append(
             key,
-            new File([file.buffer], file.originalname, {
-              type: file.mimetype,
-            }),
+            new File(
+              [file.buffer satisfies Uint8Array as any],
+              file.originalname,
+              {
+                type: file.mimetype,
+              },
+            ),
           );
   };
 
-/**
- * @internal
- */
+/** @internal */
 const isMultipartFormData = (text?: string): boolean =>
   text !== undefined &&
   text

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -39,9 +39,9 @@
     "rimraf": "^6.0.1",
     "ts-node": "^10.9.1",
     "ts-patch": "^3.3.0",
-    "typescript": "~5.8.3",
+    "typescript": "~5.9.2",
     "typescript-transform-paths": "^3.4.7",
-    "typia": "^9.5.0"
+    "typia": "^9.6.1"
   },
   "files": [
     "lib",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -44,7 +44,7 @@
     "prettier": "3.3.3",
     "prettier-plugin-jsdoc": "^1.3.2",
     "react-mui-fileuploader": "^0.5.2",
-    "typia": "^9.5.0"
+    "typia": "^9.6.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.13.0",
@@ -67,7 +67,7 @@
     "react-dom": "^18.3.1",
     "rollup": "^4.24.2",
     "ts-node": "^10.9.2",
-    "typescript": "~5.8.3",
+    "typescript": "~5.9.2",
     "typescript-eslint": "^8.10.0",
     "vite": "^5.4.9"
   },

--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -33,7 +33,7 @@
     "@typescript-eslint/eslint-plugin": "^5.46.1",
     "@typescript-eslint/parser": "^5.46.1",
     "rimraf": "^6.0.1",
-    "typescript": "~5.8.3"
+    "typescript": "~5.9.2"
   },
   "files": [
     "README.md",

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -78,8 +78,8 @@
     "prettier": "^3.3.3",
     "prettier-plugin-jsdoc": "^1.3.2",
     "tstl": "^3.0.0",
-    "typescript": "~5.8.3",
-    "typia": "^9.5.0"
+    "typescript": "~5.9.2",
+    "typia": "^9.6.1"
   },
   "files": [
     "lib",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -44,7 +44,7 @@
     "tsconfck": "^2.1.2",
     "tsconfig-paths": "^4.1.1",
     "tstl": "^3.0.0",
-    "typia": "^9.5.0"
+    "typia": "^9.6.1"
   },
   "peerDependencies": {
     "@nestia/core": ">=7.1.1-dev.20250714"
@@ -64,7 +64,7 @@
     "rimraf": "^6.0.1",
     "tgrid": "^1.1.0",
     "ts-patch": "^3.3.0",
-    "typescript": "~5.8.3",
+    "typescript": "~5.9.2",
     "typescript-transform-paths": "^3.4.4"
   },
   "files": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,8 +78,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       typia:
-        specifier: ^9.5.0
-        version: 9.5.0(typescript@5.8.3)
+        specifier: ^9.6.1
+        version: 9.6.1(typescript@5.9.2)
     devDependencies:
       '@types/autocannon':
         specifier: ^7.9.0
@@ -101,13 +101,13 @@ importers:
         version: 6.0.1
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(@types/node@20.11.16)(typescript@5.8.3)
+        version: 10.9.2(@types/node@20.11.16)(typescript@5.9.2)
       ts-patch:
         specifier: ^3.3.0
         version: 3.3.0
       typescript:
-        specifier: ~5.8.3
-        version: 5.8.3
+        specifier: ~5.9.2
+        version: 5.9.2
 
   packages/benchmark:
     dependencies:
@@ -147,19 +147,19 @@ importers:
         version: link:../cli
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.16.4)(typescript@5.8.3)
+        version: 10.9.2(@types/node@22.16.4)(typescript@5.9.2)
       ts-patch:
         specifier: ^3.3.0
         version: 3.3.0
       typescript:
-        specifier: ~5.8.3
-        version: 5.8.3
+        specifier: ~5.9.2
+        version: 5.9.2
       typescript-transform-paths:
         specifier: ^3.4.7
-        version: 3.5.5(typescript@5.8.3)
+        version: 3.5.5(typescript@5.9.2)
       typia:
-        specifier: ^9.5.0
-        version: 9.5.0(typescript@5.8.3)
+        specifier: ^9.6.1
+        version: 9.6.1(typescript@5.9.2)
       uuid:
         specifier: ^10.0.0
         version: 10.0.0
@@ -195,8 +195,8 @@ importers:
         specifier: ^6.0.1
         version: 6.0.1
       typescript:
-        specifier: ~5.8.3
-        version: 5.8.3
+        specifier: ~5.9.2
+        version: 5.9.2
 
   packages/core:
     dependencies:
@@ -237,8 +237,8 @@ importers:
         specifier: ^1.1.0
         version: 1.2.0
       typia:
-        specifier: ^9.5.0
-        version: 9.5.0(typescript@5.8.3)
+        specifier: ^9.6.1
+        version: 9.6.1(typescript@5.9.2)
       ws:
         specifier: ^7.5.3
         version: 7.5.10
@@ -260,10 +260,10 @@ importers:
         version: 8.18.1
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.46.1
-        version: 5.62.0(@typescript-eslint/parser@5.62.0(eslint@9.31.0)(typescript@5.8.3))(eslint@9.31.0)(typescript@5.8.3)
+        version: 5.62.0(@typescript-eslint/parser@5.62.0(eslint@9.31.0)(typescript@5.9.2))(eslint@9.31.0)(typescript@5.9.2)
       '@typescript-eslint/parser':
         specifier: ^5.46.1
-        version: 5.62.0(eslint@9.31.0)(typescript@5.8.3)
+        version: 5.62.0(eslint@9.31.0)(typescript@5.9.2)
       commander:
         specifier: ^10.0.0
         version: 10.0.0
@@ -272,7 +272,7 @@ importers:
         version: 4.2.5
       eslint-plugin-deprecation:
         specifier: ^1.4.1
-        version: 1.6.0(eslint@9.31.0)(typescript@5.8.3)
+        version: 1.6.0(eslint@9.31.0)(typescript@5.9.2)
       fastify:
         specifier: ^4.28.1
         version: 4.29.1
@@ -287,7 +287,7 @@ importers:
         version: 6.0.1
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(@types/node@22.16.4)(typescript@5.8.3)
+        version: 10.9.2(@types/node@22.16.4)(typescript@5.9.2)
       ts-patch:
         specifier: ^3.3.0
         version: 3.3.0
@@ -295,8 +295,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       typescript:
-        specifier: ~5.8.3
-        version: 5.8.3
+        specifier: ~5.9.2
+        version: 5.9.2
 
   packages/e2e:
     devDependencies:
@@ -308,28 +308,28 @@ importers:
         version: 18.19.119
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.57.0
-        version: 5.62.0(@typescript-eslint/parser@5.62.0(eslint@9.31.0)(typescript@5.8.3))(eslint@9.31.0)(typescript@5.8.3)
+        version: 5.62.0(@typescript-eslint/parser@5.62.0(eslint@9.31.0)(typescript@5.9.2))(eslint@9.31.0)(typescript@5.9.2)
       '@typescript-eslint/parser':
         specifier: ^5.57.0
-        version: 5.62.0(eslint@9.31.0)(typescript@5.8.3)
+        version: 5.62.0(eslint@9.31.0)(typescript@5.9.2)
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(@types/node@18.19.119)(typescript@5.8.3)
+        version: 10.9.2(@types/node@18.19.119)(typescript@5.9.2)
       ts-patch:
         specifier: ^3.3.0
         version: 3.3.0
       typescript:
-        specifier: ~5.8.3
-        version: 5.8.3
+        specifier: ~5.9.2
+        version: 5.9.2
       typescript-transform-paths:
         specifier: ^3.4.7
-        version: 3.5.5(typescript@5.8.3)
+        version: 3.5.5(typescript@5.9.2)
       typia:
-        specifier: ^9.5.0
-        version: 9.5.0(typescript@5.8.3)
+        specifier: ^9.6.1
+        version: 9.6.1(typescript@5.9.2)
 
   packages/editor:
     dependencies:
@@ -361,8 +361,8 @@ importers:
         specifier: ^0.5.2
         version: 0.5.2(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@mui/icons-material@5.18.0(@mui/material@5.18.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@mui/material@5.18.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.23)(prop-types@15.8.1)
       typia:
-        specifier: ^9.5.0
-        version: 9.5.0(typescript@5.8.3)
+        specifier: ^9.6.1
+        version: 9.6.1(typescript@5.9.2)
     devDependencies:
       '@eslint/js':
         specifier: ^9.13.0
@@ -384,7 +384,7 @@ importers:
         version: 0.4.4(rollup@4.45.1)
       '@rollup/plugin-typescript':
         specifier: ^12.1.1
-        version: 12.1.4(rollup@4.45.1)(tslib@2.8.1)(typescript@5.8.3)
+        version: 12.1.4(rollup@4.45.1)(tslib@2.8.1)(typescript@5.9.2)
       '@types/js-yaml':
         specifier: ^4.0.9
         version: 4.0.9
@@ -423,13 +423,13 @@ importers:
         version: 4.45.1
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.16.4)(typescript@5.8.3)
+        version: 10.9.2(@types/node@22.16.4)(typescript@5.9.2)
       typescript:
-        specifier: ~5.8.3
-        version: 5.8.3
+        specifier: ~5.9.2
+        version: 5.9.2
       typescript-eslint:
         specifier: ^8.10.0
-        version: 8.37.0(eslint@9.31.0)(typescript@5.8.3)
+        version: 8.37.0(eslint@9.31.0)(typescript@5.9.2)
       vite:
         specifier: ^5.4.9
         version: 5.4.19(@types/node@22.16.4)(terser@5.43.1)
@@ -445,16 +445,16 @@ importers:
         version: 18.19.119
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.46.1
-        version: 5.62.0(@typescript-eslint/parser@5.62.0(eslint@9.31.0)(typescript@5.8.3))(eslint@9.31.0)(typescript@5.8.3)
+        version: 5.62.0(@typescript-eslint/parser@5.62.0(eslint@9.31.0)(typescript@5.9.2))(eslint@9.31.0)(typescript@5.9.2)
       '@typescript-eslint/parser':
         specifier: ^5.46.1
-        version: 5.62.0(eslint@9.31.0)(typescript@5.8.3)
+        version: 5.62.0(eslint@9.31.0)(typescript@5.9.2)
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1
       typescript:
-        specifier: ~5.8.3
-        version: 5.8.3
+        specifier: ~5.9.2
+        version: 5.9.2
 
   packages/migrate:
     dependencies:
@@ -477,11 +477,11 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       typescript:
-        specifier: ~5.8.3
-        version: 5.8.3
+        specifier: ~5.9.2
+        version: 5.9.2
       typia:
-        specifier: ^9.5.0
-        version: 9.5.0(typescript@5.8.3)
+        specifier: ^9.6.1
+        version: 9.6.1(typescript@5.9.2)
     devDependencies:
       '@nestia/benchmark':
         specifier: workspace:^
@@ -515,7 +515,7 @@ importers:
         version: 0.4.4(rollup@4.45.1)
       '@rollup/plugin-typescript':
         specifier: ^12.1.1
-        version: 12.1.4(rollup@4.45.1)(tslib@2.8.1)(typescript@5.8.3)
+        version: 12.1.4(rollup@4.45.1)(tslib@2.8.1)(typescript@5.9.2)
       '@trivago/prettier-plugin-sort-imports':
         specifier: ^4.3.0
         version: 4.3.0(prettier@3.3.3)
@@ -575,13 +575,13 @@ importers:
         version: 1.2.0
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(@types/node@20.11.16)(typescript@5.8.3)
+        version: 10.9.2(@types/node@20.11.16)(typescript@5.9.2)
       ts-patch:
         specifier: ^3.3.0
         version: 3.3.0
       typescript-transform-paths:
         specifier: ^3.5.2
-        version: 3.5.5(typescript@5.8.3)
+        version: 3.5.5(typescript@5.9.2)
 
   packages/sdk:
     dependencies:
@@ -611,10 +611,10 @@ importers:
         version: 3.3.3
       ts-node:
         specifier: '>=10.6.0'
-        version: 10.9.2(@types/node@18.19.119)(typescript@5.8.3)
+        version: 10.9.2(@types/node@18.19.119)(typescript@5.9.2)
       tsconfck:
         specifier: ^2.1.2
-        version: 2.1.2(typescript@5.8.3)
+        version: 2.1.2(typescript@5.9.2)
       tsconfig-paths:
         specifier: ^4.1.1
         version: 4.2.0
@@ -622,8 +622,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       typia:
-        specifier: ^9.5.0
-        version: 9.5.0(typescript@5.8.3)
+        specifier: ^9.6.1
+        version: 9.6.1(typescript@5.9.2)
     devDependencies:
       '@nestjs/common':
         specifier: ^11.0.13
@@ -648,16 +648,16 @@ importers:
         version: ts-expose-internals@5.4.5
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.46.1
-        version: 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3)
+        version: 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2)
       '@typescript-eslint/parser':
         specifier: ^5.46.1
-        version: 5.62.0(eslint@8.57.1)(typescript@5.8.3)
+        version: 5.62.0(eslint@8.57.1)(typescript@5.9.2)
       eslint:
         specifier: ^8.29.0
         version: 8.57.1
       eslint-plugin-deprecation:
         specifier: ^1.4.1
-        version: 1.6.0(eslint@8.57.1)(typescript@5.8.3)
+        version: 1.6.0(eslint@8.57.1)(typescript@5.9.2)
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1
@@ -668,11 +668,11 @@ importers:
         specifier: ^3.3.0
         version: 3.3.0
       typescript:
-        specifier: ~5.8.3
-        version: 5.8.3
+        specifier: ~5.9.2
+        version: 5.9.2
       typescript-transform-paths:
         specifier: ^3.4.4
-        version: 3.5.5(typescript@5.8.3)
+        version: 3.5.5(typescript@5.9.2)
 
   test:
     dependencies:
@@ -705,7 +705,7 @@ importers:
         version: 4.5.0
       embed-typescript:
         specifier: ^1.1.0
-        version: 1.1.0(typescript@5.8.3)
+        version: 1.1.0(typescript@5.9.2)
       express:
         specifier: ^4.21.1
         version: 4.21.2
@@ -725,8 +725,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       typia:
-        specifier: ^9.5.0
-        version: 9.5.0(typescript@5.8.3)
+        specifier: ^9.6.1
+        version: 9.6.1(typescript@5.9.2)
       uuid:
         specifier: ^10.0.0
         version: 10.0.0
@@ -757,16 +757,16 @@ importers:
         version: link:../packages/cli
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@20.11.16)(typescript@5.8.3)
+        version: 10.9.2(@types/node@20.11.16)(typescript@5.9.2)
       ts-patch:
         specifier: ~3.3.0
         version: 3.3.0
       typescript:
-        specifier: ~5.8.3
-        version: 5.8.3
+        specifier: ~5.9.2
+        version: 5.9.2
       typescript-transform-paths:
         specifier: ^3.5.5
-        version: 3.5.5(typescript@5.8.3)
+        version: 3.5.5(typescript@5.9.2)
 
 packages:
 
@@ -1581,6 +1581,9 @@ packages:
 
   '@samchon/openapi@4.5.0':
     resolution: {integrity: sha512-zowWJBjoKC7PUjHGIGUz6Ka3UFkvHagJ/LrdW8hGMp+4JlKmyuN9BPggK+VnH5bf8V68fPqSGVLZppcFQDBNPQ==}
+
+  '@samchon/openapi@4.6.0':
+    resolution: {integrity: sha512-h6NunOljbRJ1qiPIJCIckF0k3n3jBJZSSCFy/AjbmHSrAFwMeewHkWtTwQrZztVzcD0LsSQgTGRvPX1bclnVuA==}
 
   '@scarf/scarf@1.4.0':
     resolution: {integrity: sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==}
@@ -4181,16 +4184,16 @@ packages:
     peerDependencies:
       typescript: '>=3.6.5'
 
-  typescript@5.8.3:
-    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
+  typescript@5.9.2:
+    resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typia@9.5.0:
-    resolution: {integrity: sha512-HVQ5BR95NAmlEO+NGRqKz+EOEXktAqjKdelhms1rIj68mdDI1TzA7MUfNa4D6Ois95PcDdCgq9gwZiO+HXFC/g==}
+  typia@9.6.1:
+    resolution: {integrity: sha512-AXW1SeeGeOdG92tyTll+9kr4w/AsD+LgwNZK3RL4A5ZMjqvoVmdv0slPNWxV5B+obCCotgIWhBbNrft8nUPOog==}
     hasBin: true
     peerDependencies:
-      typescript: '>=4.8.0 <5.9.0'
+      typescript: '>=4.8.0 <5.10.0'
 
   uid@2.0.2:
     resolution: {integrity: sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g==}
@@ -5105,11 +5108,11 @@ snapshots:
     optionalDependencies:
       rollup: 4.45.1
 
-  '@rollup/plugin-typescript@12.1.4(rollup@4.45.1)(tslib@2.8.1)(typescript@5.8.3)':
+  '@rollup/plugin-typescript@12.1.4(rollup@4.45.1)(tslib@2.8.1)(typescript@5.9.2)':
     dependencies:
       '@rollup/pluginutils': 5.2.0(rollup@4.45.1)
       resolve: 1.22.10
-      typescript: 5.8.3
+      typescript: 5.9.2
     optionalDependencies:
       rollup: 4.45.1
       tslib: 2.8.1
@@ -5183,6 +5186,8 @@ snapshots:
     optional: true
 
   '@samchon/openapi@4.5.0': {}
+
+  '@samchon/openapi@4.6.0': {}
 
   '@scarf/scarf@1.4.0': {}
 
@@ -5519,103 +5524,103 @@ snapshots:
     dependencies:
       '@types/node': 18.19.119
 
-  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3)':
+  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@5.8.3)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@5.9.2)
       '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/type-utils': 5.62.0(eslint@8.57.1)(typescript@5.8.3)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.8.3)
+      '@typescript-eslint/type-utils': 5.62.0(eslint@8.57.1)(typescript@5.9.2)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.9.2)
       debug: 4.4.1
       eslint: 8.57.1
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare-lite: 1.4.0
       semver: 7.7.2
-      tsutils: 3.21.0(typescript@5.8.3)
+      tsutils: 3.21.0(typescript@5.9.2)
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@9.31.0)(typescript@5.8.3))(eslint@9.31.0)(typescript@5.8.3)':
+  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@9.31.0)(typescript@5.9.2))(eslint@9.31.0)(typescript@5.9.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 5.62.0(eslint@9.31.0)(typescript@5.8.3)
+      '@typescript-eslint/parser': 5.62.0(eslint@9.31.0)(typescript@5.9.2)
       '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/type-utils': 5.62.0(eslint@9.31.0)(typescript@5.8.3)
-      '@typescript-eslint/utils': 5.62.0(eslint@9.31.0)(typescript@5.8.3)
+      '@typescript-eslint/type-utils': 5.62.0(eslint@9.31.0)(typescript@5.9.2)
+      '@typescript-eslint/utils': 5.62.0(eslint@9.31.0)(typescript@5.9.2)
       debug: 4.4.1
       eslint: 9.31.0
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare-lite: 1.4.0
       semver: 7.7.2
-      tsutils: 3.21.0(typescript@5.8.3)
+      tsutils: 3.21.0(typescript@5.9.2)
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.37.0(@typescript-eslint/parser@8.37.0(eslint@9.31.0)(typescript@5.8.3))(eslint@9.31.0)(typescript@5.8.3)':
+  '@typescript-eslint/eslint-plugin@8.37.0(@typescript-eslint/parser@8.37.0(eslint@9.31.0)(typescript@5.9.2))(eslint@9.31.0)(typescript@5.9.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.37.0(eslint@9.31.0)(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.37.0(eslint@9.31.0)(typescript@5.9.2)
       '@typescript-eslint/scope-manager': 8.37.0
-      '@typescript-eslint/type-utils': 8.37.0(eslint@9.31.0)(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.37.0(eslint@9.31.0)(typescript@5.8.3)
+      '@typescript-eslint/type-utils': 8.37.0(eslint@9.31.0)(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.37.0(eslint@9.31.0)(typescript@5.9.2)
       '@typescript-eslint/visitor-keys': 8.37.0
       eslint: 9.31.0
       graphemer: 1.4.0
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.1.0(typescript@5.8.3)
-      typescript: 5.8.3
+      ts-api-utils: 2.1.0(typescript@5.9.2)
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.3)':
+  '@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.8.3)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.9.2)
       debug: 4.4.1
       eslint: 8.57.1
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@5.62.0(eslint@9.31.0)(typescript@5.8.3)':
+  '@typescript-eslint/parser@5.62.0(eslint@9.31.0)(typescript@5.9.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.8.3)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.9.2)
       debug: 4.4.1
       eslint: 9.31.0
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.37.0(eslint@9.31.0)(typescript@5.8.3)':
+  '@typescript-eslint/parser@8.37.0(eslint@9.31.0)(typescript@5.9.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.37.0
       '@typescript-eslint/types': 8.37.0
-      '@typescript-eslint/typescript-estree': 8.37.0(typescript@5.8.3)
+      '@typescript-eslint/typescript-estree': 8.37.0(typescript@5.9.2)
       '@typescript-eslint/visitor-keys': 8.37.0
       debug: 4.4.1
       eslint: 9.31.0
-      typescript: 5.8.3
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.37.0(typescript@5.8.3)':
+  '@typescript-eslint/project-service@8.37.0(typescript@5.9.2)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.37.0(typescript@5.8.3)
+      '@typescript-eslint/tsconfig-utils': 8.37.0(typescript@5.9.2)
       '@typescript-eslint/types': 8.37.0
       debug: 4.4.1
-      typescript: 5.8.3
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
@@ -5634,43 +5639,43 @@ snapshots:
       '@typescript-eslint/types': 8.37.0
       '@typescript-eslint/visitor-keys': 8.37.0
 
-  '@typescript-eslint/tsconfig-utils@8.37.0(typescript@5.8.3)':
+  '@typescript-eslint/tsconfig-utils@8.37.0(typescript@5.9.2)':
     dependencies:
-      typescript: 5.8.3
+      typescript: 5.9.2
 
-  '@typescript-eslint/type-utils@5.62.0(eslint@8.57.1)(typescript@5.8.3)':
+  '@typescript-eslint/type-utils@5.62.0(eslint@8.57.1)(typescript@5.9.2)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.8.3)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.8.3)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.9.2)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.9.2)
       debug: 4.4.1
       eslint: 8.57.1
-      tsutils: 3.21.0(typescript@5.8.3)
+      tsutils: 3.21.0(typescript@5.9.2)
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@5.62.0(eslint@9.31.0)(typescript@5.8.3)':
+  '@typescript-eslint/type-utils@5.62.0(eslint@9.31.0)(typescript@5.9.2)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.8.3)
-      '@typescript-eslint/utils': 5.62.0(eslint@9.31.0)(typescript@5.8.3)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.9.2)
+      '@typescript-eslint/utils': 5.62.0(eslint@9.31.0)(typescript@5.9.2)
       debug: 4.4.1
       eslint: 9.31.0
-      tsutils: 3.21.0(typescript@5.8.3)
+      tsutils: 3.21.0(typescript@5.9.2)
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@8.37.0(eslint@9.31.0)(typescript@5.8.3)':
+  '@typescript-eslint/type-utils@8.37.0(eslint@9.31.0)(typescript@5.9.2)':
     dependencies:
       '@typescript-eslint/types': 8.37.0
-      '@typescript-eslint/typescript-estree': 8.37.0(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.37.0(eslint@9.31.0)(typescript@5.8.3)
+      '@typescript-eslint/typescript-estree': 8.37.0(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.37.0(eslint@9.31.0)(typescript@5.9.2)
       debug: 4.4.1
       eslint: 9.31.0
-      ts-api-utils: 2.1.0(typescript@5.8.3)
-      typescript: 5.8.3
+      ts-api-utils: 2.1.0(typescript@5.9.2)
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
@@ -5680,7 +5685,7 @@ snapshots:
 
   '@typescript-eslint/types@8.37.0': {}
 
-  '@typescript-eslint/typescript-estree@5.62.0(typescript@5.8.3)':
+  '@typescript-eslint/typescript-estree@5.62.0(typescript@5.9.2)':
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
@@ -5688,13 +5693,13 @@ snapshots:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.7.2
-      tsutils: 3.21.0(typescript@5.8.3)
+      tsutils: 3.21.0(typescript@5.9.2)
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@6.21.0(typescript@5.8.3)':
+  '@typescript-eslint/typescript-estree@6.21.0(typescript@5.9.2)':
     dependencies:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/visitor-keys': 6.21.0
@@ -5703,16 +5708,16 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.3
       semver: 7.7.2
-      ts-api-utils: 1.4.3(typescript@5.8.3)
+      ts-api-utils: 1.4.3(typescript@5.9.2)
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.37.0(typescript@5.8.3)':
+  '@typescript-eslint/typescript-estree@8.37.0(typescript@5.9.2)':
     dependencies:
-      '@typescript-eslint/project-service': 8.37.0(typescript@5.8.3)
-      '@typescript-eslint/tsconfig-utils': 8.37.0(typescript@5.8.3)
+      '@typescript-eslint/project-service': 8.37.0(typescript@5.9.2)
+      '@typescript-eslint/tsconfig-utils': 8.37.0(typescript@5.9.2)
       '@typescript-eslint/types': 8.37.0
       '@typescript-eslint/visitor-keys': 8.37.0
       debug: 4.4.1
@@ -5720,19 +5725,19 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.7.2
-      ts-api-utils: 2.1.0(typescript@5.8.3)
-      typescript: 5.8.3
+      ts-api-utils: 2.1.0(typescript@5.9.2)
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@5.62.0(eslint@8.57.1)(typescript@5.8.3)':
+  '@typescript-eslint/utils@5.62.0(eslint@8.57.1)(typescript@5.9.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.7.0(eslint@8.57.1)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.7.0
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.8.3)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.9.2)
       eslint: 8.57.1
       eslint-scope: 5.1.1
       semver: 7.7.2
@@ -5740,14 +5745,14 @@ snapshots:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@5.62.0(eslint@9.31.0)(typescript@5.8.3)':
+  '@typescript-eslint/utils@5.62.0(eslint@9.31.0)(typescript@5.9.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.7.0(eslint@9.31.0)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.7.0
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.8.3)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.9.2)
       eslint: 9.31.0
       eslint-scope: 5.1.1
       semver: 7.7.2
@@ -5755,42 +5760,42 @@ snapshots:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@6.21.0(eslint@8.57.1)(typescript@5.8.3)':
+  '@typescript-eslint/utils@6.21.0(eslint@8.57.1)(typescript@5.9.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.7.0(eslint@8.57.1)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.7.0
       '@typescript-eslint/scope-manager': 6.21.0
       '@typescript-eslint/types': 6.21.0
-      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.8.3)
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.9.2)
       eslint: 8.57.1
       semver: 7.7.2
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@6.21.0(eslint@9.31.0)(typescript@5.8.3)':
+  '@typescript-eslint/utils@6.21.0(eslint@9.31.0)(typescript@5.9.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.7.0(eslint@9.31.0)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.7.0
       '@typescript-eslint/scope-manager': 6.21.0
       '@typescript-eslint/types': 6.21.0
-      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.8.3)
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.9.2)
       eslint: 9.31.0
       semver: 7.7.2
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@8.37.0(eslint@9.31.0)(typescript@5.8.3)':
+  '@typescript-eslint/utils@8.37.0(eslint@9.31.0)(typescript@5.9.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.7.0(eslint@9.31.0)
       '@typescript-eslint/scope-manager': 8.37.0
       '@typescript-eslint/types': 8.37.0
-      '@typescript-eslint/typescript-estree': 8.37.0(typescript@5.8.3)
+      '@typescript-eslint/typescript-estree': 8.37.0(typescript@5.9.2)
       eslint: 9.31.0
-      typescript: 5.8.3
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
@@ -6414,10 +6419,10 @@ snapshots:
 
   electron-to-chromium@1.5.185: {}
 
-  embed-typescript@1.1.0(typescript@5.8.3):
+  embed-typescript@1.1.0(typescript@5.9.2):
     dependencies:
       tstl: 3.0.0
-      typescript: 5.8.3
+      typescript: 5.9.2
 
   emoji-regex@8.0.0: {}
 
@@ -6482,23 +6487,23 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-plugin-deprecation@1.6.0(eslint@8.57.1)(typescript@5.8.3):
+  eslint-plugin-deprecation@1.6.0(eslint@8.57.1)(typescript@5.9.2):
     dependencies:
-      '@typescript-eslint/utils': 6.21.0(eslint@8.57.1)(typescript@5.8.3)
+      '@typescript-eslint/utils': 6.21.0(eslint@8.57.1)(typescript@5.9.2)
       eslint: 8.57.1
       tslib: 2.8.1
-      tsutils: 3.21.0(typescript@5.8.3)
-      typescript: 5.8.3
+      tsutils: 3.21.0(typescript@5.9.2)
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-deprecation@1.6.0(eslint@9.31.0)(typescript@5.8.3):
+  eslint-plugin-deprecation@1.6.0(eslint@9.31.0)(typescript@5.9.2):
     dependencies:
-      '@typescript-eslint/utils': 6.21.0(eslint@9.31.0)(typescript@5.8.3)
+      '@typescript-eslint/utils': 6.21.0(eslint@9.31.0)(typescript@5.9.2)
       eslint: 9.31.0
       tslib: 2.8.1
-      tsutils: 3.21.0(typescript@5.8.3)
-      typescript: 5.8.3
+      tsutils: 3.21.0(typescript@5.9.2)
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
@@ -8218,17 +8223,17 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  ts-api-utils@1.4.3(typescript@5.8.3):
+  ts-api-utils@1.4.3(typescript@5.9.2):
     dependencies:
-      typescript: 5.8.3
+      typescript: 5.9.2
 
-  ts-api-utils@2.1.0(typescript@5.8.3):
+  ts-api-utils@2.1.0(typescript@5.9.2):
     dependencies:
-      typescript: 5.8.3
+      typescript: 5.9.2
 
   ts-expose-internals@5.4.5: {}
 
-  ts-node@10.9.2(@types/node@18.19.119)(typescript@5.8.3):
+  ts-node@10.9.2(@types/node@18.19.119)(typescript@5.9.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -8242,11 +8247,11 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.8.3
+      typescript: 5.9.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  ts-node@10.9.2(@types/node@20.11.16)(typescript@5.8.3):
+  ts-node@10.9.2(@types/node@20.11.16)(typescript@5.9.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -8260,11 +8265,11 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.8.3
+      typescript: 5.9.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  ts-node@10.9.2(@types/node@22.16.4)(typescript@5.8.3):
+  ts-node@10.9.2(@types/node@22.16.4)(typescript@5.9.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -8278,7 +8283,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.8.3
+      typescript: 5.9.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
@@ -8291,9 +8296,9 @@ snapshots:
       semver: 7.7.2
       strip-ansi: 6.0.1
 
-  tsconfck@2.1.2(typescript@5.8.3):
+  tsconfck@2.1.2(typescript@5.9.2):
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.9.2
 
   tsconfig-paths@4.2.0:
     dependencies:
@@ -8307,10 +8312,10 @@ snapshots:
 
   tstl@3.0.0: {}
 
-  tsutils@3.21.0(typescript@5.8.3):
+  tsutils@3.21.0(typescript@5.9.2):
     dependencies:
       tslib: 1.14.1
-      typescript: 5.8.3
+      typescript: 5.9.2
 
   type-check@0.4.0:
     dependencies:
@@ -8335,34 +8340,34 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typescript-eslint@8.37.0(eslint@9.31.0)(typescript@5.8.3):
+  typescript-eslint@8.37.0(eslint@9.31.0)(typescript@5.9.2):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.37.0(@typescript-eslint/parser@8.37.0(eslint@9.31.0)(typescript@5.8.3))(eslint@9.31.0)(typescript@5.8.3)
-      '@typescript-eslint/parser': 8.37.0(eslint@9.31.0)(typescript@5.8.3)
-      '@typescript-eslint/typescript-estree': 8.37.0(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.37.0(eslint@9.31.0)(typescript@5.8.3)
+      '@typescript-eslint/eslint-plugin': 8.37.0(@typescript-eslint/parser@8.37.0(eslint@9.31.0)(typescript@5.9.2))(eslint@9.31.0)(typescript@5.9.2)
+      '@typescript-eslint/parser': 8.37.0(eslint@9.31.0)(typescript@5.9.2)
+      '@typescript-eslint/typescript-estree': 8.37.0(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.37.0(eslint@9.31.0)(typescript@5.9.2)
       eslint: 9.31.0
-      typescript: 5.8.3
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
-  typescript-transform-paths@3.5.5(typescript@5.8.3):
+  typescript-transform-paths@3.5.5(typescript@5.9.2):
     dependencies:
       minimatch: 9.0.5
-      typescript: 5.8.3
+      typescript: 5.9.2
 
-  typescript@5.8.3: {}
+  typescript@5.9.2: {}
 
-  typia@9.5.0(typescript@5.8.3):
+  typia@9.6.1(typescript@5.9.2):
     dependencies:
-      '@samchon/openapi': 4.5.0
+      '@samchon/openapi': 4.6.0
       '@standard-schema/spec': 1.0.0
       commander: 10.0.0
       comment-json: 4.2.5
       inquirer: 8.2.5
       package-manager-detector: 0.2.11
       randexp: 0.5.3
-      typescript: 5.8.3
+      typescript: 5.9.2
 
   uid@2.0.2:
     dependencies:

--- a/test/features/distribute-assert-json/packages/api/package.json
+++ b/test/features/distribute-assert-json/packages/api/package.json
@@ -29,10 +29,10 @@
   "devDependencies": {
     "rimraf": "^6.0.1",
     "ts-patch": "^3.2.1",
-    "typescript": "~5.8.3"
+    "typescript": "~5.9.2"
   },
   "dependencies": {
     "@nestia/fetcher": "^4.0.1-dev.20241203",
-    "typia": "^9.5.0"
+    "typia": "^9.6.1"
   }
 }

--- a/test/features/distribute-assert/packages/api/package.json
+++ b/test/features/distribute-assert/packages/api/package.json
@@ -29,10 +29,10 @@
   "devDependencies": {
     "rimraf": "^6.0.1",
     "ts-patch": "^3.2.1",
-    "typescript": "~5.8.3"
+    "typescript": "~5.9.2"
   },
   "dependencies": {
     "@nestia/fetcher": "^4.0.1-dev.20241203",
-    "typia": "^9.5.0"
+    "typia": "^9.6.1"
   }
 }

--- a/test/features/distribute-json/packages/api/package.json
+++ b/test/features/distribute-json/packages/api/package.json
@@ -29,10 +29,10 @@
   "devDependencies": {
     "rimraf": "^6.0.1",
     "ts-patch": "^3.2.1",
-    "typescript": "~5.8.3"
+    "typescript": "~5.9.2"
   },
   "dependencies": {
     "@nestia/fetcher": "^4.0.1-dev.20241203",
-    "typia": "^9.5.0"
+    "typia": "^9.6.1"
   }
 }

--- a/test/features/distribute/packages/api/package.json
+++ b/test/features/distribute/packages/api/package.json
@@ -29,10 +29,10 @@
   "devDependencies": {
     "rimraf": "^6.0.1",
     "ts-patch": "^3.2.1",
-    "typescript": "~5.8.3"
+    "typescript": "~5.9.2"
   },
   "dependencies": {
     "@nestia/fetcher": "^4.0.1-dev.20241203",
-    "typia": "^9.5.0"
+    "typia": "^9.6.1"
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -36,7 +36,7 @@
     "nestia": "workspace:^",
     "ts-node": "^10.9.2",
     "ts-patch": "~3.3.0",
-    "typescript": "~5.8.3",
+    "typescript": "~5.9.2",
     "typescript-transform-paths": "^3.5.5"
   },
   "dependencies": {
@@ -56,7 +56,7 @@
     "multer": "^2.0.2",
     "tgrid": "^1.1.0",
     "tstl": "^3.0.0",
-    "typia": "^9.5.0",
+    "typia": "^9.6.1",
     "uuid": "^10.0.0"
   }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -43,6 +43,6 @@
     "rimraf": "^6.0.1",
     "ts-node": "^10.9.2",
     "typedoc": "^0.27.3",
-    "typescript": "~5.8.3"
+    "typescript": "~5.9.2"
   }
 }


### PR DESCRIPTION
This pull request updates dependencies across multiple packages to ensure compatibility and leverage the latest features and fixes. The key changes include upgrading `typescript` and `typia` versions in various `package.json` files.

### Dependency Updates:

* Upgraded `typescript` from `~5.8.3` to `~5.9.2` across multiple packages, including `benchmark`, `cli`, `core`, `e2e`, `editor`, `fetcher`, `migrate`, `sdk`, `test`, and `website` (`benchmark/package.json` [[1]](diffhunk://#diff-ebd18337ce8dc8b96a8403d2731d05bbb7502293037672a62faa622e36d2821aL56-R56) `packages/cli/package.json` [[2]](diffhunk://#diff-6e2e2a1851648938b325ba84de634407a4e69a644ea61102df15ca4a8a7a9758L45-R45) `packages/core/package.json` [[3]](diffhunk://#diff-0b810c38f3c138a3d5e44854edefd5eb966617ca84e62f06511f60acc40546c7L83-R83) `packages/e2e/package.json` [[4]](diffhunk://#diff-67adead8de9872bd465961c6570bce9bc06e7164ea116e45ad405ddf8eff238aL42-R44) `packages/editor/package.json` [[5]](diffhunk://#diff-f4eedd0a8aaf55cc64de9e66438e075fb5c0c992b6fd2039bf5863b06cea99a0L70-R70) `packages/fetcher/package.json` [[6]](diffhunk://#diff-2a022191711573e83999286f3e1c7e334a8605f599e66ada0cde6d1745a4e5faL36-R36) `packages/migrate/package.json` [[7]](diffhunk://#diff-7739d7895fb583911437fd4f346e956025b0a924cf4a718f5c8e636eba32a679L81-R82) `packages/sdk/package.json` [[8]](diffhunk://#diff-77164cc5c071d1488e1cf72c0f91fdd99dd8976edb5004c83198bbd517039572L67-R67) `test/package.json` [[9]](diffhunk://#diff-b9188cc104c28fc06ff913ef07a9fa1a038b3f4de944a86c32f85fe3df17efafL39-R39) `website/package.json` [[10]](diffhunk://#diff-fae242fbf77a8a9d52625664bc36ea12316586f8a716b41137d897a2b7e3df76L46-R46).

* Upgraded `typia` from `^9.5.0` to `^9.6.1` across multiple packages, including `benchmark`, `core`, `e2e`, `editor`, `migrate`, `sdk`, and `test` (`benchmark/package.json` [[1]](diffhunk://#diff-ebd18337ce8dc8b96a8403d2731d05bbb7502293037672a62faa622e36d2821aL45-R45) `packages/core/package.json` [[2]](diffhunk://#diff-0b810c38f3c138a3d5e44854edefd5eb966617ca84e62f06511f60acc40546c7L61-R61) `packages/e2e/package.json` [[3]](diffhunk://#diff-67adead8de9872bd465961c6570bce9bc06e7164ea116e45ad405ddf8eff238aL42-R44) `packages/editor/package.json` [[4]](diffhunk://#diff-f4eedd0a8aaf55cc64de9e66438e075fb5c0c992b6fd2039bf5863b06cea99a0L47-R47) `packages/migrate/package.json` [[5]](diffhunk://#diff-7739d7895fb583911437fd4f346e956025b0a924cf4a718f5c8e636eba32a679L81-R82) `packages/sdk/package.json` [[6]](diffhunk://#diff-77164cc5c071d1488e1cf72c0f91fdd99dd8976edb5004c83198bbd517039572L47-R47) `test/package.json` [[7]](diffhunk://#diff-b9188cc104c28fc06ff913ef07a9fa1a038b3f4de944a86c32f85fe3df17efafL59-R59).

### Version Increment:

* Incremented the version of the `@nestia/station` package from `7.3.1` to `7.3.2` (`package.json` [package.jsonL4-R4](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4)).