### PR TITLE
Complete #1364: `@setHeader` and `@assignHeaders` in `@nestia/migrate`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@nestia/station",
-  "version": "7.3.3",
+  "version": "7.4.0",
   "description": "Nestia station",
   "scripts": {
     "build": "node deploy build",

--- a/packages/migrate/assets/input/v3.1/setHeaders.json
+++ b/packages/migrate/assets/input/v3.1/setHeaders.json
@@ -1,0 +1,120 @@
+{
+  "openapi": "3.1.0",
+  "paths": {
+    "/customers/authorizations/join": {
+      "post": {
+        "description": "Join a customer.\n\n@setHeader token.access access",
+        "operationId": "joinCustomer",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ICustomer.IJoin"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ICustomer.IAuthorized"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/customers/authorizations/login": {
+      "post": {
+        "description": "Login a customer.\n\n@assignHeaders token",
+        "operationId": "loginCustomer",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ICustomer.ILogin"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ICustomer.IAuthorized"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/customers/authorizations/refresh": {
+      "get": {
+        "description": "Refresh a customer's authorization token.\n\n@setHeader access access",
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IAuthorizationToken"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "IAuthorizationToken": {
+        "type": "object",
+        "properties": {
+          "access": { "type": "string" },
+          "refresh": { "type": "string" },
+          "expired_at": { "type": "string", "format": "date-time" },
+          "refreshable_until": { "type": "string", "format": "date-time" }
+        },
+        "required": ["access", "refresh", "expired_at", "refreshable_until"]
+      },
+      "ICustomer.IAuthorized": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "name": { "type": "string" },
+          "email": { "type": "string", "format": "email" },
+          "token": { "$ref": "#/components/schemas/IAuthorizationToken" }
+        },
+        "required": ["id", "name", "email", "token"]
+      },
+      "ICustomer.IJoin": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "email": { "type": "string", "format": "email" },
+          "password": { "type": "string", "minLength": 8 }
+        },
+        "required": ["name", "email", "password"]
+      },
+      "ICustomer.ILogin": {
+        "type": "object",
+        "properties": {
+          "email": { "type": "string", "format": "email" },
+          "password": { "type": "string" }
+        },
+        "required": ["email", "password"]
+      }
+    }
+  },
+  "x-samchon-emended-v4": true
+}


### PR DESCRIPTION
This pull request introduces support for parsing and handling custom header assignment directives (`@setHeader` and `@assignHeaders`) in API endpoint descriptions, and updates the OpenAPI input and package version accordingly. The changes enhance how headers are set or assigned in generated API functions based on OpenAPI comments.

Key changes include:

**Header Assignment and Parsing Enhancements:**

* Added logic in `NestiaMigrateApiFunctionProgrammer.ts` to parse `@setHeader` and `@assignHeaders` directives from route descriptions, generating corresponding TypeScript code to set or assign headers in the API response. [[1]](diffhunk://#diff-d248141e49ffcafb2ad3e2ad3cb8d99f04cacf101dee90127914c7ae6adb72e9R240-R280) [[2]](diffhunk://#diff-d248141e49ffcafb2ad3e2ad3cb8d99f04cacf101dee90127914c7ae6adb72e9R303-R342)
* Introduced helper types (`IAssignHeader`, `ISetHeader`) and a `getHeaders` function to support the new header directive parsing.

**API Function Generation Improvements:**

* Updated the API function generation logic to conditionally return the output and set headers on the connection object if any header directives are present.
* Refactored the function to use `await` for fetch calls and improved simulation logic for handling simulated connections. [[1]](diffhunk://#diff-d248141e49ffcafb2ad3e2ad3cb8d99f04cacf101dee90127914c7ae6adb72e9R146) [[2]](diffhunk://#diff-d248141e49ffcafb2ad3e2ad3cb8d99f04cacf101dee90127914c7ae6adb72e9R216-R222)

**OpenAPI Input Update:**

* Added a new OpenAPI 3.1 input file (`setHeaders.json`) with endpoints utilizing the new `@setHeader` and `@assignHeaders` directives in their descriptions.

**Dependency and Version Updates:**

* Bumped the package version in `package.json` from `7.3.3` to `7.4.0` to reflect the new feature additions.
* Added missing imports for `StatementFactory` and `Escaper` to support the new code generation logic.