### PR TITLE
fix(website): fix nextra version to avoid its bug

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -34,9 +34,9 @@
     "@nestia/editor": "../deploy/tarballs/editor.tgz",
     "@nestia/migrate": "../deploy/tarballs/migrate.tgz",
     "next": "^15.3.4",
-    "nextra": "^4.6.0",
-    "nextra-theme-blog": "^4.6.1",
-    "nextra-theme-docs": "^4.6.0",
+    "nextra": "4.6.0",
+    "nextra-theme-blog": "4.6.0",
+    "nextra-theme-docs": "4.6.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },


### PR DESCRIPTION
This pull request makes a small change to the `website/package.json` file, updating the version specifiers for the `nextra`, `nextra-theme-blog`, and `nextra-theme-docs` dependencies from caret (^) versions to exact versions. This change helps ensure consistent dependency resolution across different environments.