### PR TITLE
feat(sdk): `reconnect()` function for websocket operations.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@nestia/station",
-  "version": "8.0.8",
+  "version": "8.1.0",
   "description": "Nestia station",
   "scripts": {
     "build": "node deploy build",

--- a/packages/sdk/src/generates/internal/SdkWebSocketNamespaceProgrammer.ts
+++ b/packages/sdk/src/generates/internal/SdkWebSocketNamespaceProgrammer.ts
@@ -78,6 +78,19 @@ export namespace SdkWebSocketNamespaceProgrammer {
               [ts.factory.createTypeReferenceNode("Listener")],
             ),
           ),
+          ts.factory.createPropertySignature(
+            undefined,
+            "reconnect",
+            undefined,
+            ts.factory.createFunctionTypeNode(
+              undefined,
+              [],
+              ts.factory.createTypeReferenceNode(
+                ts.factory.createIdentifier("Promise"),
+                [ts.factory.createKeywordTypeNode(ts.SyntaxKind.VoidKeyword)],
+              ),
+            ),
+          ),
         ]),
       );
 

--- a/packages/sdk/src/generates/internal/SdkWebSocketRouteProgrammer.ts
+++ b/packages/sdk/src/generates/internal/SdkWebSocketRouteProgrammer.ts
@@ -104,6 +104,26 @@ export namespace SdkWebSocketRouteProgrammer {
             )
           : ts.factory.createIdentifier(key);
       return [
+        local("url")(ts.factory.createTypeReferenceNode("string"))(
+          joinPath(
+            ts.factory.createCallExpression(
+              ts.factory.createPropertyAccessExpression(
+                ts.factory.createIdentifier(route.name),
+                "path",
+              ),
+              [],
+              project.config.keyword === true &&
+                SdkWebSocketParameterProgrammer.isPathEmpty(route) === false
+                ? [ts.factory.createIdentifier("props")]
+                : SdkWebSocketParameterProgrammer.getEntries({
+                    project,
+                    route,
+                    provider: false,
+                    prefix: true,
+                  }).map((p) => ts.factory.createIdentifier(p.key)),
+            ),
+          ),
+        ),
         local("connector")(
           ts.factory.createTypeReferenceNode(
             importer.external({
@@ -153,27 +173,7 @@ export namespace SdkWebSocketRouteProgrammer {
                 "connect",
               ),
               undefined,
-              [
-                joinPath(
-                  ts.factory.createCallExpression(
-                    ts.factory.createPropertyAccessExpression(
-                      ts.factory.createIdentifier(route.name),
-                      "path",
-                    ),
-                    [],
-                    project.config.keyword === true &&
-                      SdkWebSocketParameterProgrammer.isPathEmpty(route) ===
-                        false
-                      ? [ts.factory.createIdentifier("props")]
-                      : SdkWebSocketParameterProgrammer.getEntries({
-                          project,
-                          route,
-                          provider: false,
-                          prefix: true,
-                        }).map((p) => ts.factory.createIdentifier(p.key)),
-                  ),
-                ),
-              ],
+              [ts.factory.createIdentifier("url")],
             ),
           ),
         ),
@@ -202,6 +202,26 @@ export namespace SdkWebSocketRouteProgrammer {
             [
               ts.factory.createShorthandPropertyAssignment("connector"),
               ts.factory.createShorthandPropertyAssignment("driver"),
+              ts.factory.createPropertyAssignment(
+                ts.factory.createIdentifier("reconnect"),
+                ts.factory.createArrowFunction(
+                  [ts.factory.createToken(ts.SyntaxKind.AsyncKeyword)],
+                  undefined,
+                  [],
+                  undefined,
+                  ts.factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+                  ts.factory.createAwaitExpression(
+                    ts.factory.createCallExpression(
+                      ts.factory.createPropertyAccessExpression(
+                        ts.factory.createIdentifier("connector"),
+                        ts.factory.createIdentifier("connect"),
+                      ),
+                      undefined,
+                      [ts.factory.createIdentifier("url")],
+                    ),
+                  ),
+                ),
+              ),
             ],
             true,
           ),

--- a/test/features/websocket-clone/src/api/functional/calculate/index.ts
+++ b/test/features/websocket-clone/src/api/functional/calculate/index.ts
@@ -21,24 +21,25 @@ export async function connect(
   connection: IConnection<connect.Header>,
   provider: connect.Provider,
 ): Promise<connect.Output> {
+  const url: string = `${connection.host.endsWith("/") ? connection.host.substring(0, connection.host.length - 1) : connection.host}${connect.path()}`;
   const connector: WebSocketConnector<
     connect.Header,
     connect.Provider,
     connect.Listener
   > = new WebSocketConnector(connection.headers ?? ({} as any), provider);
-  await connector.connect(
-    `${connection.host.endsWith("/") ? connection.host.substring(0, connection.host.length - 1) : connection.host}${connect.path()}`,
-  );
+  await connector.connect(url);
   const driver: Driver<connect.Listener> = connector.getDriver();
   return {
     connector,
     driver,
+    reconnect: async () => await connector.connect(url),
   };
 }
 export namespace connect {
   export type Output = {
     connector: WebSocketConnector<Header, Provider, Listener>;
     driver: Driver<Listener>;
+    reconnect: () => Promise<void>;
   };
   export type Header = IPrecision;
   export type Provider = IListener;

--- a/test/features/websocket-keyword/src/api/functional/calculate/index.ts
+++ b/test/features/websocket-keyword/src/api/functional/calculate/index.ts
@@ -60,18 +60,18 @@ export async function composite(
   connection: IConnection<composite.Header>,
   props: composite.Props,
 ): Promise<composite.Output> {
+  const url: string = `${connection.host.endsWith("/") ? connection.host.substring(0, connection.host.length - 1) : connection.host}${composite.path(props)}`;
   const connector: WebSocketConnector<
     composite.Header,
     composite.Provider,
     composite.Listener
   > = new WebSocketConnector(connection.headers ?? ({} as any), props.provider);
-  await connector.connect(
-    `${connection.host.endsWith("/") ? connection.host.substring(0, connection.host.length - 1) : connection.host}${composite.path(props)}`,
-  );
+  await connector.connect(url);
   const driver: Driver<composite.Listener> = connector.getDriver();
   return {
     connector,
     driver,
+    reconnect: async () => await connector.connect(url),
   };
 }
 export namespace composite {
@@ -84,6 +84,7 @@ export namespace composite {
   export type Output = {
     connector: WebSocketConnector<Header, Provider, Listener>;
     driver: Driver<Listener>;
+    reconnect: () => Promise<void>;
   };
   export type Header = ICalcConfig;
   export type Provider = ICalcEventListener;
@@ -115,18 +116,18 @@ export async function simple(
   connection: IConnection<simple.Header>,
   props: simple.Props,
 ): Promise<simple.Output> {
+  const url: string = `${connection.host.endsWith("/") ? connection.host.substring(0, connection.host.length - 1) : connection.host}${simple.path()}`;
   const connector: WebSocketConnector<
     simple.Header,
     simple.Provider,
     simple.Listener
   > = new WebSocketConnector(connection.headers ?? ({} as any), props.provider);
-  await connector.connect(
-    `${connection.host.endsWith("/") ? connection.host.substring(0, connection.host.length - 1) : connection.host}${simple.path()}`,
-  );
+  await connector.connect(url);
   const driver: Driver<simple.Listener> = connector.getDriver();
   return {
     connector,
     driver,
+    reconnect: async () => await connector.connect(url),
   };
 }
 export namespace simple {
@@ -136,6 +137,7 @@ export namespace simple {
   export type Output = {
     connector: WebSocketConnector<Header, Provider, Listener>;
     driver: Driver<Listener>;
+    reconnect: () => Promise<void>;
   };
   export type Header = ICalcConfig;
   export type Provider = ICalcEventListener;
@@ -155,18 +157,18 @@ export async function scientific(
   connection: IConnection<scientific.Header>,
   props: scientific.Props,
 ): Promise<scientific.Output> {
+  const url: string = `${connection.host.endsWith("/") ? connection.host.substring(0, connection.host.length - 1) : connection.host}${scientific.path()}`;
   const connector: WebSocketConnector<
     scientific.Header,
     scientific.Provider,
     scientific.Listener
   > = new WebSocketConnector(connection.headers ?? ({} as any), props.provider);
-  await connector.connect(
-    `${connection.host.endsWith("/") ? connection.host.substring(0, connection.host.length - 1) : connection.host}${scientific.path()}`,
-  );
+  await connector.connect(url);
   const driver: Driver<scientific.Listener> = connector.getDriver();
   return {
     connector,
     driver,
+    reconnect: async () => await connector.connect(url),
   };
 }
 export namespace scientific {
@@ -176,6 +178,7 @@ export namespace scientific {
   export type Output = {
     connector: WebSocketConnector<Header, Provider, Listener>;
     driver: Driver<Listener>;
+    reconnect: () => Promise<void>;
   };
   export type Header = ICalcConfig;
   export type Provider = ICalcEventListener;
@@ -195,18 +198,18 @@ export async function statistics(
   connection: IConnection<statistics.Header>,
   props: statistics.Props,
 ): Promise<statistics.Output> {
+  const url: string = `${connection.host.endsWith("/") ? connection.host.substring(0, connection.host.length - 1) : connection.host}${statistics.path()}`;
   const connector: WebSocketConnector<
     statistics.Header,
     statistics.Provider,
     statistics.Listener
   > = new WebSocketConnector(connection.headers ?? ({} as any), props.provider);
-  await connector.connect(
-    `${connection.host.endsWith("/") ? connection.host.substring(0, connection.host.length - 1) : connection.host}${statistics.path()}`,
-  );
+  await connector.connect(url);
   const driver: Driver<statistics.Listener> = connector.getDriver();
   return {
     connector,
     driver,
+    reconnect: async () => await connector.connect(url),
   };
 }
 export namespace statistics {
@@ -216,6 +219,7 @@ export namespace statistics {
   export type Output = {
     connector: WebSocketConnector<Header, Provider, Listener>;
     driver: Driver<Listener>;
+    reconnect: () => Promise<void>;
   };
   export type Header = ICalcConfig;
   export type Provider = ICalcEventListener;

--- a/test/features/websocket/src/api/functional/calculate/index.ts
+++ b/test/features/websocket/src/api/functional/calculate/index.ts
@@ -63,24 +63,25 @@ export async function composite(
   query: composite.Query,
   provider: composite.Provider,
 ): Promise<composite.Output> {
+  const url: string = `${connection.host.endsWith("/") ? connection.host.substring(0, connection.host.length - 1) : connection.host}${composite.path(id, nickname, query)}`;
   const connector: WebSocketConnector<
     composite.Header,
     composite.Provider,
     composite.Listener
   > = new WebSocketConnector(connection.headers ?? ({} as any), provider);
-  await connector.connect(
-    `${connection.host.endsWith("/") ? connection.host.substring(0, connection.host.length - 1) : connection.host}${composite.path(id, nickname, query)}`,
-  );
+  await connector.connect(url);
   const driver: Driver<composite.Listener> = connector.getDriver();
   return {
     connector,
     driver,
+    reconnect: async () => await connector.connect(url),
   };
 }
 export namespace composite {
   export type Output = {
     connector: WebSocketConnector<Header, Provider, Listener>;
     driver: Driver<Listener>;
+    reconnect: () => Promise<void>;
   };
   export type Header = ICalcConfig;
   export type Provider = ICalcEventListener;
@@ -116,24 +117,25 @@ export async function simple(
   connection: IConnection<simple.Header>,
   provider: simple.Provider,
 ): Promise<simple.Output> {
+  const url: string = `${connection.host.endsWith("/") ? connection.host.substring(0, connection.host.length - 1) : connection.host}${simple.path()}`;
   const connector: WebSocketConnector<
     simple.Header,
     simple.Provider,
     simple.Listener
   > = new WebSocketConnector(connection.headers ?? ({} as any), provider);
-  await connector.connect(
-    `${connection.host.endsWith("/") ? connection.host.substring(0, connection.host.length - 1) : connection.host}${simple.path()}`,
-  );
+  await connector.connect(url);
   const driver: Driver<simple.Listener> = connector.getDriver();
   return {
     connector,
     driver,
+    reconnect: async () => await connector.connect(url),
   };
 }
 export namespace simple {
   export type Output = {
     connector: WebSocketConnector<Header, Provider, Listener>;
     driver: Driver<Listener>;
+    reconnect: () => Promise<void>;
   };
   export type Header = ICalcConfig;
   export type Provider = ICalcEventListener;
@@ -153,24 +155,25 @@ export async function scientific(
   connection: IConnection<scientific.Header>,
   provider: scientific.Provider,
 ): Promise<scientific.Output> {
+  const url: string = `${connection.host.endsWith("/") ? connection.host.substring(0, connection.host.length - 1) : connection.host}${scientific.path()}`;
   const connector: WebSocketConnector<
     scientific.Header,
     scientific.Provider,
     scientific.Listener
   > = new WebSocketConnector(connection.headers ?? ({} as any), provider);
-  await connector.connect(
-    `${connection.host.endsWith("/") ? connection.host.substring(0, connection.host.length - 1) : connection.host}${scientific.path()}`,
-  );
+  await connector.connect(url);
   const driver: Driver<scientific.Listener> = connector.getDriver();
   return {
     connector,
     driver,
+    reconnect: async () => await connector.connect(url),
   };
 }
 export namespace scientific {
   export type Output = {
     connector: WebSocketConnector<Header, Provider, Listener>;
     driver: Driver<Listener>;
+    reconnect: () => Promise<void>;
   };
   export type Header = ICalcConfig;
   export type Provider = ICalcEventListener;
@@ -190,24 +193,25 @@ export async function statistics(
   connection: IConnection<statistics.Header>,
   provider: statistics.Provider,
 ): Promise<statistics.Output> {
+  const url: string = `${connection.host.endsWith("/") ? connection.host.substring(0, connection.host.length - 1) : connection.host}${statistics.path()}`;
   const connector: WebSocketConnector<
     statistics.Header,
     statistics.Provider,
     statistics.Listener
   > = new WebSocketConnector(connection.headers ?? ({} as any), provider);
-  await connector.connect(
-    `${connection.host.endsWith("/") ? connection.host.substring(0, connection.host.length - 1) : connection.host}${statistics.path()}`,
-  );
+  await connector.connect(url);
   const driver: Driver<statistics.Listener> = connector.getDriver();
   return {
     connector,
     driver,
+    reconnect: async () => await connector.connect(url),
   };
 }
 export namespace statistics {
   export type Output = {
     connector: WebSocketConnector<Header, Provider, Listener>;
     driver: Driver<Listener>;
+    reconnect: () => Promise<void>;
   };
   export type Header = ICalcConfig;
   export type Provider = ICalcEventListener;


### PR DESCRIPTION
This pull request introduces a new `reconnect` capability to the WebSocket SDK and updates related test utilities to support easier reconnection to WebSocket endpoints. The changes include updates to the SDK's internal type definitions and code generation logic, as well as modifications to test helper functions to expose a `reconnect` method in their outputs.

**SDK Enhancements:**

- Added a `reconnect` method to the generated WebSocket route and namespace output types, allowing consumers to easily re-establish WebSocket connections. [[1]](diffhunk://#diff-df4ec1c13797e1291dd1392bb9dab43a6c31404ea250be1ed20025318715e5bcR81-R93) [[2]](diffhunk://#diff-89f745e3e17a8a9ec46d4e66cefc2f1d4b9e95e38c2c4575d7745ce31a635518R205-R224)
- Refactored the generated code to pass a precomputed `url` to the `connect` method, simplifying the connection logic and making reconnection straightforward. [[1]](diffhunk://#diff-89f745e3e17a8a9ec46d4e66cefc2f1d4b9e95e38c2c4575d7745ce31a635518R107-R126) [[2]](diffhunk://#diff-89f745e3e17a8a9ec46d4e66cefc2f1d4b9e95e38c2c4575d7745ce31a635518L156-R176)

**Test Utility Improvements:**

- Updated all relevant test helper functions (e.g., `connect`, `composite`, `simple`, `scientific`, `statistics`) to:
  - Compute and reuse a `url` variable for WebSocket connections.
  - Expose a `reconnect` method in their returned object, which reconnects using the same URL. [[1]](diffhunk://#diff-3e3f84ed156e357881193f8ccc125fefd0d6b00e2d29cd5e1d62b667980e6559R24-R42) [[2]](diffhunk://#diff-519f9954125e0413224765d433c67388d00d522c05c2e15583592c18e46ea11aR63-R74) [[3]](diffhunk://#diff-519f9954125e0413224765d433c67388d00d522c05c2e15583592c18e46ea11aR119-R130) [[4]](diffhunk://#diff-519f9954125e0413224765d433c67388d00d522c05c2e15583592c18e46ea11aR160-R171) [[5]](diffhunk://#diff-519f9954125e0413224765d433c67388d00d522c05c2e15583592c18e46ea11aR201-R212) [[6]](diffhunk://#diff-ebc59a029abcc7ec01b7ad592404220199382e5216618799daad66ccefe8b011R66-R84) [[7]](diffhunk://#diff-ebc59a029abcc7ec01b7ad592404220199382e5216618799daad66ccefe8b011R120-R138) [[8]](diffhunk://#diff-ebc59a029abcc7ec01b7ad592404220199382e5216618799daad66ccefe8b011R158-R176) [[9]](diffhunk://#diff-ebc59a029abcc7ec01b7ad592404220199382e5216618799daad66ccefe8b011R196-R214)
  - Update the output types to include the new `reconnect` method. [[1]](diffhunk://#diff-519f9954125e0413224765d433c67388d00d522c05c2e15583592c18e46ea11aR87) [[2]](diffhunk://#diff-519f9954125e0413224765d433c67388d00d522c05c2e15583592c18e46ea11aR140) [[3]](diffhunk://#diff-519f9954125e0413224765d433c67388d00d522c05c2e15583592c18e46ea11aR181) [[4]](diffhunk://#diff-519f9954125e0413224765d433c67388d00d522c05c2e15583592c18e46ea11aR222) [[5]](diffhunk://#diff-ebc59a029abcc7ec01b7ad592404220199382e5216618799daad66ccefe8b011R66-R84) [[6]](diffhunk://#diff-ebc59a029abcc7ec01b7ad592404220199382e5216618799daad66ccefe8b011R120-R138) [[7]](diffhunk://#diff-ebc59a029abcc7ec01b7ad592404220199382e5216618799daad66ccefe8b011R158-R176) [[8]](diffhunk://#diff-ebc59a029abcc7ec01b7ad592404220199382e5216618799daad66ccefe8b011R196-R214)

**Versioning:**

- Bumped the package version from `8.0.8` to `8.1.0` to reflect these new features.

These changes make it easier and more reliable to programmatically reconnect WebSocket sessions, both in SDK consumers and in test scenarios.