### PR TITLE
Let `@nestia/migrate` to use JsonSchemaPlugin for only `x-` starting properties.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@nestia/station",
-  "version": "8.0.1",
+  "version": "8.0.2",
   "description": "Nestia station",
   "scripts": {
     "build": "node deploy build",

--- a/packages/migrate/src/programmers/NestiaMigrateSchemaProgrammer.ts
+++ b/packages/migrate/src/programmers/NestiaMigrateSchemaProgrammer.ts
@@ -479,7 +479,11 @@ const writePlugin = (props: {
 }) => {
   const extra: any = {};
   for (const [key, value] of Object.entries(props.schema))
-    if (value !== undefined && false === props.regular.includes(key))
+    if (
+      value !== undefined &&
+      false === props.regular.includes(key) &&
+      key.startsWith("x-")
+    )
       extra[key] = value;
   if (Object.keys(extra).length !== 0)
     props.intersection.push(props.importer.tag("JsonSchemaPlugin", extra));


### PR DESCRIPTION
This pull request includes a minor version bump and a small logic improvement for handling schema extensions. The most important changes are:

Version update:

* Bumped the package version from `8.0.1` to `8.0.2` in `package.json` to reflect the latest changes.

Schema extension handling:

* Updated the logic in `NestiaMigrateSchemaProgrammer.ts` so that only schema keys starting with `"x-"` (custom extensions) are included in the `extra` object, ensuring that only valid extension properties are processed.