### PR TITLE
fix(migrate): omitted `publishConfig.bin`.

### DIFF
--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -43,8 +43,10 @@
     "@rollup/plugin-typescript": "^12.1.1",
     "@types/inquirer": "^9.0.7",
     "@types/node": "catalog:utils",
-    "rimraf": "^6.0.1",
-    "rollup": "^4.24.3"
+    "js-yaml": "^4.1.0",
+    "rimraf": "catalog:utils",
+    "rollup": "^4.24.3",
+    "ts-node": "catalog:typescript"
   },
   "dependencies": {
     "@trivago/prettier-plugin-sort-imports": "catalog:typescript",
@@ -73,6 +75,9 @@
     "types": "lib/index.d.ts",
     "main": "lib/index.js",
     "module": "lib/index.mjs",
+    "bin": {
+      "@nestia/migrate": "./lib/executable/migrate.js"
+    },
     "exports": {
       ".": {
         "types": "./lib/index.d.ts",

--- a/packages/migrate/src/executable/bundle.js
+++ b/packages/migrate/src/executable/bundle.js
@@ -4,6 +4,9 @@ const fs = require("fs");
 
 const ROOT = `${__dirname}/../..`;
 const ASSETS = `${ROOT}/assets`;
+const TYPIA = require("js-yaml").load(
+  fs.readFileSync(`${__dirname}/../../../../pnpm-lock.yaml`, "utf8"),
+).catalogs.samchon;
 
 const update = (content) => {
   const parsed = JSON.parse(content);
@@ -14,6 +17,7 @@ const update = (content) => {
     for (const key of Object.keys(record))
       if (key.startsWith("@nestia/") || key === "nestia")
         record[key] = `^${version}`;
+      else if (TYPIA[key]) record[key] = TYPIA[key].specifier;
   return JSON.stringify(parsed, null, 2);
 };
 
@@ -97,7 +101,7 @@ const main = async () => {
       "test/features",
     ],
     transform: (key, value) => {
-      if (key === "package.json") return update(value);
+      if (key.endsWith("package.json")) return update(value);
       return value;
     },
   });
@@ -114,7 +118,7 @@ const main = async () => {
       "test/features",
     ],
     transform: (key, value) => {
-      if (key === "package.json") return update(value);
+      if (key.endsWith("package.json")) return update(value);
       return value;
     },
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ catalogs:
       specifier: ^12.0.0
       version: 12.0.0
     tgrid:
-      specifier: ^1.1.0
+      specifier: ^1.2.1
       version: 1.2.1
     tstl:
       specifier: ^3.0.0
@@ -516,12 +516,18 @@ importers:
       '@types/node':
         specifier: catalog:utils
         version: 25.3.3
+      js-yaml:
+        specifier: ^4.1.0
+        version: 4.1.1
       rimraf:
-        specifier: ^6.0.1
+        specifier: catalog:utils
         version: 6.1.3
       rollup:
         specifier: ^4.24.3
         version: 4.59.0
+      ts-node:
+        specifier: catalog:typescript
+        version: 10.9.2(@types/node@25.3.3)(typescript@5.9.3)
 
   packages/sdk:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,7 +12,7 @@ catalogs:
     '@typia/core': ^12.0.0
     '@typia/interface': ^12.0.0
     '@typia/utils': ^12.0.0
-    tgrid: ^1.1.0
+    tgrid: ^1.2.1
     tstl: ^3.0.0
     typia: ^12.0.0
   utils:


### PR DESCRIPTION
This pull request introduces several improvements and updates to the `packages/migrate` package, focusing on dependency management, executable configuration, and package version synchronization. The most significant changes include enhanced dependency handling using `js-yaml`, updated bin configuration for CLI usage, and version alignment for the `tgrid` package across workspace files.

**Dependency and Version Management:**

* Added `js-yaml` and `ts-node` as dependencies in `package.json`, with `rimraf` now referencing the catalog for consistency. [[1]](diffhunk://#diff-7739d7895fb583911437fd4f346e956025b0a924cf4a718f5c8e636eba32a679L46-R49) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR519-R530)
* Updated the `tgrid` package version from `^1.1.0` to `^1.2.1` in both `pnpm-lock.yaml` and `pnpm-workspace.yaml` to ensure consistency across the workspace. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL32-R32) [[2]](diffhunk://#diff-18ae0a0fab29a7db7aded913fd05f30a2c8f6c104fadae86c9d217091709794cL15-R15)

**Executable and CLI Improvements:**

* Added a `bin` field to `package.json` to expose the `@nestia/migrate` CLI executable.

**Enhanced Package Synchronization Logic:**

* Updated `bundle.js` to load package specifiers from `pnpm-lock.yaml` using `js-yaml`, and synchronize dependency versions based on the catalog, improving automation and accuracy. [[1]](diffhunk://#diff-ef7cd1e0e7732a9015ae538aee4b68014df7d9a9c29c29641e461fc8e4f4e424R7-R9) [[2]](diffhunk://#diff-ef7cd1e0e7732a9015ae538aee4b68014df7d9a9c29c29641e461fc8e4f4e424R20)
* Improved the file transformation logic in `bundle.js` to handle all `package.json` files (not just the root), ensuring broader coverage during migration. [[1]](diffhunk://#diff-ef7cd1e0e7732a9015ae538aee4b68014df7d9a9c29c29641e461fc8e4f4e424L100-R104) [[2]](diffhunk://#diff-ef7cd1e0e7732a9015ae538aee4b68014df7d9a9c29c29641e461fc8e4f4e424L117-R121)