### PR TITLE
fix(e2e): make TestValidator's generic to be compatible with before.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@nestia/station",
-  "version": "8.0.3",
+  "version": "8.0.4",
   "description": "Nestia station",
   "scripts": {
     "build": "node deploy build",

--- a/packages/e2e/src/TestValidator.ts
+++ b/packages/e2e/src/TestValidator.ts
@@ -124,7 +124,7 @@ export namespace TestValidator {
    *   comparison
    * @throws Error with detailed diff information when values are not equal
    */
-  export function equals<X, Y extends X>(
+  export function equals<X, Y extends X = X>(
     title: string,
     X: X,
     y: Y | null | undefined,
@@ -175,7 +175,7 @@ export namespace TestValidator {
    *   comparison
    * @throws Error when values are equal (indicating validation failure)
    */
-  export function notEquals<X, Y extends X>(
+  export function notEquals<X, Y extends X = X>(
     title: string,
     x: X,
     y: Y | null | undefined,
@@ -349,7 +349,7 @@ export namespace TestValidator {
    * @param trace - Optional flag to enable debug logging (default: false)
    * @throws Error when entity order differs between expected and actual results
    */
-  export const index = <X extends IEntity<any>, Y extends X>(
+  export const index = <X extends IEntity<any>, Y extends X = X>(
     title: string,
     expected: X[],
     gotten: Y[],


### PR DESCRIPTION
This pull request includes a patch version bump and type improvements for generic functions in the `TestValidator` namespace. The main focus is on enhancing the flexibility of type parameters by providing default values, which improves type inference and usability.

Version update:

* Bumped the package version from `8.0.3` to `8.0.4` in `package.json`.

Type parameter enhancements in `TestValidator`:

* Updated the `equals`, `notEquals`, and `index` functions to provide default values for the generic type parameter `Y` (`Y extends X = X`), making these functions easier to use without explicitly specifying both type parameters. (`packages/e2e/src/TestValidator.ts`: [[1]](diffhunk://#diff-494b687c0a2686d080da5fc90028eb6df8771c4a887e28dd4cc23ec57ebd3062L127-R127) [[2]](diffhunk://#diff-494b687c0a2686d080da5fc90028eb6df8771c4a887e28dd4cc23ec57ebd3062L178-R178) [[3]](diffhunk://#diff-494b687c0a2686d080da5fc90028eb6df8771c4a887e28dd4cc23ec57ebd3062L352-R352)