### PR TITLE
Update TypedBody.mdx

### DIFF
--- a/website/pages/docs/core/TypedBody.mdx
+++ b/website/pages/docs/core/TypedBody.mdx
@@ -39,8 +39,8 @@ Therefore, it is not a matter to use `@TypedBody()` or `@Body()` of the original
 ## How to use
 <Tabs 
   items={[
-    <code>IAttachmentFile.ts</code>,
     <code>IBbsArticle.ts</code>,
+    <code>IAttachmentFile.ts</code>,
     <code>BbsArticlesController.ts</code>,
     'Compiled JavaScript File',
   ]}


### PR DESCRIPTION
Switch `IBbsArticle.ts`, `IAttachmentFile.ts` tab position to show right interface example in the [documentation](https://nestia.io/docs/core/TypedBody/#how-to-use).
<img width="1766" height="796" alt="image" src="https://github.com/user-attachments/assets/3278bb25-893a-44f0-b560-fb255e50284d" />
