### PR TITLE
remove undocumented "title" property from IParameter

### DIFF
--- a/packages/sdk/src/generates/internal/SwaggerOperationParameterComposer.ts
+++ b/packages/sdk/src/generates/internal/SwaggerOperationParameterComposer.ts
@@ -134,7 +134,12 @@ export namespace SwaggerOperationParameterComposer {
           in: props.parameter.category === "query" ? "query" : "header",
           schema: json.schemas[0],
           required: p.value.isRequired(),
-          description: p.description ?? null
+          description:
+            SwaggerDescriptionComposer.compose({
+              description: p.description ?? null,
+              jsDocTags: p.jsDocTags,
+              kind: "title",
+            }).description ?? null,
         };
       });
   };


### PR DESCRIPTION
The title is not specified on parameter objects: https://swagger.io/specification/#parameter-object
related PRs: 
- https://github.com/samchon/nestia/pull/1385
- https://github.com/samchon/openapi/pull/207

What it does:
```json
"/my-route": {
  "get": {
    "parameters": [
      {
-       "title": "My fancy description",
        "description": "My fancy description",
        "in": "query",
        "name": "myParam1",
        "required": true,
        "schema": {
          "type": "string",
        },
      },
    ]
  }
}

```