### PR TITLE
feat(website): go migration strategy

### DIFF
--- a/.wiki/00-index.md
+++ b/.wiki/00-index.md
@@ -1,0 +1,31 @@
+# Nestia Go 포팅 지식대백과
+
+이 `.wiki`는 `ttsc`, `typia@next`, `typia`, 그리고 현재 `nestia@next`의 구조를 근거로 Nestia의 Go 포팅 방향을 정리한 작업 지식베이스다.
+
+핵심 결론은 단순하다. Nestia의 Go 포팅은 런타임 데코레이터나 fetcher부터 바꾸는 일이 아니라, `ts-patch` 기반 TypeScript transformer를 `ttsc` native sidecar로 옮기는 일에서 시작해야 한다. 또한 `ttsc`의 transform stage는 서로 다른 native binary를 동시에 허용하지 않으므로, `typia`, `@nestia/core`, `@nestia/sdk` 변환은 장기적으로 하나의 native transform host 안에서 협업해야 한다.
+
+## 문서 구조
+
+- `00-ledger/`: 읽기 범위, 파일 수, 라인 수, 조사 근거, 후속 정독 기준
+- `01-ttsc/`: `ttsc`의 구동 원리, 플러그인 프로토콜, Nestia가 따라야 할 철학
+- `02-typia/`: `typia` TypeScript 원본과 `typia@next` Go 포팅의 대응 방식
+- `03-nestia/`: 현재 `nestia@next` 패키지와 transformer/generator 구조
+- `04-strategy/`: Nestia Go 포팅 마스터 플랜, native layout, 단계, 검증 계획
+
+## 현재 판단
+
+1. `ttsc`는 TypeScript-Go를 감싸는 JS host이며, 실제 Program/Checker/emit/transform 작업은 Go binary가 수행한다.
+2. `typia@next`는 `../typia/packages/core/src`와 `../typia/packages/transform/src`를 1:1 파일 대응으로 Go에 옮겼고, JS package surface는 얇은 `createTtscPlugin()` manifest로 바뀌었다.
+3. `nestia@next`는 아직 `ts-patch`와 `ts-node`에 묶여 있다. `@nestia/core/lib/transform`과 `@nestia/sdk/lib/transform`은 TypeScript transformer 함수를 export한다.
+4. Nestia 포팅의 첫 번째 병목은 변환기 자체가 아니라 실행 모델이다. `NestiaSetupWizard`, `PluginConfigurator`, `NestiaConfigLoader`, CLI boot path가 `ttsc`/`ttsx` 실행 모델로 먼저 바뀌어야 한다.
+5. `@nestia/core` 변환기는 request/response decorator 인자에 typia 기반 validator/stringifier plan을 주입한다.
+6. `@nestia/sdk` 변환기는 controller method에 `OperationMetadata` decorator를 주입하고, CLI는 그 runtime reflection 결과를 SDK/Swagger/E2E generator로 넘긴다.
+
+## 포팅 원칙
+
+- TypeScript 원본과 Go 포트는 파일 단위로 추적 가능해야 한다.
+- 기존 공개 API, decorator 이름, config option 이름, generated SDK surface는 보존한다.
+- `ttsc`의 plugin contract를 우회하지 않는다.
+- `typia@next`처럼 copy-first, per-file ledger-first, test-immutable 방식으로 진행한다.
+- Nestia 전용 hard-coding으로 특정 테스트나 특정 DTO 이름을 통과시키지 않는다.
+

--- a/.wiki/00-ledger/00-scope.md
+++ b/.wiki/00-ledger/00-scope.md
@@ -1,0 +1,50 @@
+# 조사 범위와 정독 기준
+
+사용자 요청의 범위는 세 저장소 전체와 현재 저장소다.
+
+- `ttsc`: `/home/samchon/github/samchon/ttsc`
+- `typia@next`: `/home/samchon/github/samchon/typia@next`
+- `typia`: `/home/samchon/github/samchon/typia`
+- `nestia@next`: `/home/samchon/github/samchon/nestia@next`
+
+## 이번 위키의 근거 범위
+
+이번 문서는 다음 축을 우선 근거로 삼았다.
+
+- `ttsc` README, guide docs, JS host, plugin loader/cache, native driver, native CLI
+- `typia@next`의 `GO-MIGRATION-INSTRUCTION.md`, ttsc plugin manifest, native `ttsc-typia` command, adapter, setup/generate wizard
+- `typia` TypeScript 원본과 `typia@next` native core/transform의 파일 대응성
+- `nestia@next`의 package manifest, setup/configurator, core transformer/programmers, sdk transformer/analyzer/generator, migrate entry
+
+## 정직한 상태 표시
+
+이 위키는 포팅 착수 전 의사결정을 위한 1차 지식대백과다. `git ls-files` 기반 전체 inventory와 대표 핵심 파일의 실제 내용을 근거로 작성했다. 다만 `typia@next`의 benchmark 결과물, 테스트 fixture, generated output 같은 대량 산출물은 현재 상태와 라인 수를 inventory로 잡았고, 포팅 설계의 authoritative source는 source/docs/tree correspondence로 제한했다.
+
+향후 실제 포팅에 들어가기 전에는 `typia@next/GO-MIGRATION-INSTRUCTION.md`의 방식처럼 Nestia도 파일별 문서를 만들어야 한다. 특히 `packages/core/src/**/*.ts`, `packages/sdk/src/**/*.ts`, `packages/cli/src/**/*.ts`, `packages/migrate/src/**/*.ts`는 각 파일마다 다음 항목이 있어야 한다.
+
+- 원본 경로
+- native 대응 경로
+- public/exported surface
+- 내부 알고리즘
+- 사용하는 TypeScript-Go shim
+- typia native 의존점
+- 상태: `TS_ORIGINAL`, `GO_PLANNED`, `GO_PORTED`, `VERIFIED`
+
+## 조사 명령 기록
+
+대표적으로 사용한 명령은 다음과 같다.
+
+```bash
+git ls-files | wc -l
+git ls-files | awk '{ ... wc -l ... }'
+git ls-files 'packages/*/src/**'
+rg -n "ts-patch|typia/lib/transform|compilerOptions.plugins|transform"
+sed -n '1,260p' README.md
+sed -n '1,260p' docs/README.md
+sed -n '1,280p' packages/ttsc/src/TtscCompiler.ts
+sed -n '1,260p' packages/typia/src/transform.ts
+sed -n '1,320p' packages/typia/native/cmd/ttsc-typia/build.go
+sed -n '1,320p' packages/core/src/transformers/*.ts
+sed -n '1,380p' packages/sdk/src/transformers/SdkOperationProgrammer.ts
+```
+

--- a/.wiki/00-ledger/01-current-inventory.md
+++ b/.wiki/00-ledger/01-current-inventory.md
@@ -1,0 +1,87 @@
+# 현재 파일 Inventory
+
+## ttsc
+
+Tracked files: 402  
+Total lines: 30,826
+
+확장자별 주요 분포:
+
+| 확장자 | 파일 | 라인 |
+| --- | ---: | ---: |
+| `.go` | 71 | 13,389 |
+| `.ts` | 189 | 6,078 |
+| `.cjs` | 28 | 4,528 |
+| `.md` | 27 | 3,324 |
+| `.json` | 41 | 774 |
+| `.yaml` | 2 | 1,050 |
+
+`ttsc`에서 의미상 핵심인 축은 네 개다.
+
+- JS host: `packages/ttsc/src/**`
+- plugin samples: `packages/banner`, `packages/strip`, `packages/paths`, `packages/lint`
+- native host: `packages/ttsc/cmd/ttsc/**`, `packages/ttsc/driver/**`
+- guide docs: `docs/**`
+
+## typia@next
+
+Tracked files: 2,789  
+Total lines: 348,985
+
+상위 디렉터리별 주요 분포:
+
+| 디렉터리 | 파일 | 라인 |
+| --- | ---: | ---: |
+| `tests` | 866 | 220,402 |
+| `packages` | 737 | 78,877 |
+| `website` | 147 | 19,334 |
+| `benchmark` | 906 | 14,831 |
+| `examples` | 74 | 2,297 |
+| `experiments` | 29 | 1,473 |
+
+`tests` 라인 수가 큰 이유는 native port 검증 fixture와 generated result가 포함되어 있기 때문이다. 포팅 설계의 핵심 source는 `packages/typia/native/**`, `packages/typia/src/**`, `GO-MIGRATION-INSTRUCTION.md`다.
+
+## typia
+
+Tracked files: 2,621  
+Total lines: 154,789
+
+상위 디렉터리별 주요 분포:
+
+| 디렉터리 | 파일 | 라인 |
+| --- | ---: | ---: |
+| `benchmark` | 906 | 14,836 |
+| `tests` | 770 | 38,610 |
+| `packages` | 688 | 66,419 |
+| `website` | 149 | 19,651 |
+| `examples` | 74 | 2,310 |
+
+`typia`의 authoritative 원본은 `packages/core/src/**`와 `packages/transform/src/**`다. `typia@next`의 native 대응은 다음 명령의 비교 결과 차이가 없었다.
+
+```bash
+comm -3 \
+  <(git -C ../typia ls-files 'packages/core/src/**' 'packages/transform/src/**' | sed -e 's#packages/core/src/#core/#' -e 's#packages/transform/src/#transform/#' -e 's/\.ts$/.go/' | sort) \
+  <(git -C ../typia@next ls-files 'packages/typia/native/core/**' 'packages/typia/native/transform/**' | sed -e 's#packages/typia/native/##' | sort)
+```
+
+출력이 없으므로 원본 `core/transform` 트리와 native `core/transform` 트리의 파일 경로 대응은 현재 1:1이다.
+
+## nestia@next
+
+Tracked files: 2,466  
+`packages/*/src/**`: 258 files, 25,056 lines
+
+패키지 source 분포:
+
+| 패키지 | 파일 | 라인 |
+| --- | ---: | ---: |
+| `packages/sdk/src` | 97 | 9,418 |
+| `packages/core/src` | 73 | 5,526 |
+| `packages/migrate/src` | 41 | 4,785 |
+| `packages/e2e/src` | 9 | 2,138 |
+| `packages/fetcher/src` | 13 | 1,205 |
+| `packages/editor/src` | 9 | 801 |
+| `packages/cli/src` | 10 | 619 |
+| `packages/benchmark/src` | 6 | 564 |
+
+Go 포팅의 1차 대상은 `core`, `sdk`, `cli`다. `fetcher`, `e2e`, `editor`, `benchmark`, `migrate`는 runtime/tooling 성격이 강하므로 native transformer 안정화 이후 단계로 둔다.

--- a/.wiki/00-ledger/02-reading-ledger.md
+++ b/.wiki/00-ledger/02-reading-ledger.md
@@ -1,0 +1,56 @@
+# 읽기 Ledger
+
+## ttsc 핵심 파일
+
+| 경로 | 확인한 내용 |
+| --- | --- |
+| `README.md` | `ttsc`, `ttsx`, transformer support, setup command, plugin list |
+| `docs/README.md` | JS manifest와 Go backend의 책임 분리, plugin kind, reading order |
+| `packages/ttsc/src/TtscCompiler.ts` | `prepare`, `clean`, `compile`, `transform` programmatic API와 in-memory contract |
+| `packages/ttsc/src/plugin/internal/loadProjectPlugins.ts` | `compilerOptions.plugins` 로딩, `createTtscPlugin` 우선, `source` 검증, stage 판정 |
+| `packages/ttsc/src/plugin/internal/buildSourcePlugin.ts` | source plugin build target, cache key, bundled Go toolchain, `go.work` overlay |
+| `packages/ttsc/src/compiler/internal/transformProjectInMemory.ts` | transform stage 실행, check stage 선행, single transform backend 제약 |
+| `packages/ttsc/driver/program.go` | Program facade, diagnostics, checker lease, source file filter |
+| `packages/ttsc/driver/rewrite.go` | emit-time rewrite, `RewriteSet`, sentinel, output path와 source path 매칭 |
+| `packages/ttsc/cmd/ttsc/api_transform.go` | source-to-source JSON API `{ typescript }` |
+| `packages/ttsc/cmd/ttsc/build.go` | native build/check/emit path |
+
+## typia 핵심 파일
+
+| 경로 | 확인한 내용 |
+| --- | --- |
+| `GO-MIGRATION-INSTRUCTION.md` | copy-first, 1:1 mechanical porting, immutable tests, per-file wiki rule |
+| `packages/typia/src/transform.ts` | `createTtscPlugin()` manifest, native source resolution |
+| `packages/typia/native/cmd/ttsc-typia/main.go` | command dispatcher: build/check/transform/demo/version |
+| `packages/typia/native/cmd/ttsc-typia/build.go` | Program load, typia call site rewrite, `--plugins-json`, options regex |
+| `packages/typia/native/cmd/ttsc-typia/transform.go` | project/single-file transform, source rewrite map, TS output cleanup |
+| `packages/typia/native/adapter/adapter.go` | `ITypiaContext` 구성, native transformer 호출, printer, error handling |
+| `packages/typia/native/adapter/visit.go` | signature declaration 기반 typia call site 탐지 |
+| `packages/typia/src/executable/TypiaSetupWizard.ts` | `ttsc`와 `@typescript/native-preview` 설치, `ts-patch` 제거 |
+| `packages/typia/src/executable/setup/PluginConfigurator.ts` | `typia/lib/transform` 등록과 strict/skipLibCheck 보정 |
+| `packages/typia/src/executable/TypiaGenerateWizard.ts` | `TtscCompiler.transform()` 기반 source generation |
+
+## nestia 핵심 파일
+
+| 경로 | 확인한 내용 |
+| --- | --- |
+| `package.json` | root `prepare: ts-patch install`, `ts-patch` devDependency |
+| `packages/core/package.json` | `./lib/transform` export, publishConfig, typia/core/interface/utils 의존 |
+| `packages/sdk/package.json` | `./lib/transform`, CLI bin, sdk generator 의존 |
+| `packages/cli/src/NestiaSetupWizard.ts` | `ts-patch`, `ts-node`, TypeScript 설치 및 prepare 실행 |
+| `packages/cli/src/internal/PluginConfigurator.ts` | core/sdk/typia transformer 등록, decorator metadata 설정 |
+| `packages/cli/src/boot.js` | `ts-node.register()`와 plugin list |
+| `packages/core/src/transform.ts` | strictNullChecks 검증, `FileTransformer` delegating |
+| `packages/core/src/transformers/FileTransformer.ts` | source file visitor, importer 주입, `TransformerError` diagnostic |
+| `packages/core/src/transformers/MethodTransformer.ts` | method decorator/return Promise 분석, typed route/websocket transform |
+| `packages/core/src/transformers/ParameterDecoratorTransformer.ts` | signature declaration path 기반 Nestia decorator 인식 |
+| `packages/core/src/programmers/*.ts` | typia programmers 기반 request/response validator/stringifier plan 생성 |
+| `packages/sdk/src/transform.ts` | `SdkOperationTransformer.iterateFile()` export |
+| `packages/sdk/src/transformers/SdkOperationTransformer.ts` | controller method에 `OperationMetadata` decorator 주입 |
+| `packages/sdk/src/transformers/SdkOperationProgrammer.ts` | typia `MetadataFactory`로 parameter/success/exception schema 생성 |
+| `packages/sdk/src/NestiaSdkApplication.ts` | runtime reflection 분석 후 SDK/E2E/Swagger generation |
+| `packages/sdk/src/analyses/*.ts` | controller/operation/parameter/response/security/import/path 분석 |
+| `packages/sdk/src/generates/*.ts` | generated SDK/Swagger/E2E 파일 작성 |
+| `packages/sdk/src/executable/internal/NestiaConfigLoader.ts` | `ts-node`로 config import, sdk transform 자동 추가 |
+| `packages/migrate/src/NestiaMigrateApplication.ts` | OpenAPI document를 Nest/SDK 프로젝트 파일로 변환 |
+

--- a/.wiki/01-ttsc/00-encyclopedia.md
+++ b/.wiki/01-ttsc/00-encyclopedia.md
@@ -1,0 +1,80 @@
+# ttsc 백과: 무엇인가
+
+`ttsc`는 `typescript-go` 기반 TypeScript compiler/runtime/plugin host다. 사용자는 `ttsc`로 build/check/transform을 수행하고, `ttsx`로 type checking이 있는 TypeScript 실행을 수행한다.
+
+`ttsc`의 철학은 다음과 같다.
+
+- TypeScript-Go가 parse/check/emit의 authoritative compiler다.
+- JavaScript layer는 project config, plugin manifest, cache, process execution을 담당한다.
+- Go native backend가 Program, Checker, AST, printer, emit rewrite를 담당한다.
+- plugin author는 JS hook을 작성하지 않고 Go command package를 제공한다.
+- compile output과 source transform output은 구분된다.
+
+## JS host의 역할
+
+`packages/ttsc/src/TtscCompiler.ts`는 public programmatic API다.
+
+- `prepare()`는 source plugin을 cache에 미리 build한다. Program을 만들지 않고 diagnostics도 돌리지 않는다.
+- `clean()`은 cache root를 지운다.
+- `compile()`은 emitted JS/d.ts/map을 in-memory result로 돌려준다. plugin이 있으면 temporary output directory를 사용한다.
+- `transform()`은 TypeScript source map만 반환한다. JS emit, declaration, source map은 반환하지 않는다.
+
+이 구분은 Nestia에 중요하다. `@nestia/core` decorator argument rewrite와 `@nestia/sdk` OperationMetadata injection은 source-to-source 성격이 강하고, generated SDK 파일 생성은 별도의 runtime CLI/generator 성격이다.
+
+## plugin loader의 역할
+
+`loadProjectPlugins.ts`는 `compilerOptions.plugins[]`를 읽고 active entry만 load한다.
+
+허용되는 JS export shape:
+
+- `createTtscPlugin(context)`
+- `default`
+- `plugin`
+- module object/function 자체
+
+반환된 plugin object는 최소한 다음을 가져야 한다.
+
+- `name: string`
+- `source: string`
+- `stage?: "transform" | "check" | "output"`
+
+`stage`가 없으면 `"transform"`이다. `transformSource`나 `transformOutput` 같은 JS hook은 거부된다.
+
+## source plugin build
+
+`buildSourcePlugin.ts`는 plugin의 Go source를 cache binary로 만든다.
+
+핵심 규칙:
+
+- `source`는 Go package directory 또는 `go.mod` file이어야 한다.
+- `go.mod`는 source directory에서 최대 3단계 부모 안에 있어야 한다.
+- scratch copy에서 `node_modules`, `.git`, `dist`, `build`, `vendor`, `lib`, `go.work`를 제외한다.
+- `go.work`를 scratch에 새로 쓰고 `ttsc` shim overlay를 연결한다.
+- cache key는 `ttsc` version, TypeScript-Go version, platform/arch, entry, source file contents로 구성한다.
+- Go compiler는 `TTSC_GO_BINARY`, bundled `@ttsc/${platform}-${arch}`, local native Go, system `go` 순으로 찾는다.
+
+Nestia는 이 모델에 맞춰 consumer가 별도 Go toolchain을 설치하지 않아도 native backend가 build되게 해야 한다.
+
+## native driver
+
+`packages/ttsc/driver/program.go`는 TypeScript-Go shim을 감싼 facade다.
+
+주요 기능:
+
+- tsconfig parse
+- Program 생성
+- TypeChecker lease 획득/해제
+- declaration file을 제외한 source file 열람
+- bind/semantic diagnostics 취합
+- lint/plugin diagnostics와 TypeScript diagnostics를 같은 형식으로 출력
+
+`packages/ttsc/driver/rewrite.go`는 emit-time rewrite를 담당한다.
+
+- plugin이 source file과 call expression별 replacement를 `RewriteSet`에 쌓는다.
+- TypeScript-Go emit의 `WriteFile` callback에서 JS output text를 가로챈다.
+- output path와 source path의 suffix를 비교해 source file을 찾는다.
+- call text를 찾아 replacement로 바꾼다.
+- `/* @ttsc-rewritten */` sentinel로 중복 rewrite를 방지한다.
+
+`typia@next`는 이 구조를 그대로 활용한다. Nestia도 decorator call rewrite를 할 때 source-level rewrite와 emit-time rewrite 중 어느 표면이 맞는지 명확히 골라야 한다.
+

--- a/.wiki/01-ttsc/01-execution-model.md
+++ b/.wiki/01-ttsc/01-execution-model.md
@@ -1,0 +1,74 @@
+# ttsc 실행 모델
+
+## CLI와 programmatic API
+
+사용자가 보는 CLI는 다음과 같다.
+
+- `ttsc`: project build/check/watch/prepare/clean
+- `ttsx`: TypeScript direct execution with checking and transform
+
+library host가 보는 API는 `TtscCompiler`다.
+
+```ts
+new TtscCompiler({
+  cwd,
+  tsconfig,
+  binary,
+  plugins,
+  cacheDir,
+  env,
+}).transform();
+```
+
+Nestia의 `NestiaConfigLoader`는 현재 `ts-node.register()`를 사용한다. Go 포팅에서는 이 부분이 `TtscCompiler.compile()` 또는 `ttsx` equivalent execution으로 바뀌어야 한다. `ts-node`는 `ttsc` native plugin을 실행하지 않는다.
+
+## build path
+
+`runBuild` 계열의 책임은 다음이다.
+
+1. project config resolve
+2. native plugin load/build
+3. check stage plugin 실행
+4. transform/build stage plugin 또는 TypeScript-Go normal build 실행
+5. output stage plugin 적용
+6. diagnostics/result 정규화
+
+Go sidecar가 compiler backend라면 Program creation과 emit을 sidecar가 소유한다.
+
+## transform path
+
+`transformProjectInMemory.ts`는 source-to-source API다.
+
+- plugin이 없으면 native compiler의 `api-transform` command를 실행한다.
+- plugin이 있으면 check plugin을 먼저 실행한다.
+- transform plugin이 있으면 single transform host를 강제한다.
+- sidecar stdout은 `{ "typescript": { ... } }` JSON이어야 한다.
+
+이 지점이 Nestia 포팅의 가장 중요한 제약이다.
+
+## 단일 transform host 제약
+
+`ttsc`는 여러 transform stage plugin이 있더라도 native binary path가 하나여야 한다.
+
+즉 다음 조합은 위험하다.
+
+```json
+{
+  "plugins": [
+    { "transform": "typia/lib/transform" },
+    { "transform": "@nestia/core/lib/transform" },
+    { "transform": "@nestia/sdk/lib/transform" }
+  ]
+}
+```
+
+각 plugin이 서로 다른 native command를 반환하면 `ttsc: multiple transform native backends cannot share one source-to-source pass`에 걸린다.
+
+Nestia는 이 문제를 다음 중 하나로 풀어야 한다.
+
+1. `@nestia/core`와 `@nestia/sdk`가 같은 native source command를 반환한다.
+2. Nestia native command가 typia call rewrite까지 포함하고, Nestia setup은 별도 `typia/lib/transform` entry를 넣지 않는다.
+3. `typia` 쪽 manifest와 Nestia manifest가 같은 통합 backend를 반환할 수 있도록 별도 협업 protocol을 만든다.
+
+현재 `ttsc` 철학을 따르면 2번 또는 3번이 맞다. 1번만으로는 user project 안의 일반 `typia.*<T>()` call을 같이 처리하지 못한다.
+

--- a/.wiki/01-ttsc/02-plugin-protocol.md
+++ b/.wiki/01-ttsc/02-plugin-protocol.md
@@ -1,0 +1,72 @@
+# ttsc Plugin Protocol
+
+## manifest
+
+live code 기준 manifest는 단순하다.
+
+```ts
+export interface ITtscPlugin {
+  name: string;
+  source: string;
+  stage?: "transform" | "check" | "output";
+}
+```
+
+예전 guide 문서에는 `native.source` descriptor가 남아 있으나 현재 loader는 `source: string`을 직접 요구한다. Nestia 문서와 구현은 live code를 따라야 한다.
+
+## binary command
+
+native binary는 stage와 host 호출에 맞춰 command를 구현해야 한다. 모든 plugin이 모든 command를 구현해야 하는 것은 아니다. 아래는 stage별 host contract다.
+
+- `check`: check stage plugin과 `--noEmit` compiler backend가 사용한다.
+- `transform`: source-to-source transform stage가 사용한다.
+- `build`: emit을 소유하는 compiler backend가 사용한다.
+- `output`: output stage plugin이 emitted file마다 사용한다.
+- `version`, `help`: host 필수 contract는 아니지만 운영과 진단을 위해 권장한다.
+
+`typia@next`의 `ttsc-typia`는 이 command dispatcher를 이미 갖추고 있다. Nestia도 `ttsc-nestia` 같은 단일 command를 만들고, command별 의미를 명확히 해야 한다.
+
+## `--plugins-json`
+
+`ttsc`는 sidecar에 ordered plugin payload를 `--plugins-json`으로 넘긴다.
+
+payload에는 적어도 다음 정보가 들어간다.
+
+- plugin name
+- stage
+- original config entry
+
+Nestia는 이 payload에서 다음을 읽어야 한다.
+
+- `@nestia/core/lib/transform` config의 `validate`, `stringify`, 기타 extras
+- `@nestia/sdk/lib/transform` 존재 여부
+- `typia/lib/transform` config의 `functional`, `numeric`, `finite`, `undefined`
+- plugin order
+
+`typia@next`는 현재 tsconfig text를 regex로 읽어 typia option을 뽑는다. Nestia는 option 수가 많고 core/sdk/typia 협업이 필요하므로 `--plugins-json`을 우선 source of truth로 삼아야 한다.
+
+## diagnostics
+
+diagnostics는 TypeScript diagnostics처럼 file/line/column/code/message를 가져야 한다. `ttsc` driver에는 rich diagnostics 출력 path가 있으므로 Nestia sidecar도 가능한 한 `driver.NewLintDiagnostic` 또는 같은 shape로 오류를 만들어야 한다.
+
+Nestia에서 diagnostics가 중요한 지점:
+
+- `strictNullChecks` 미설정
+- 잘못된 decorator argument
+- `TypedParam` field 누락
+- `GET`/`HEAD` body 금지
+- wildcard path 미지원 warning
+- WebSocketRoute parameter contract 위반
+- typia metadata validation 실패
+
+## cache와 배포
+
+source plugin은 consumer project에서 lazy build된다. 따라서 Nestia package에 포함되어야 하는 것은 native source tree와 JS manifest다.
+
+배포 시 확인할 점:
+
+- `files`에 `native/**` 포함
+- `publishConfig.exports`가 built JS manifest와 type file을 가리킴
+- `source`가 package root에서 안정적으로 resolve됨
+- `lib` 제외 규칙 때문에 source plugin scratch copy에서 build output과 source가 섞이지 않음
+- monorepo dev와 npm package install 양쪽에서 `go.mod`를 찾을 수 있음

--- a/.wiki/01-ttsc/03-lessons-for-nestia.md
+++ b/.wiki/01-ttsc/03-lessons-for-nestia.md
@@ -1,0 +1,58 @@
+# ttsc에서 Nestia가 배워야 할 점
+
+## 1. JS transformer 함수에서 native manifest로 전환
+
+현재 `@nestia/core/lib/transform`과 `@nestia/sdk/lib/transform`은 TypeScript transformer function을 export한다. `ttsc`에서 필요한 것은 function transformer가 아니라 `createTtscPlugin()` manifest다.
+
+전환 방식은 `typia@next/packages/typia/src/transform.ts`를 따라야 한다.
+
+- package root resolve
+- native command source resolve
+- `{ name, source }` 반환
+- 기존 ts-patch 호환 export는 transition 동안만 유지
+
+## 2. ts-node 실행 경로 제거
+
+`packages/sdk/src/executable/internal/NestiaConfigLoader.ts`는 `ts-node.register()`로 config를 load한다. 이 방식은 `ttsc` native plugin을 실행하지 못한다.
+
+필요한 전환:
+
+- config/project를 `TtscCompiler.compile()`로 임시 output에 compile
+- 또는 `ttsx` execution을 library화해서 config import
+- compile cache와 generated temp output을 명시적으로 관리
+- `@nestia/sdk/lib/transform` 자동 추가도 `plugins` 배열 조작이 아니라 ttsc plugin payload에 반영
+
+## 3. 하나의 transform host 설계
+
+Nestia는 typia에 깊게 의존한다. `@nestia/core` transformer는 typia `AssertProgrammer`, `IsProgrammer`, `ValidateProgrammer`, `JsonStringifyProgrammer`, `HttpQueryProgrammer` 등을 호출한다. `@nestia/sdk` transformer도 typia `MetadataFactory`와 `MetadataCollection`을 사용한다.
+
+따라서 Nestia native backend는 typia native core를 단순 dependency로 쓰는 수준을 넘어 user source 안의 typia call rewrite와 Nestia decorator rewrite를 같은 transform pass에서 조율해야 한다.
+
+## 4. 변환과 생성의 표면을 나누기
+
+Nestia에는 두 종류의 compile-time work가 섞여 있다.
+
+- source transform: decorator argument와 OperationMetadata decorator 주입
+- project generation: SDK/Swagger/E2E file generation
+
+`ttsc.transform()`은 source map을 돌려주는 API이고, SDK 파일 생성은 filesystem writer다. 둘을 한 command에 섞으면 API surface가 흐려진다.
+
+권장 분리:
+
+- `ttsc-nestia transform`: source-to-source transform
+- `ttsc-nestia build/check`: compile path
+- `nestia sdk`: config 실행과 generated file write
+- internal bridge: SDK CLI가 `TtscCompiler.compile()`로 config/controller metadata를 준비
+
+## 5. output hard-coding 금지
+
+`ttsc`와 `typia@next`의 공통 철학은 일반 알고리즘이다. Nestia도 특정 controller 이름, DTO 이름, 테스트 fixture 이름에 의존하는 예외 처리를 넣으면 안 된다.
+
+모든 처리는 다음 근거 중 하나로 결정해야 한다.
+
+- TypeScript-Go AST kind
+- TypeChecker symbol/signature/declaration
+- NestJS reflect metadata key
+- Nestia decorator declaration path
+- typia metadata/schema validation result
+

--- a/.wiki/02-typia/00-encyclopedia.md
+++ b/.wiki/02-typia/00-encyclopedia.md
@@ -1,0 +1,66 @@
+# typia 백과: TS 원본과 Go 포트
+
+`typia`는 TypeScript type을 분석해 runtime validator, serializer, random generator, schema, LLM parameter 등을 생성하는 compiler-powered library다.
+
+`typia@next`는 이 중 compiler 핵심인 다음 두 tree를 Go로 옮겼다.
+
+- `../typia/packages/core/src`
+- `../typia/packages/transform/src`
+
+현재 대응 tree:
+
+- `packages/typia/native/core`
+- `packages/typia/native/transform`
+
+파일 경로 대응은 1:1이다. 원본 `.ts` 경로를 native `.go` 경로로 바꿨을 때 차이가 없다.
+
+## Go 포팅의 핵심 철학
+
+`GO-MIGRATION-INSTRUCTION.md`의 핵심은 다음이다.
+
+- TS 원본을 먼저 native tree에 bulk-copy한다.
+- `.ts`는 아직 대기 중인 원본이고, `.go`는 변환 완료 파일이다.
+- 파일 tree, module structure, class/function/type name을 최대한 보존한다.
+- Go idiom으로 재설계하지 않는다.
+- 일반 알고리즘만 허용한다.
+- AST assembly로 code generation한다.
+- test는 수정하지 않는다.
+- 모든 파일에 per-file wiki 문서를 둔다.
+
+Nestia도 같은 방식이어야 한다. 특히 `packages/core/src/programmers`와 `packages/sdk/src/transformers`는 typia API 호출이 많으므로 이름과 책임을 보존한 1:1 포팅이 추적 가능성을 만든다.
+
+## typia native backend의 위치
+
+`packages/typia/src/transform.ts`는 얇은 manifest다.
+
+- consumer project에서 `typia/package.json`을 resolve한다.
+- package root의 `native/cmd/ttsc-typia`를 source로 반환한다.
+- plugin name은 `typia`다.
+
+native command는 다음을 제공한다.
+
+- `build`: Program load, diagnostics, rewrite, emit
+- `check`: `build --noEmit`
+- `transform`: project 또는 single file transform
+- `demo`
+- `version`
+- `help`
+
+## adapter
+
+`packages/typia/native/adapter`는 `ttsc` driver와 typia native core/transform 사이의 접착층이다.
+
+역할:
+
+- user source에서 typia call site 수집
+- signature declaration path로 typia module 식별
+- method/root/namespace 추출
+- `ITypiaContext` 구성
+- native `CallExpressionTransformer.Transform()` 호출
+- printer로 JS 또는 type-preserving TS expression 출력
+- unsupported generic call 진단
+- CommonJS identifier substitution
+- import cleanup
+
+Nestia native backend도 이 adapter 수준의 접착층이 필요하다. 단, Nestia는 function call뿐 아니라 decorator call, method declaration, parameter declaration, class declaration을 다뤄야 한다.
+

--- a/.wiki/02-typia/01-porting-protocol.md
+++ b/.wiki/02-typia/01-porting-protocol.md
@@ -1,0 +1,66 @@
+# typia 포팅 프로토콜에서 차용할 규칙
+
+## copy-first
+
+Nestia 포팅을 시작할 때는 빈 Go 파일을 설계하지 않는다. 원본을 먼저 native tree에 복사하고, 파일별로 번역한다.
+
+권장 seed:
+
+```bash
+mkdir -p packages/core/native packages/sdk/native packages/cli/native
+rsync -a packages/core/src/ packages/core/native/core/
+rsync -a packages/sdk/src/ packages/sdk/native/sdk/
+rsync -a packages/cli/src/ packages/cli/native/cli/
+```
+
+실제 작업에서는 `--delete` 사용 전 native tree에 이미 변환된 `.go`가 없는지 확인해야 한다.
+
+## 파일별 wiki
+
+Nestia도 다음 위치에 파일별 포팅 문서를 둔다.
+
+```text
+.wiki/packages/core/.../{filename}.md
+.wiki/packages/sdk/.../{filename}.md
+.wiki/packages/cli/.../{filename}.md
+```
+
+각 문서 필수 항목:
+
+- original TS path
+- native copy path
+- exported identifiers
+- transformer/programmer/analyzer role
+- TypeScript compiler API usage
+- TypeScript-Go shim replacement
+- typia native dependency
+- diagnostics behavior
+- status
+
+## 상태 값
+
+권장 상태:
+
+- `TS_ORIGINAL`: 원본 확인 전
+- `READ`: 원본 파일 의미 확인
+- `GO_PLANNED`: Go 대응 shim/API 계획 완료
+- `GO_PORTED`: `.go` 변환 완료
+- `PARITY_TESTED`: golden test 또는 fixture pass
+- `VERIFIED`: package-level build/test 통과
+
+## test immutable
+
+Nestia의 테스트와 fixture는 포팅 기준이다. 테스트를 단순화하거나 fixture를 native 구현에 맞게 바꾸면 안 된다.
+
+허용되는 변경:
+
+- test runner가 `ts-patch` 대신 `ttsc`를 사용하도록 하는 infrastructure 전환
+- setup wizard expected output이 `ttsc`/`@typescript/native-preview` 기준으로 바뀌는 경우
+
+허용되지 않는 변경:
+
+- decorator 동작 기대치 삭제
+- generated SDK output 축소
+- validation/stringify mode 일부 제거
+- WebSocket route validation 생략
+

--- a/.wiki/02-typia/02-native-backend.md
+++ b/.wiki/02-typia/02-native-backend.md
@@ -1,0 +1,61 @@
+# typia native backend 구조
+
+## build command
+
+`ttsc-typia build.go`는 다음 순서로 동작한다.
+
+1. flags parse
+2. `driver.LoadProgram(cwd, tsconfig, options)`
+3. diagnostics 출력
+4. typia call sites 수집
+5. 각 call site를 native transformer로 바꿔 `RewriteSet`에 추가
+6. `prog.EmitAll(rewrites, writeFile)`
+7. cleanup과 manifest 작성
+
+Nestia의 build command도 이 흐름을 따른다. 다만 call site 대신 다음 site를 수집한다.
+
+- `@TypedBody`, `@EncryptedBody`, `@PlainBody`, `@TypedHeaders`, `@TypedParam`, `@TypedQuery`, `@TypedFormData.Body`
+- `@TypedRoute`, `@EncryptedRoute`, `@TypedQuery.*`
+- `@WebSocketRoute.*`
+- controller method declaration for `OperationMetadata`
+- user source의 typia call sites
+
+## transform command
+
+`ttsc-typia transform.go`는 두 모드를 가진다.
+
+- `--file`: 한 파일 emit 또는 TS source transform
+- project transform: 모든 source file을 `{ typescript }` JSON으로 반환
+
+Nestia에는 project transform이 중요하다. `TtscCompiler.transform()`을 사용하는 generate command나 tests에서 transformed TypeScript source를 확인할 수 있어야 한다.
+
+## source rewrite
+
+typia project transform은 source text를 직접 replace한다.
+
+- call expression node의 `Pos()`와 `End()`를 range로 사용한다.
+- range는 뒤에서 앞으로 정렬해 적용한다.
+- replacement는 printer output이다.
+- 마지막에 TypeScript output cleanup을 수행한다.
+
+Nestia decorator rewrite도 source transform에서는 같은 방식이 유효하다. 다만 decorator argument 추가는 AST node 전체를 printer로 다시 출력해야 하므로, TS AST printer가 decorator syntax를 안정적으로 보존하는지 별도 검증이 필요하다.
+
+## adapter context
+
+typia adapter는 다음 context를 구성한다.
+
+- `Program`
+- `CompilerOptions`
+- `Checker`
+- `Options`
+- `Importer`
+
+Nestia core transformer도 사실상 `ITypiaContext`를 확장한 `INestiaTransformContext`를 사용한다. 따라서 Go port에서도 다음을 보존한다.
+
+- compiler options
+- checker
+- importer
+- transform options
+- diagnostics sink
+- extras/config
+

--- a/.wiki/02-typia/03-ts-go-correspondence.md
+++ b/.wiki/02-typia/03-ts-go-correspondence.md
@@ -1,0 +1,74 @@
+# typia TS/Go 대응성
+
+## 파일 대응
+
+`../typia/packages/core/src/**`와 `typia@next/packages/typia/native/core/**`는 파일 경로가 대응한다.
+
+`../typia/packages/transform/src/**`와 `typia@next/packages/typia/native/transform/**`도 대응한다.
+
+이 대응성은 Nestia에서 매우 중요하다. Nestia도 포팅할 때 다음 식의 추적이 가능해야 한다.
+
+```text
+packages/core/src/programmers/TypedBodyProgrammer.ts
+-> packages/core/native/core/programmers/TypedBodyProgrammer.go
+
+packages/sdk/src/transformers/SdkOperationProgrammer.ts
+-> packages/sdk/native/sdk/transformers/SdkOperationProgrammer.go
+```
+
+## 알고리즘 대응 예시
+
+`CallExpressionTransformer.ts`와 `CallExpressionTransformer.go`는 module/method dispatcher 구조를 보존한다.
+
+- `module`
+- `functional`
+- `http`
+- `llm`
+- `json`
+- `protobuf`
+- `reflect`
+- `misc`
+- `notations`
+
+`IsProgrammer.ts`와 `IsProgrammer.go`는 `configure`, `decompose`, `write`, `decode`, `CheckerProgrammer`, `FeatureProgrammer`, object check functor 흐름을 유지한다.
+
+`MetadataFactory.ts`와 `MetadataFactory.go`는 type exploration, collection iteration, validation visitor를 보존한다.
+
+## Nestia에 필요한 typia API
+
+Nestia core transformer가 직접 사용하는 typia 계층:
+
+- `AssertProgrammer`
+- `IsProgrammer`
+- `ValidateProgrammer`
+- `MiscAssertCloneProgrammer`
+- `MiscValidateCloneProgrammer`
+- `MiscAssertPruneProgrammer`
+- `MiscValidatePruneProgrammer`
+- `JsonStringifyProgrammer`
+- `JsonAssertStringifyProgrammer`
+- `JsonIsStringifyProgrammer`
+- `JsonValidateStringifyProgrammer`
+- `HttpAssertQuerifyProgrammer`
+- `HttpIsQuerifyProgrammer`
+- `HttpValidateQuerifyProgrammer`
+- `HttpQueryProgrammer`
+- `HttpHeadersProgrammer`
+- `HttpParameterProgrammer`
+- `HttpFormDataProgrammer`
+- `JsonMetadataFactory`
+- `MetadataFactory`
+- `LlmSchemaProgrammer`
+- `LlmParametersProgrammer`
+
+Nestia SDK transformer가 사용하는 typia 계층:
+
+- `MetadataFactory`
+- `MetadataCollection`
+- `MetadataSchema`
+- `LiteralFactory`
+- `TypeFactory`
+- `CommentFactory`
+- validation pipe shape
+
+따라서 Nestia native backend는 typia native core를 library로 import해야 하며, TypeScript 원본 `@typia/core` import를 문자열로 흉내내면 안 된다.

--- a/.wiki/02-typia/04-lessons-for-nestia.md
+++ b/.wiki/02-typia/04-lessons-for-nestia.md
@@ -1,0 +1,24 @@
+# typia에서 Nestia가 배워야 할 점
+
+## 1. 포팅은 알고리즘 보존이다
+
+Go로 옮긴다는 말은 Go식 설계로 재작성한다는 뜻이 아니다. `typia@next`는 원본 파일과 identifier를 최대한 보존했다. Nestia도 `TypedRouteProgrammer.generate`, `SdkOperationProgrammer.write`, `ReflectHttpOperationParameterAnalyzer.analyze` 같은 이름과 구조를 보존해야 한다.
+
+## 2. JS package는 얇게 유지한다
+
+`typia@next`의 JS transform file은 native source를 가리키는 manifest다. Nestia도 consumer-facing package는 TS/JS package로 유지하되 compiler work는 Go sidecar가 한다.
+
+## 3. setup wizard가 생태계를 바꾼다
+
+typia setup은 `ts-patch`를 제거하고 `ttsc`, `@typescript/native-preview`를 설치한다. Nestia setup도 같은 전환을 해야 한다.
+
+현재 Nestia setup은 반대로 `ts-patch`와 `ts-node`를 설치하고 `prepare`에 `ts-patch install`을 넣는다. 이 부분은 포팅 초기에 반드시 제거 대상이다.
+
+## 4. generate path는 `TtscCompiler.transform()`을 쓸 수 있다
+
+typia generate wizard는 `new TtscCompiler(...).transform()`으로 source를 변환한 뒤 파일을 쓴다. Nestia SDK CLI도 config/controller metadata 준비에 `TtscCompiler.compile()` 또는 transform/compile hybrid를 써야 한다.
+
+## 5. printer cleanup은 필수지만 위험하다
+
+typia native transform은 TypeScript-Go printer output을 후처리한다. Nestia decorator syntax와 metadata literal은 formatting에 민감할 수 있다. 따라서 cleanup rule은 최소화하고 golden output test를 둬야 한다.
+

--- a/.wiki/03-nestia/00-package-map.md
+++ b/.wiki/03-nestia/00-package-map.md
@@ -1,0 +1,69 @@
+# nestia@next Package Map
+
+## root
+
+현재 root `package.json`은 다음 compiler patch 모델을 가진다.
+
+- `scripts.prepare = "ts-patch install"`
+- devDependency `ts-patch`
+- devDependency `typescript`
+
+Go 포팅에서는 root prepare가 없어지거나 `ttsc prepare` 성격으로 바뀌어야 한다. consumer package에 `ts-patch install`을 강제하지 않는다.
+
+## packages/core
+
+`@nestia/core`는 NestJS decorator와 runtime validator/stringifier wrapper, 그리고 compiler transformer를 제공한다.
+
+중요 export:
+
+- `.`
+- `./lib/transform`
+- `./src/transform.ts`
+
+중요 source:
+
+- `decorators/**`: public decorator와 runtime helper
+- `programmers/**`: typia 기반 validator/stringifier plan 생성
+- `transformers/**`: AST transformer
+- `options/**`: transform option contract
+
+## packages/sdk
+
+`@nestia/sdk`는 SDK/Swagger/E2E generator와 compile-time metadata transformer를 제공한다.
+
+중요 export:
+
+- `.`
+- `./lib/executable/sdk`
+- `./lib/transform`
+
+중요 source:
+
+- `transformers/**`: controller method에 `OperationMetadata` decorator 주입
+- `analyses/**`: runtime reflection 결과를 typed route로 분석
+- `generates/**`: SDK/Swagger/E2E output 작성
+- `executable/**`: CLI command/config loader
+
+## packages/cli
+
+`nestia` CLI는 setup wizard를 제공한다.
+
+현재 역할:
+
+- Nestia/typia/ts-patch/ts-node/typescript 설치
+- `ts-patch install` prepare script 구성
+- core/sdk/typia transformer tsconfig 등록
+
+Go 포팅 후 역할:
+
+- Nestia/typia/ttsc/@typescript/native-preview 설치
+- `ts-patch` 제거
+- 통합 native transform plugin 등록
+- `ttsc`/`ttsx` 실행 안내
+
+## packages/migrate
+
+`@nestia/migrate`는 OpenAPI document를 Nest/SDK project file set으로 변환한다. compiler transformer와 직접 연결된 핵심 경로는 아니다. typia runtime validation과 `@typia/utils` migration utilities에 의존한다.
+
+Go 포팅 1차 범위에서는 `migrate` 자체 재작성보다 typia@next runtime compatibility와 package contract 확인이 우선이다.
+

--- a/.wiki/03-nestia/01-core-transform.md
+++ b/.wiki/03-nestia/01-core-transform.md
@@ -1,0 +1,89 @@
+# @nestia/core Transform 구조
+
+## entry
+
+`packages/core/src/transform.ts`는 TypeScript transformer entry다.
+
+흐름:
+
+1. `program.getCompilerOptions()`
+2. `strictNullChecks` 또는 `strict` 확인
+3. strict가 아니면 diagnostic 추가
+4. `FileTransformer.transform()`에 checker, printer, compilerOptions, options, extras 전달
+
+Go 포팅에서는 이 파일이 `createTtscPlugin()` manifest로 바뀌어야 한다. strict diagnostics는 native sidecar가 `driver.Program`의 parsed compiler options에서 확인한다.
+
+## FileTransformer
+
+`FileTransformer`는 source file 단위 visitor다.
+
+- declaration file은 건너뛴다.
+- `ImportProgrammer`를 `internalPrefix: "nestia_core_transform"`로 만든다.
+- node visitor에서 `TransformerError`를 잡아 diagnostics에 넣는다.
+- 필요한 import statements를 `"use ..."` directive 뒤에 주입한다.
+
+Go 포팅의 핵심 과제는 `ImportProgrammer`와 import injection이다. typia native adapter의 cleanup/import substitution을 참고하되, Nestia는 decorator argument에 import alias를 직접 넣으므로 source-level TS output과 JS emit output 양쪽을 검증해야 한다.
+
+## NodeTransformer
+
+`NodeTransformer`는 두 종류만 dispatch한다.
+
+- `MethodDeclaration` -> `MethodTransformer`
+- `Parameter` -> `ParameterTransformer`
+
+이 단순성은 Go port에 유리하다. Go adapter도 visitor를 넓게 만들지 말고 이 두 node type에서 시작한다.
+
+## MethodTransformer
+
+`MethodTransformer`는 method decorator를 처리한다.
+
+- decorators가 없으면 원본 반환
+- return type을 checker로 얻음
+- Promise면 type argument를 return type으로 사용
+- 각 decorator에 `TypedRouteTransformer.transform`
+- 각 decorator에 `WebSocketRouteTransformer.validate`
+
+Go port 주의점:
+
+- TypeScript-Go에서 Promise type detection은 symbol name과 type arguments로 해야 한다.
+- decorator modifier 위치는 TS 5 최신 API와 legacy decorator shape를 둘 다 고려해야 한다.
+
+## ParameterTransformer와 ParameterDecoratorTransformer
+
+`ParameterTransformer`는 parameter decorator를 돌며 parameter type을 전달한다.
+
+`ParameterDecoratorTransformer`는 다음 기준으로 Nestia decorator를 식별한다.
+
+- decorator expression이 call expression인지
+- resolved signature declaration이 있는지
+- declaration source file path가 `@nestia/core/lib/decorators` 또는 `packages/core/src/decorators`인지
+- declaration symbol name이 functor map에 있는지
+
+대상 functor:
+
+- `EncryptedBody`
+- `TypedBody`
+- `TypedHeaders`
+- `TypedParam`
+- `TypedQuery`
+- `TypedQuery.Body`
+- `TypedFormData.Body`
+- `PlainBody`
+- `WebSocketRoute.Header`
+- `WebSocketRoute.Param`
+- `WebSocketRoute.Query`
+
+Go port는 path substring만으로 끝내지 말고 package root resolution과 source file suffix normalization을 같이 해야 한다.
+
+## Programmer 계층
+
+`programmers/**`는 decorator 인자에 들어갈 plan object를 만든다.
+
+- body/header/query/param validators
+- route response stringify/validate plan
+- query route querify plan
+- form-data body plan
+- plain text body plan
+
+대부분 typia core programmers를 호출한다. 따라서 Nestia native core는 typia native core를 반드시 link해야 한다.
+

--- a/.wiki/03-nestia/02-sdk-transform-and-generation.md
+++ b/.wiki/03-nestia/02-sdk-transform-and-generation.md
@@ -1,0 +1,98 @@
+# @nestia/sdk Transform 및 Generation 구조
+
+## transform entry
+
+`packages/sdk/src/transform.ts`는 `SdkOperationTransformer.iterateFile(program.getTypeChecker())`를 반환한다.
+
+이 transformer는 controller method에 `OperationMetadata` decorator를 주입한다. SDK generator는 runtime reflection으로 이 metadata를 읽는다.
+
+## SdkOperationTransformer
+
+핵심 흐름:
+
+1. source file declaration 건너뜀
+2. `MetadataCollection` singleton 준비
+3. class declaration 방문
+4. method declaration별 symbol lookup
+5. decorator가 있는 method만 처리
+6. `SdkOperationProgrammer.write()`로 metadata literal 생성
+7. `__OperationMetadata.OperationMetadata(metadata as any)` decorator를 method modifiers에 추가
+8. 파일 상단에 `import * as __OperationMetadata from "@nestia/sdk"` 추가
+
+Go port 주의점:
+
+- method 중복 방문 방지를 `className/methodName` hash로 한다.
+- JSDoc comment/tag 수집은 TypeScript-Go shim에서 가능한 API 범위를 확인해야 한다.
+- `LiteralFactory.write(metadata)`를 Go에서 재현해야 한다.
+- decorator injection 후 printer가 기존 decorator/modifier 순서를 안정적으로 보존해야 한다.
+
+## SdkOperationProgrammer
+
+`SdkOperationProgrammer.write()`는 parameter/success/exception metadata를 생성한다.
+
+사용하는 typia 기능:
+
+- `MetadataFactory.analyze`
+- `MetadataCollection`
+- `MetadataSchema`
+- `CommentFactory.description`
+- `TypeFactory.keyword`
+- `DtoAnalyzer`
+
+metadata에는 두 schema가 들어간다.
+
+- `primitive`: `escape: true`
+- `resolved`: `escape: false`
+
+parameter optionality는 `questionToken`으로 metadata에 반영한다. return type은 `Promise<T>`이면 `T`로 unwrap한다.
+
+## runtime reflection pipeline
+
+`NestiaSdkApplication.generate()`는 runtime reflection을 기반으로 한다.
+
+1. config input 분석
+2. controller class import 또는 Nest application container 분석
+3. `ReflectControllerAnalyzer`
+4. `ReflectHttpOperationAnalyzer` 또는 `ReflectWebSocketOperationAnalyzer`
+5. typed route 변환
+6. `AccessorAnalyzer`
+7. validate
+8. `SdkGenerator`, `E2eGenerator`, `SwaggerGenerator`
+
+즉 SDK generator는 native transformer만으로 끝나지 않는다. config/controller source를 변환된 상태로 실행해야 runtime metadata가 생긴다.
+
+## ConfigLoader 병목
+
+`NestiaConfigLoader.configurations()`는 현재 `ts-node.register()`를 사용한다.
+
+```ts
+register({
+  emit: false,
+  compilerOptions: {
+    ...compilerOptions,
+    plugins,
+  },
+});
+```
+
+이 방식은 ttsc native plugin 실행 경로가 아니다. Go 포팅에서는 CLI가 config를 load하기 전에 ttsc compile/execute bridge를 사용해야 한다.
+
+권장 방향:
+
+- `NestiaConfigLoader`가 project compiler options를 읽는다.
+- sdk transform plugin이 빠져 있으면 in-memory plugin list에 추가한다.
+- `TtscCompiler.compile()`로 config와 controller graph를 temp output에 compile한다.
+- compiled config module을 import한다.
+- temp output/cache lifecycle을 명시한다.
+
+## Generator
+
+`SdkGenerator.generate()`는 filesystem writer다.
+
+- bundle asset copy
+- clone structure generation
+- functional SDK file generation
+- distribution composer
+
+이 계층은 ttsc transform sidecar의 직접 대상이 아니다. Native rewrite보다 output deterministic test와 config execution bridge가 먼저다.
+

--- a/.wiki/03-nestia/03-migrate-runtime.md
+++ b/.wiki/03-nestia/03-migrate-runtime.md
@@ -1,0 +1,34 @@
+# Migrate와 Runtime 계층
+
+## fetcher/e2e/editor/benchmark
+
+이 패키지들은 compiler transformer와 직접 연결되지 않는다.
+
+- `@nestia/fetcher`: generated SDK가 사용하는 fetch/runtime utility
+- `@nestia/e2e`: E2E helper
+- `@nestia/editor`: Swagger UI + editor
+- `@nestia/benchmark`: benchmark utility
+
+Go 포팅 1차 범위에서 이들을 native로 옮길 이유는 약하다. 이들은 TypeScript runtime package로 유지하고, native compiler sidecar가 생성하는 output과 compatibility를 검증한다.
+
+## migrate
+
+`@nestia/migrate`는 OpenAPI document를 입력받아 Nest/SDK 프로젝트 파일들을 생성한다.
+
+핵심 entry:
+
+- `NestiaMigrateApplication.assert`
+- `NestiaMigrateApplication.validate`
+- `nest(config)`
+- `sdk(config)`
+
+내부적으로 `HttpMigration`, `OpenApiConverter`, typia runtime validation을 사용한다.
+
+Go 포팅 관점에서 `migrate`는 세 번째 물결이다.
+
+1. core/sdk transformer native parity
+2. SDK config execution/generation parity
+3. migrate generator parity
+
+`migrate`를 먼저 옮기면 compiler host 문제를 풀지 못한 채 파일 출력기만 재작성하게 된다.
+

--- a/.wiki/03-nestia/04-risk-map.md
+++ b/.wiki/03-nestia/04-risk-map.md
@@ -1,0 +1,64 @@
+# Nestia Go 포팅 Risk Map
+
+## R1. 여러 transform backend 충돌
+
+현재 Nestia setup은 typia/core/sdk transformer를 모두 등록한다. ttsc에서는 transform stage native binary가 하나여야 한다.
+
+대응:
+
+- 통합 native backend 설계
+- `--plugins-json` 기반 mode dispatch
+- setup wizard에서 중복 backend를 만들지 않도록 plugin config 재설계
+
+## R2. ts-node 실행 경로
+
+SDK CLI는 config를 `ts-node`로 실행한다. ttsc native transform이 적용되지 않으면 `OperationMetadata` decorator가 주입되지 않는다.
+
+대응:
+
+- `TtscCompiler.compile()` 기반 temp compile/import
+- 또는 `ttsx` 실행 bridge
+- config loader golden test
+
+## R3. decorator printer fidelity
+
+Nestia는 decorator argument와 method decorator를 수정한다. printer가 comment, decorator order, modifier order, import order를 흔들 수 있다.
+
+대응:
+
+- source transform golden test
+- JS emit golden test
+- decorator-only fixtures
+- TypeScript 5 decorator API와 legacy decorator shape 양쪽 확인
+
+## R4. typia native dependency drift
+
+Nestia core programmers는 typia internals에 깊게 의존한다. typia native port의 API가 TS 원본과 다르면 Nestia가 흔들린다.
+
+대응:
+
+- typia native API wrapper를 Nestia adapter에서 흡수
+- typia `MetadataFactory`, programmers, `ImportProgrammer` 사용 지점별 compatibility ledger
+- typia update에 맞춘 integration tests
+
+## R5. runtime reflection과 compile-time metadata의 결합
+
+SDK generator는 compile-time transformer가 주입한 decorator를 runtime reflection으로 읽는다. 이 결합이 깨지면 generator는 정상적으로 실행되어도 route metadata가 비어 있을 수 있다.
+
+대응:
+
+- sample controller를 compile/import한 뒤 reflection metadata를 직접 assert
+- `NestiaSdkApplication` end-to-end golden output
+- wildcard path warning, versioning, security, exception metadata fixtures
+
+## R6. setup migration compatibility
+
+기존 사용자는 `ts-patch`, `ts-node`, `typescript` 중심 설정을 가지고 있다.
+
+대응:
+
+- setup wizard가 legacy `ts-patch install`과 `typia patch` 제거
+- `ttsc`, `@typescript/native-preview` 설치
+- 기존 plugin option을 보존해 새 manifest config로 변환
+- migration note 작성
+

--- a/.wiki/04-strategy/00-master-plan.md
+++ b/.wiki/04-strategy/00-master-plan.md
@@ -1,0 +1,75 @@
+# Nestia Go 포팅 Master Plan
+
+## 목표
+
+Nestia의 Go 포팅 목표는 Nestia를 Go application framework로 바꾸는 것이 아니다. 목표는 TypeScript/NestJS 사용자 경험을 유지하면서 compiler-powered 부분을 `ttsc` native sidecar로 이전하는 것이다.
+
+보존할 사용자 경험:
+
+- `@nestia/core` decorators
+- `@nestia/sdk` generator
+- `nestia setup`
+- generated SDK output
+- typia 기반 validator/stringifier 성능/정확성
+- NestJS runtime compatibility
+
+바꿀 내부 구조:
+
+- `ts-patch` transformer hook 제거
+- `ts-node` plugin execution 제거
+- TypeScript transformer 구현을 Go native backend로 이전
+- typia/core/sdk transform을 single native transform host에서 처리
+
+## 제1 원칙
+
+Nestia native backend는 `ttsc`의 plugin contract 안에 있어야 한다.
+
+따라서 다음은 금지다.
+
+- `ts-patch`를 남겨 둔 채 Go 구현을 우회 호출
+- JS transformer hook으로 TypeScript AST를 계속 조작
+- typia와 nestia가 서로 다른 transform native binary를 반환
+- SDK CLI에서 `ts-node` plugin 옵션을 계속 신뢰
+
+## 권장 전체 그림
+
+```text
+consumer tsconfig
+  compilerOptions.plugins
+    - @nestia/core/lib/transform
+    - @nestia/sdk/lib/transform
+    - typia/lib/transform
+
+ttsc JS host
+  load plugins
+  build one native source backend
+  pass ordered --plugins-json
+
+ttsc-nestia native backend
+  load Program / Checker
+  read plugin payload
+  collect typia call sites
+  collect nestia decorators
+  collect sdk controller metadata sites
+  produce source transform JSON or emit rewrites
+```
+
+현실적으로 `typia/lib/transform`이 별도 binary를 반환하면 충돌한다. 그러므로 Nestia setup은 통합 backend 전략을 Phase 0/1에서 먼저 결정해야 한다. 이 결정을 Phase 5까지 미루면 기존 setup이 등록하는 `typia/lib/transform`, `@nestia/core/lib/transform`, `@nestia/sdk/lib/transform` 세 entry가 즉시 충돌할 수 있다.
+
+가장 안전한 설계는 `@nestia/core/lib/transform`과 `@nestia/sdk/lib/transform`이 같은 `ttsc-nestia` source를 반환하고, Nestia backend가 typia native transformer를 내부 dependency로 호출하는 것이다. user project의 일반 `typia.*<T>()` call까지 처리하려면 setup 단계에서 `typia/lib/transform`을 별도로 넣지 않거나, typia와 합의한 shared backend manifest를 사용해야 한다.
+
+## 포팅 우선순위
+
+1. `core/sdk/typia` single-host 공존 정책 결정
+2. legacy-compatible manifest와 package source resolution smoke
+3. native transform skeleton
+4. package/tarball native source inclusion gate
+5. SDK OperationMetadata transformer와 최소 config execution harness
+6. core decorator transformer
+7. typia call rewrite 통합
+8. SDK config compile/import bridge 정식화
+9. generator parity tests
+10. setup/migration UX
+11. migrate package 검토
+
+SDK OperationMetadata를 core decorator보다 먼저 잡는 이유는 output이 metadata literal decorator로 국한되어 있어 parity 검증이 쉽기 때문이다. core decorator는 typia programmers와 import injection, runtime helper alias가 얽혀 있어 난도가 높다.

--- a/.wiki/04-strategy/01-native-layout.md
+++ b/.wiki/04-strategy/01-native-layout.md
@@ -1,0 +1,101 @@
+# Native Package Layout 제안
+
+## 단일 backend
+
+권장 native command:
+
+```text
+packages/core/native/
+  go.mod
+  cmd/ttsc-nestia/
+    main.go
+    build.go
+    transform.go
+    plugins.go
+  adapter/
+    program.go
+    collect_decorators.go
+    collect_typia.go
+    printer.go
+    diagnostics.go
+    imports.go
+  core/
+    options/
+    programmers/
+    transformers/
+  sdk/
+    analyses/
+    transformers/
+    structures/
+    utils/
+```
+
+`@nestia/sdk`는 `@nestia/core`에 의존하므로 `@nestia/sdk/lib/transform` manifest도 core package의 같은 native source를 resolve할 수 있다. 이 경우 SDK package 내부 상대 경로가 아니라 `require.resolve("@nestia/core/package.json", { paths: [context.projectRoot] })`를 기준으로 core package root를 찾아야 한다. 단, package 경계를 더 깨끗하게 하고 싶다면 장기적으로 `@nestia/compiler` package를 새로 만들 수 있다.
+
+## manifest files
+
+`packages/core/src/transform.ts`:
+
+- `createTtscPlugin(context)` 추가
+- package root resolve
+- `native/cmd/ttsc-nestia` source 반환
+- transition 동안 기존 default transformer는 별도 legacy path로 격리
+
+`packages/sdk/src/transform.ts`:
+
+- 같은 source를 반환
+- name은 `nestia-sdk` 또는 `@nestia/sdk`
+- plugin config는 `--plugins-json`에 보존
+
+## Go module
+
+`go.mod`는 typia native와 ttsc driver를 참조해야 한다.
+
+예상 module/import 관계:
+
+```text
+module github.com/samchon/nestia/packages/core/native
+
+require github.com/samchon/ttsc/packages/ttsc
+require github.com/samchon/typia/packages/typia/native
+
+import github.com/samchon/typia/packages/typia/native/core/...
+import github.com/samchon/typia/packages/typia/native/transform/...
+import github.com/microsoft/typescript-go/shim/...
+```
+
+`ttsc` source build가 `go.work` overlay를 구성하므로 monorepo 개발과 npm install 환경을 모두 검증해야 한다. 특히 typia native source를 npm dependency에서 어떻게 공급할지 결정해야 한다. 선택지는 typia native module을 package dependency로 그대로 참조하는 방식, Nestia compiler package 안에 tested snapshot을 vendoring하는 방식, 또는 `ttsc` overlay를 확장하는 방식이다. 이 결정이 닫히기 전에는 Go build contract가 완성되지 않는다.
+
+## plugin payload parser
+
+`plugins.go`는 `--plugins-json`을 읽어 다음 config를 정규화한다.
+
+```go
+type NestiaPluginPlan struct {
+  EnableCore bool
+  EnableSdk bool
+  EnableTypia bool
+  CoreOptions CoreTransformOptions
+  SdkOptions SdkTransformOptions
+  TypiaOptions typiaadapter.PluginOptions
+}
+```
+
+이 plan이 모든 transform pass의 source of truth가 되어야 한다.
+
+## adapter responsibilities
+
+adapter는 TypeScript-Go shim의 거친 API를 Nestia 원본 구조에 맞게 감싼다.
+
+- source file text와 path normalization
+- decorator list abstraction
+- method/parameter declaration abstraction
+- call expression abstraction
+- signature declaration source path match
+- type-to-type-node 대응
+- Promise unwrap
+- import alias registry
+- diagnostics builder
+- printer output cleanup
+
+이 adapter가 빈약하면 ported programmer가 TypeScript-Go shim detail에 직접 오염된다.

--- a/.wiki/04-strategy/02-phases.md
+++ b/.wiki/04-strategy/02-phases.md
@@ -1,0 +1,140 @@
+# Migration Phases
+
+## Phase 0. Ledger 완성
+
+목표:
+
+- Nestia source file별 wiki 생성
+- core/sdk/cli/migrate package별 포팅 대상 분류
+- TypeScript compiler API 사용 지점 전수 목록화
+
+완료 기준:
+
+- `packages/core/src/**/*.ts` 전체 문서화
+- `packages/sdk/src/**/*.ts` 전체 문서화
+- `packages/cli/src/**/*.ts` 전체 문서화
+- `ts-patch`/`ts-node` 의존 경로 전부 표시
+
+## Phase 1. ttsc manifest transition
+
+목표:
+
+- `core/sdk/typia` single-host 공존 정책 결정
+- `@nestia/core/lib/transform`과 `@nestia/sdk/lib/transform`에 legacy-compatible `createTtscPlugin()` 추가
+- package root/source resolution smoke test 작성
+- setup wizard 전환은 아직 하지 않는다. native skeleton, tarball inclusion, `ttsc prepare` smoke가 끝나기 전에는 consumer setup을 바꾸지 않는다.
+
+검증:
+
+```bash
+pnpm --filter=./packages/core build
+pnpm --filter=./packages/sdk build
+pnpm --filter=./packages/cli build
+```
+
+## Phase 2. native skeleton
+
+목표:
+
+- `ttsc-nestia` command skeleton 작성
+- `build`, `check`, `transform`, `version`, `help` 구현
+- Program load와 diagnostics 출력만 먼저 연결
+- `--plugins-json` parser 작성
+- `native/**` package inclusion과 clean fixture `ttsc prepare` smoke 검증
+
+검증:
+
+```bash
+npx ttsc prepare
+npx ttsc --noEmit
+pnpm package:tgz
+```
+
+## Phase 3. SDK OperationMetadata native transform
+
+목표:
+
+- `SdkOperationTransformer`
+- `SdkOperationProgrammer`
+- `IOperationMetadata` literal generation
+- `OperationMetadata` import/decorator injection
+- 최소 config execution harness. `TtscCompiler.compile()` output은 in-memory이므로 import 가능한 temp directory로 materialize하거나, `ttsx` execution bridge를 library화하는 방식 중 하나를 검증용으로 선택한다.
+
+검증:
+
+- controller method fixture source transform 비교
+- runtime `Reflect.getMetadata("nestia/OperationMetadata", ...)` 확인
+- SDK generator route count 확인
+
+## Phase 4. Core decorator native transform
+
+목표:
+
+- `FileTransformer`
+- `NodeTransformer`
+- `MethodTransformer`
+- `ParameterTransformer`
+- `ParameterDecoratorTransformer`
+- `TypedRouteTransformer`
+- `WebSocketRouteTransformer`
+- `programmers/**`
+
+검증:
+
+- body/header/query/param decorator fixtures
+- `TypedRoute` response stringify mode fixtures
+- `EncryptedRoute`
+- `TypedQueryRoute`
+- `WebSocketRoute`
+- diagnostics fixtures
+
+## Phase 5. typia rewrite integration
+
+목표:
+
+- user source의 typia call rewrite와 Nestia rewrite를 같은 native transform host에서 처리
+- typia plugin options 보존
+- import cleanup 충돌 제거
+
+검증:
+
+- Nestia decorator와 일반 typia call이 같은 file에 있는 fixture
+- `typia/lib/transform` entry가 있거나 없을 때 behavior 정의
+- multiple transform backend 충돌 없음
+
+## Phase 6. SDK config execution bridge
+
+목표:
+
+- `NestiaConfigLoader`에서 `ts-node` 제거
+- `TtscCompiler.compile()` output materialization 또는 `ttsx` bridge로 config/controller 실행
+- temp output/cache lifecycle 관리
+
+검증:
+
+- `nestia sdk`
+- `nestia swagger`
+- `nestia e2e`
+- path alias/baseUrl config
+- Nest application input function config
+
+## Phase 7. package contract and publish
+
+목표:
+
+- package `files`에 native source 포함
+- publishConfig exports 정리
+- setup docs 수정
+- `ts-patch` dependency 제거
+- CI가 ttsc path를 사용
+- migrate template assets에서 legacy `ts-patch`, `ts-node`, 기존 transformer setup을 compatibility scope로 점검
+
+검증:
+
+```bash
+pnpm build
+pnpm test
+pnpm package:tgz
+```
+
+tarball에서 native source, transform manifest, CLI bin, assets를 직접 확인한다.

--- a/.wiki/04-strategy/03-verification.md
+++ b/.wiki/04-strategy/03-verification.md
@@ -1,0 +1,88 @@
+# Verification Plan
+
+## 단위 검증
+
+Go unit tests:
+
+- plugin payload parser
+- decorator path matcher
+- Promise unwrap
+- import registry
+- source rewrite range sorting
+- diagnostics formatter
+- option normalization
+
+TypeScript tests:
+
+- transform manifest resolution
+- setup wizard package mutation
+- config loader compile/import bridge
+
+## Golden transform fixtures
+
+필수 fixture:
+
+- `@TypedBody()` with no args
+- `@TypedBody(custom)` with existing args
+- `@TypedParam("id")`
+- `@TypedQuery()`
+- `@TypedQuery.Body()`
+- `@TypedFormData.Body()`
+- `@PlainBody()`
+- `@TypedRoute.Get()`
+- `@TypedRoute.Post()`
+- `@EncryptedRoute.Post()`
+- `@TypedQuery.Get()`
+- `@WebSocketRoute()`
+- method with `@TypedException<T>()`
+- class with inherited methods
+- controller with versioning/security/tags
+
+각 fixture는 세 결과를 비교한다.
+
+1. 기존 ts-patch transformer output
+2. native `ttsc-nestia transform --output ts`
+3. native `ttsc-nestia build --emit` JS output
+
+## End-to-end 검증
+
+명령:
+
+```bash
+pnpm build
+pnpm test
+pnpm --filter=./packages/cli build
+pnpm --filter=./packages/sdk build
+pnpm --filter=./packages/core build
+```
+
+추가 sample:
+
+```bash
+npx nestia setup
+npx ttsc --noEmit
+npx nestia sdk
+npx nestia swagger
+npx nestia e2e
+```
+
+## Tarball 검증
+
+`pnpm package:tgz` 이후 tarball에서 확인한다.
+
+- `@nestia/core` tarball에 `native/**` 포함
+- `@nestia/sdk` transform manifest가 같은 source를 resolve
+- `lib/transform.js`와 `lib/transform.d.ts` 존재
+- `package.json` exports가 built output을 가리킴
+- consumer install 후 `npx ttsc prepare` 성공
+
+## Regression gates
+
+merge 전 필수 gate:
+
+- ttsc single transform backend 충돌 없음
+- `ts-patch install` 문자열이 setup path에서 사라짐
+- SDK CLI가 `ts-node.register({ plugins })`에 의존하지 않음
+- generated SDK output diff가 의도한 범위 안에 있음
+- typia 일반 call과 Nestia decorator가 같은 project에서 동시에 변환됨
+

--- a/.wiki/04-strategy/04-decisions.md
+++ b/.wiki/04-strategy/04-decisions.md
@@ -1,0 +1,52 @@
+# 설계 결정 기록
+
+## D1. 포팅 시작점은 compiler sidecar다
+
+결정: runtime package 재작성보다 `@nestia/core`/`@nestia/sdk` transformer의 native sidecar 전환을 먼저 한다.
+
+근거:
+
+- ttsc와 typia@next의 현재 진화 방향과 일치한다.
+- Nestia의 성능/정확성 핵심은 decorator transform과 SDK metadata transform이다.
+- fetcher/e2e/editor/migrate는 compiler host 병목을 풀지 못한다.
+
+## D2. 단일 transform host를 전제로 한다
+
+결정: Nestia native transform은 typia/core/sdk 협업을 하나의 native backend에서 처리하도록 설계한다.
+
+근거:
+
+- `ttsc`는 서로 다른 transform native binary 동시 실행을 금지한다.
+- Nestia는 typia programmers와 metadata factory에 의존한다.
+- consumer project는 일반 typia call과 Nestia decorator를 같이 쓴다.
+
+## D3. SDK OperationMetadata부터 포팅한다
+
+결정: core decorator transform보다 SDK OperationMetadata transform을 먼저 Go로 옮긴다.
+
+근거:
+
+- output이 metadata decorator literal로 비교적 고정되어 있다.
+- runtime reflection pipeline의 병목을 빨리 드러낸다.
+- `NestiaConfigLoader` 전환 필요성을 end-to-end로 검증할 수 있다.
+
+## D4. setup wizard는 typia@next 방식을 따른다
+
+결정: `ts-patch` 설치/prepare 추가를 제거하고 `ttsc`, `@typescript/native-preview` 설치로 전환한다.
+
+근거:
+
+- Go native transformer는 `ts-patch`에서 실행되지 않는다.
+- typia@next setup이 이미 같은 생태계 전환을 수행한다.
+- consumer project의 `prepare` script를 compiler patch lifecycle에 묶지 않는 편이 안전하다.
+
+## D5. generator는 transform sidecar와 분리한다
+
+결정: `nestia sdk/swagger/e2e` 파일 생성은 native transform command에 넣지 않는다.
+
+근거:
+
+- `ttsc.transform()`의 contract는 TypeScript source map이다.
+- SDK generator는 filesystem writer, config loader, runtime reflection pipeline이다.
+- 같은 command에 섞으면 API와 diagnostics가 불명확해진다.
+

--- a/.wiki/05-review/00-verdict.md
+++ b/.wiki/05-review/00-verdict.md
@@ -1,0 +1,42 @@
+# 위키 심층 리뷰 최종 판정
+
+## 회의 결과
+
+2026-05-04에 5명 참여자 전원이 `.wiki/**/*.md` 전체를 읽고 회의했다. 회의록은 `conventions/00-session-minutes.md`에 남겼다.
+
+최종 판정은 다음과 같다.
+
+- 방향성: 승인
+- 포팅 구현 착수 기준: 아직 NOT READY
+- 사용자 요청의 “모든 소스코드 line-by-line 지식대백과” 기준: 아직 NOT READY
+- 다음 작업: 구현이 아니라 Phase 0 지식대백과 보강
+
+## 유지할 결론
+
+Nestia Go 포팅은 runtime/fetcher/migrate 재작성부터 시작하면 안 된다. 시작점은 `@nestia/core/lib/transform`, `@nestia/sdk/lib/transform`, `typia/lib/transform`의 compiler execution model 전환이다.
+
+`ttsc`는 서로 다른 transform native backend를 하나의 source-to-source pass에 함께 넣지 못한다. 따라서 Nestia는 `core/sdk/typia`를 하나의 native transform host 안에서 공존시키는 정책을 먼저 결정해야 한다.
+
+## 반려할 주장
+
+현재 `.wiki`가 이미 포팅 착수 가능한 완성 지식대백과라는 주장은 반려한다.
+
+이유:
+
+- 파일별 ledger가 없다.
+- `packages/core/src`, `packages/sdk/src`, `packages/cli/src` 180개 source 파일의 per-file 분석이 없다.
+- typia native module 공급 방식이 결정되지 않았다.
+- `typia/lib/transform` migration 정책이 결정되지 않았다.
+- SDK config execution bridge가 `TtscCompiler.compile()` 한 단어로만 쓰였고, in-memory output materialization 또는 `ttsx` bridge 중 어느 쪽인지 닫히지 않았다.
+- package/tarball native source inclusion gate가 너무 늦게 배치되어 있었다.
+- TypeScript-Go printer가 Nestia decorator syntax와 metadata literal을 안정적으로 보존하는지 실증 fixture가 없다.
+
+## 회의 합의
+
+1. `core/sdk/typia` single-host 공존 정책은 Phase 0/1 선결정이다.
+2. setup wizard에서 `ts-patch`를 제거하는 작업은 native skeleton, tarball inclusion, `ttsc prepare` smoke 이후에 해야 한다.
+3. `@nestia/sdk/lib/transform`이 `@nestia/core` native source를 공유한다면 `@nestia/core/package.json` resolution 기준을 문서화하고 검증해야 한다.
+4. typia native source 공급 방식은 별도 결정 항목이다.
+5. `TtscCompiler.compile()`은 in-memory output을 반환하므로 SDK config import bridge에는 materialization 또는 `ttsx` bridge 설계가 필요하다.
+6. migrate 자체 재작성은 후순위가 맞지만, migrate template의 legacy compiler setup은 package/setup compatibility 범위에 포함해야 한다.
+

--- a/.wiki/05-review/01-required-corrections.md
+++ b/.wiki/05-review/01-required-corrections.md
@@ -1,0 +1,75 @@
+# 필수 보강 항목
+
+## P0. 파일별 Ledger
+
+현재 Phase 0 완료 기준을 만족하지 못한다.
+
+필수 생성 대상:
+
+- `packages/core/src/**/*.ts`
+- `packages/sdk/src/**/*.ts`
+- `packages/cli/src/**/*.ts`
+
+현재 합계는 180개 source file이다.
+
+각 파일별 문서에는 다음을 포함한다.
+
+- 원본 경로
+- native 대응 경로
+- exported identifiers
+- 내부 알고리즘
+- TypeScript compiler API 사용 지점
+- TypeScript-Go shim 대응
+- typia native API 의존점
+- diagnostics behavior
+- status
+
+## P1. Single Host 정책
+
+결정해야 할 질문:
+
+- 기존 `typia/lib/transform` entry를 Nestia setup에서 제거/치환할 것인가?
+- typia와 shared backend manifest를 합의할 것인가?
+- 기존 사용자 tsconfig에 이미 있는 typia/core/sdk 3개 entry는 migration 시 어떻게 정리할 것인가?
+
+이 결정 없이 manifest만 바꾸면 `ttsc` transform backend 충돌이 난다.
+
+## P2. typia Native 공급 방식
+
+결정해야 할 질문:
+
+- Nestia native module이 `github.com/samchon/typia/packages/typia/native`를 직접 require할 것인가?
+- npm dependency의 Go source를 `ttsc` scratch build에 어떻게 공급할 것인가?
+- typia native source를 tested snapshot으로 vendoring할 것인가?
+- `ttsc` overlay/replacement를 확장할 것인가?
+
+## P3. SDK Config Execution Bridge
+
+`TtscCompiler.compile()`은 output을 in-memory record로 반환한다. 따라서 config import bridge는 다음 중 하나를 선택해야 한다.
+
+- compile output을 temp directory에 materialize하고 compiled config module을 import한다.
+- `ttsx` execution bridge를 library화한다.
+
+`ts-node.register({ plugins })`는 native transform 실행 경로가 아니므로 제거 대상이다.
+
+## P4. Early Package Gate
+
+초기 phase에서 검증해야 한다.
+
+- `native/**`가 tarball에 포함되는가?
+- `createTtscPlugin()`의 `source`가 clean install에서 resolve되는가?
+- `npx ttsc prepare`가 clean fixture에서 성공하는가?
+- `@nestia/sdk/lib/transform`이 core native source를 참조한다면 `@nestia/core/package.json` 기준 resolution이 동작하는가?
+
+## P5. Printer/Decorator Fidelity
+
+필수 fixture:
+
+- method decorator argument 추가
+- parameter decorator argument 추가
+- `OperationMetadata` decorator 추가
+- existing decorator order 보존
+- `use strict`/directive 뒤 import 삽입
+- JSDoc tag/description 보존
+- published d.ts path, pnpm symlink path, monorepo source path
+

--- a/conventions/00-session-minutes.md
+++ b/conventions/00-session-minutes.md
@@ -1,0 +1,86 @@
+# Nestia Go 포팅 위키 심층 리뷰 회의록
+
+## 2026-05-04 세션 시작
+
+- 의장: Codex Main
+- 요청: `.wiki` 전체 지식대백과 심층 리뷰, 5명 팀 에이전트 끝장토론, 회의록 작성, 결론 도출
+- 범위: `.wiki/**/*.md` 전체 23개 문서
+- 원칙: 범위 분담 금지. 모든 참여자는 `.wiki` 전체를 읽고 이해한 뒤 발언한다. 관점만 다르게 둔다.
+- 회의 전/중 기록 위치: `conventions/`
+- 최종 결론 반영 위치: 세션 종료 후 `.wiki/05-review/`
+
+## 참여자
+
+1. Main: 의장, 회의록, 통합 결론
+2. Agent A: `ttsc` 실행 모델 및 plugin protocol 검증 관점
+3. Agent B: `typia@next`/`typia` 포팅 대응성 검증 관점
+4. Agent C: `nestia@next` 현재 architecture 검증 관점
+5. Agent D: 포팅 전략, phase, release risk 검증 관점
+6. Agent E: 반대자 관점, 오점/과장/누락 탐지
+
+## 회의 진행 로그
+
+- 00:00 Main: 회의록을 개설했다. 범위 분담 없이 모든 참여자에게 전체 `.wiki`를 읽게 한다.
+- 00:01 Main: 직접 재검토에서 첫 쟁점을 확인했다. `.wiki/01-ttsc/02-plugin-protocol.md`의 native command 목록은 `build/check/transform/version/help`만 적혀 있는데, `ttsc` output stage contract를 고려하면 `output` command도 명시해야 한다.
+- 00:02 Agent D: READY. `.wiki`의 큰 결론은 맞다. Nestia 포팅의 시작점은 runtime/fetcher/migrate 재작성이 아니라 `@nestia/core/lib/transform`, `@nestia/sdk/lib/transform`, `typia/lib/transform`의 compiler execution model 전환이다.
+- 00:03 Agent D: 실제 `ttsc`는 transform stage native backend가 여러 개면 `"ttsc: multiple transform native backends cannot share one source-to-source pass"`로 막는다. 따라서 single native transform host 결론은 유지해야 한다.
+- 00:04 Agent D: 단, `.wiki/04-strategy/02-phases.md`의 Phase 1 순서가 위험하다. manifest 전환, setup wizard의 `ttsc` 전환, `ts-patch` 제거를 native skeleton보다 먼저 묶으면 missing native source를 가리키는 상태로 consumer build가 깨질 수 있다.
+- 00:05 Agent D: package/tarball 검증도 너무 늦다. 현재 `@nestia/core`와 `@nestia/sdk` package `files`에는 `native/**`가 없다. `native/**` 포함, `source` resolve, packed install smoke는 Phase 7이 아니라 Phase 1~2 hard gate가 되어야 한다.
+- 00:06 Agent D: `@nestia/sdk/lib/transform`이 core package의 native source를 참조하려면 SDK package 내부 기준이 아니라 `require.resolve("@nestia/core/package.json")` 기준으로 core root를 찾아야 한다.
+- 00:07 Agent D: `SDK OperationMetadata`부터 포팅한다는 결론은 맞지만 쉬운 단계가 아니다. `MetadataFactory`, `MetadataCollection`, `CommentFactory`, `DtoAnalyzer`, `LiteralFactory`, JSDoc tag, import 분석을 먼저 작은 표면으로 검증하는 단계라고 표현해야 정확하다.
+- 00:08 Agent D: Phase 3의 `Reflect.getMetadata("nestia/OperationMetadata", ...)` 검증은 config execution bridge 없이 완결되기 어렵다. 최소한 임시 ttsc compile/import harness를 Phase 3에 포함하거나 Phase 6 일부를 앞당겨야 한다.
+- 00:09 Agent D: `ts-node` risk는 SDK ConfigLoader뿐 아니라 `packages/core/src/decorators/internal/load_controller.ts`의 `detect-ts-node` 경로에도 있다. Phase 0 ledger에 명시해야 한다.
+- 00:10 Agent B: READY. `.wiki`의 대전제는 맞다. `ttsc`의 transform path뿐 아니라 build emit path도 여러 compiler native backend를 막는다.
+- 00:11 Agent B: `typia@next`의 manifest와 `typia` TS 원본 대 native Go tree 1:1 경로 대응은 실제로 확인된다.
+- 00:12 Agent B: 문제는 typia native Go module 공급 방식이 닫히지 않았다는 점이다. `ttsc` source plugin build는 scratch copy에서 `node_modules`를 제외하며 overlay replacement도 현재 `ttsc` module 중심이다. Nestia가 typia native source를 npm dependency에서 어떻게 안정적으로 Go build에 공급할지 결정해야 한다.
+- 00:13 Agent B: 기존 Nestia setup은 `typia/lib/transform`을 항상 추가한다. single native host 결론을 구현하려면 setup migration이 typia entry를 제거/치환할지, typia manifest가 같은 backend를 반환할지 결정해야 한다.
+- 00:14 Agent B: typia API 의존성 목록은 좋지만 API compatibility ledger가 부족하다. `MetadataFactory`, `JsonMetadataFactory`, `LiteralFactory`, `CommentFactory`, `ImportProgrammer`, 각 programmer별로 Go export 직접 호출 가능 여부와 adapter wrapper 필요 여부를 내려 적어야 한다.
+- 00:15 Agent E: READY. 단, 회의 참여 준비가 READY이지, 위키 자체는 NOT READY라고 판정한다.
+- 00:16 Agent E: `.wiki/00-ledger/00-scope.md`가 스스로 대표 핵심 파일과 inventory 기반이라고 밝힌다. 이것은 정직하지만 사용자 기준의 `line by line`, 모든 소스코드, 단 하나의 오점 없음에는 미달한다.
+- 00:17 Agent E: Phase 0 완료 기준은 `core/sdk/cli` 전체 문서화인데 현재 `.wiki/packages/**` 파일별 문서가 0개다. 실제 `packages/core/src`, `packages/sdk/src`, `packages/cli/src` tracked source는 180개다.
+- 00:18 Agent E: `ttsc` inventory가 drift되었다. 현재 `ttsc` checkout은 30,826 total lines인데 `.wiki/00-ledger/01-current-inventory.md`는 30,561 lines를 적고 있다.
+- 00:19 Agent E: single backend 결론은 맞지만 `typia/lib/transform`을 빼는지 shared backend로 합의하는지 아직 열린 문제다. 확정 설계처럼 말하면 과장이다.
+- 00:20 Agent E: TypeScript-Go printer가 decorator syntax, modifier order, JSDoc, metadata literal을 안정적으로 보존한다는 실증이 없다. 이것은 설계 핵심 리스크다.
+- 00:21 Agent E: typia API 목록의 명칭 정밀도가 떨어진다. 예를 들어 실제 `TypedBodyProgrammer`는 `AssertCloneProgrammer`가 아니라 `MiscAssertCloneProgrammer`, `MiscValidateCloneProgrammer`를 import한다.
+- 00:22 Main: Agent E의 inventory drift와 API 명칭 지적을 직접 확인했다. `ttsc` 현재 라인 수는 30,826이고, `TypedBodyProgrammer`는 `MiscAssertCloneProgrammer`, `MiscValidateCloneProgrammer`를 사용한다.
+- 00:23 Agent A: READY. 위키의 큰 결론에는 찬성한다. 다만 Nestia native port의 0번 결정은 `core/sdk/typia`가 한 transform host에서 어떻게 공존하는가다.
+- 00:24 Agent A: Phase 1에서 core/sdk manifest 전환을 먼저 하고 typia 통합을 Phase 5로 미루면, 기존 setup이 `typia/lib/transform`, `@nestia/core/lib/transform`, `@nestia/sdk/lib/transform` 세 개를 동시에 넣기 때문에 `ttsc`에서 즉시 충돌한다.
+- 00:25 Agent A: `.wiki/01-ttsc/02-plugin-protocol.md`의 “native binary는 build/check/transform/version/help를 구현해야 한다”는 표현은 과하다. `ttsc` stage model은 `check`, `transform`, `output`이고 모든 plugin이 모든 command를 갖는 것은 아니다. Nestia 통합 backend에는 build/check/transform이 사실상 필요하지만 version/help는 운영상 권장이다.
+- 00:26 Agent A: `TtscCompiler.compile()`로 temp output에 compile/import한다고 쓴 결론은 약하다. public `compile()`은 in-memory output을 반환하고 내부 temp dir은 정리된다. SDK config import bridge는 in-memory output을 별도 temp dir에 materialize할지, `ttsx` 실행 bridge를 library화할지 명확히 골라야 한다.
+- 00:27 Agent A: Go dependency 표기가 package import와 module require를 섞고 있다. `typia@next` module은 `github.com/samchon/typia/packages/typia/native`이고 `core`/`transform`은 하위 import path다.
+- 00:28 Agent A: `--plugins-json` source of truth 결론은 맞지만, typia@next는 아직 tsconfig regex로 typia option을 읽는다. Nestia 통합 rewrite를 하려면 `--plugins-json` 기반 typia option adapter를 새 contract로 확정해야 한다.
+- 00:29 Agent C: READY. 위키의 큰 방향, 즉 Nestia Go 포팅은 runtime 재작성보다 `ttsc` native compiler sidecar 전환이 먼저이고 typia/core/sdk transform은 단일 backend에서 협업해야 한다는 결론에 찬성한다.
+- 00:30 Agent C: `@nestia/core` transformer 구조 설명과 `@nestia/sdk` OperationMetadata/runtime reflection 설명은 실제 소스와 맞다.
+- 00:31 Agent C: 그러나 현재 `.wiki`는 전략 결론은 강하지만 실행 ledger가 약하다. `packages/*/src/**`는 258파일 25,056라인인데 현재 파일별 포팅 문서가 없다.
+- 00:32 Agent C: SDK OperationMetadata를 먼저 잡는 전략은 타당하지만 runtime reflection 검증은 config/controller를 변환된 상태로 실행해야 하므로 config bridge를 Phase 6까지 미루면 Phase 3 검증이 반쪽이 된다.
+- 00:33 Agent C: migrate를 3차 물결로 미루는 결론은 compiler core 관점에서는 맞지만 migrate template이 이미 `ts-patch`, `ts-node`, 기존 transform plugin을 포함한다. generated project UX 관점에서 migrate asset 정리는 Phase 7 package/setup compatibility scope에 포함되어야 한다.
+- 00:34 Agent C: path matching risk를 더 강하게 써야 한다. 현재 core transformer는 `@nestia/core/lib/decorators`와 `packages/core/src/decorators` substring에 의존한다. native port에서는 package root resolution, pnpm symlink, published d.ts 경로 fixture를 고정해야 한다.
+
+## 끝장토론
+
+- 00:35 Main: 모든 참여자의 공통 합의는 “single native transform host 결론은 맞다”이다.
+- 00:36 Agent A: 그렇다. 하지만 이 결정을 Phase 5로 미루면 실행 모델상 즉시 충돌한다. `core/sdk/typia` 공존 정책은 Phase 0 또는 Phase 1의 선결정이어야 한다.
+- 00:37 Agent B: 동의한다. 특히 `typia/lib/transform`을 제거/치환할지, typia와 shared backend manifest를 합의할지 닫아야 한다.
+- 00:38 Agent D: package/tarball도 같은 성격이다. native source가 tarball에 없으면 `createTtscPlugin()`은 설계가 아니라 설치 실패다. release gate가 아니라 초기 gate다.
+- 00:39 Agent E: 더 근본적으로 현재 위키는 1차 전략 메모다. 사용자 기준의 전체 지식대백과로 승인하면 안 된다. 파일별 ledger가 없다.
+- 00:40 Agent C: 파일별 ledger와 config execution bridge가 없으면 SDK OperationMetadata phase의 runtime 검증도 성립하지 않는다.
+- 00:41 Main: 쟁점 정리. 승인할 것: 방향, single backend, runtime/fetcher/migrate 후순위. 반려할 것: 포팅 착수 READY 주장, Phase ordering, package/module/typia migration 미결정, line-by-line 완료 주장.
+- 00:42 Agent E: 위키는 NOT READY라고 명시해야 한다. 다만 방향성은 폐기하지 말고 보강 목록으로 전환해야 한다.
+- 00:43 Agent A: `TtscCompiler.compile()` 표현도 수정해야 한다. compile 결과는 in-memory이므로 config import용 materialization 또는 `ttsx` bridge 중 하나를 설계해야 한다.
+- 00:44 Agent B: typia native module 공급 방식도 필수 결정이다. npm dependency의 Go source를 `ttsc` scratch build에 어떻게 안정적으로 공급할지 없으면 구현이 막힌다.
+- 00:45 Agent D: Phase 1은 legacy-compatible manifest와 source resolution smoke 정도로 낮추고, setup migration은 skeleton/tarball/prepare green 이후로 미뤄야 한다.
+- 00:46 Main: 최종 결론은 조건부 승인이다. “전략 방향은 승인, 현재 위키는 구현 착수 기준 NOT READY, 다음 작업은 Phase 0 보강”으로 결정한다.
+
+## 최종 합의
+
+1. `.wiki`의 핵심 방향은 유지한다.
+2. 현재 `.wiki`는 사용자 기준의 “모든 소스코드 line-by-line 지식대백과”로는 미달이다.
+3. 포팅 구현 착수 전 Phase 0 보강이 필요하다.
+4. Phase 0 보강의 최우선 항목은 파일별 ledger, typia/native module 공급 방식, `typia/lib/transform` migration 정책, SDK config execution bridge, package/tarball early gate다.
+5. 결론 문서는 `.wiki/05-review/`에 새로 작성한다.
+
+## 세션 종료
+
+- 00:47 Main: `.wiki/05-review/00-verdict.md`와 `.wiki/05-review/01-required-corrections.md`를 작성했다.
+- 00:48 Main: 명백한 사실 오류도 보정했다. `ttsc` inventory를 현재 checkout 기준으로 갱신했고, plugin protocol에 `output` command를 추가했으며, typia programmer 명칭과 phase ordering을 수정했다.
+- 00:49 Main: 최종 상태는 `방향성 승인 / 구현 착수 NOT READY / Phase 0 보강 필요`로 확정한다.

--- a/conventions/participants/READINESS.md
+++ b/conventions/participants/READINESS.md
@@ -1,0 +1,22 @@
+# 참여자 Readiness Ledger
+
+## 원칙
+
+READY는 `.wiki` 전체를 읽고, 최소한 다음을 독립적으로 판단할 수 있을 때만 부여한다.
+
+- `ttsc` 실행 모델과 single transform host 제약
+- `typia@next`의 copy-first/1:1 포팅 방식
+- `typia` TS 원본과 native Go tree 대응성
+- `nestia@next`의 core/sdk/cli/migrate 구조
+- Go 포팅 master plan의 논리적 약점과 보완점
+
+## 상태
+
+| 참여자 | 상태 | 비고 |
+| --- | --- | --- |
+| Main | READY | 회의 주관, 직접 검증, 최종 판정 문서 작성 완료 |
+| Agent A | READY | 전체 `.wiki` 읽음. single host 정책을 Phase 0/1로 당길 것, plugin command 표현 정정, compile/import bridge 구체화 요구 |
+| Agent B | READY | 전체 `.wiki` 읽음. typia native module 공급 방식, typia transform migration 정책, API compatibility ledger 보강 요구 |
+| Agent C | READY | 전체 `.wiki` 읽음. 전략 방향 승인, 실행 ledger/SDK config bridge/migrate template compatibility 보강 요구 |
+| Agent D | READY | 전체 `.wiki` 읽음. phase ordering, package/tarball gate, SDK->core native source resolution 반론 제기 |
+| Agent E | READY | 전체 `.wiki` 읽음. 위키 자체는 사용자 기준 NOT READY 판정. 파일별 ledger 0개, inventory drift, API 명칭 부정확성 지적 |


### PR DESCRIPTION
This pull request adds a comprehensive knowledge base in the `.wiki` directory documenting the direction and technical considerations for porting Nestia to Go, based on the architectures of `ttsc`, `typia@next`, and `nestia@next`. The new documentation covers the current inventory, reading ledger, and lessons learned from the `ttsc` and `typia` projects, as well as protocols and best practices for the porting process. The most important changes are grouped below by theme.

**Nestia Go Porting Overview and Principles:**

- Added `.wiki/00-index.md` outlining the purpose, structure, and key conclusions for the Nestia Go port, emphasizing the need to migrate the TypeScript transformer to a native `ttsc` sidecar and to unify transform hosts for `typia`, `@nestia/core`, and `@nestia/sdk`.
- Added `.wiki/00-ledger/00-scope.md` defining the scope of investigation, documentation methodology, and criteria for file-level porting documentation.
- Added `.wiki/00-ledger/01-current-inventory.md` providing a detailed inventory of core files, line counts, and package distributions for `ttsc`, `typia@next`, `typia`, and `nestia@next`.
- Added `.wiki/00-ledger/02-reading-ledger.md` summarizing the key files and their roles across `ttsc`, `typia`, and `nestia` to inform porting decisions.

**ttsc Architecture and Plugin Protocol:**

- Added `.wiki/01-ttsc/00-encyclopedia.md` describing `ttsc`'s philosophy, JS host responsibilities, plugin loader, source plugin build process, native driver, and how these relate to Nestia's needs.
- Added `.wiki/01-ttsc/01-execution-model.md` explaining the CLI, programmatic API, build/transform paths, and the critical constraint that only a single transform host is allowed in `ttsc`.
- Added `.wiki/01-ttsc/02-plugin-protocol.md` detailing the plugin manifest format, native binary contract, plugin payload, diagnostics, and distribution guidelines, with recommendations for Nestia's implementation.
- Added `.wiki/01-ttsc/03-lessons-for-nestia.md` outlining actionable lessons for Nestia, including transitioning to a native manifest, removing `ts-node`, designing a unified transform host, separating transform and generation surfaces, and prohibiting hard-coded output.

**typia Porting Protocol and Lessons:**

- Added `.wiki/02-typia/00-encyclopedia.md` summarizing the relationship between the TypeScript source and Go port in `typia`, the porting philosophy, native backend structure, and the adapter's role.
- Added `.wiki/02-typia/01-porting-protocol.md` specifying the copy-first approach, file-level wiki requirements, porting status values, and the importance of immutable tests for Nestia's Go port.