### PR TITLE
feat(sdk/migrate): `export * as directory/index` pattern.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@nestia/station",
-  "version": "8.0.6",
+  "version": "8.0.7",
   "description": "Nestia station",
   "scripts": {
     "build": "node deploy build",

--- a/packages/migrate/src/programmers/NestiaMigrateApiFileProgrammer.ts
+++ b/packages/migrate/src/programmers/NestiaMigrateApiFileProgrammer.ts
@@ -45,7 +45,7 @@ export namespace NestiaMigrateApiFileProgrammer {
           undefined,
           false,
           ts.factory.createNamespaceExport(ts.factory.createIdentifier(child)),
-          ts.factory.createStringLiteral(`./${child}`),
+          ts.factory.createStringLiteral(`./${child}/index`),
           undefined,
         ),
       ),

--- a/packages/migrate/src/test/index.ts
+++ b/packages/migrate/src/test/index.ts
@@ -72,11 +72,11 @@ const execute = (
       files,
     });
     cp.execSync(`npx tsc -p ${directory}/tsconfig.json`, {
-      stdio: "ignore",
+      stdio: "inherit",
       cwd: directory,
     });
     cp.execSync(`npx tsc -p ${directory}/test/tsconfig.json`, {
-      stdio: "ignore",
+      stdio: "inherit",
       cwd: directory,
     });
   });

--- a/packages/sdk/src/generates/internal/SdkFileProgrammer.ts
+++ b/packages/sdk/src/generates/internal/SdkFileProgrammer.ts
@@ -62,7 +62,7 @@ export namespace SdkFileProgrammer {
             undefined,
             false,
             ts.factory.createNamespaceExport(ts.factory.createIdentifier(key)),
-            ts.factory.createStringLiteral(`./${key}`),
+            ts.factory.createStringLiteral(`./${key}/index`),
             undefined,
           ),
         );


### PR DESCRIPTION
For the `somePath/index/anyPath` case.

--------------

This pull request contains several updates across the migration and SDK code generation logic, as well as improvements to the test output and a version bump. The main changes involve fixing module export paths to point to the correct entry files and improving the visibility of TypeScript compilation output during testing.

### Module export path fixes
* Updated namespace export paths in both `NestiaMigrateApiFileProgrammer` and `SdkFileProgrammer` to reference `./<module>/index` instead of just `./<module>`, ensuring correct module resolution. [[1]](diffhunk://#diff-6861f45b4b5689924a131d55cb275db79e1775b11d739bd26c30ca50305a099eL48-R48) [[2]](diffhunk://#diff-a9e620875f75faf4ea554bbc7976016ab68d1d36883c2f949125f71b72a5eb0bL65-R65)

### Testing improvements
* Changed TypeScript compilation in the migration test runner to display output in the console (`stdio: "inherit"`), making debugging easier.

### Version update
* Bumped the package version from `8.0.6` to `8.0.7` in `package.json` to reflect the new changes.