### PR TITLE
fix(sdk): register tsconfig-paths when paths exist without baseUrl

### DIFF
--- a/packages/sdk/src/executable/internal/NestiaConfigLoader.ts
+++ b/packages/sdk/src/executable/internal/NestiaConfigLoader.ts
@@ -55,7 +55,7 @@ export namespace NestiaConfigLoader {
           ...compilerOptions,
           plugins,
         },
-        require: compilerOptions.baseUrl || hasPathAliases
+        require: (compilerOptions.baseUrl || hasPathAliases)
           ? ["tsconfig-paths/register"]
           : undefined,
       });

--- a/packages/sdk/src/executable/internal/NestiaConfigLoader.ts
+++ b/packages/sdk/src/executable/internal/NestiaConfigLoader.ts
@@ -47,6 +47,7 @@ export namespace NestiaConfigLoader {
       ...(compilerOptions.plugins ?? []),
       ...(setup ? [] : [{ transform: "@nestia/sdk/lib/transform" }]),
     ];
+    const hasPathAliases = Object.keys(compilerOptions.paths ?? {}).length > 0;
     if (!(process as any)[Symbol.for("ts-node.register.instance")])
       register({
         emit: false,
@@ -54,7 +55,7 @@ export namespace NestiaConfigLoader {
           ...compilerOptions,
           plugins,
         },
-        require: compilerOptions.baseUrl
+        require: compilerOptions.baseUrl || hasPathAliases
           ? ["tsconfig-paths/register"]
           : undefined,
       });


### PR DESCRIPTION
## Summary

`NestiaConfigLoader` registers `tsconfig-paths/register` for `ts-node` only when `compilerOptions.baseUrl` was set. After TypeScript 6, `baseUrl` is deprecated (TS5101) and many projects keep only `compilerOptions.paths` (e.g. `"@/*": ["./src/*"]`). In that setup `nestia sdk` (and loading the app module graph) fails at runtime with unresolved imports such as `@/…` while loading `nestia.config.ts`, because `tsconfig-paths` was never registered.

Register `tsconfig-paths/register` when **`baseUrl` is set or `paths` has at least one key**. `hasPathAliases` uses `Object.keys(compilerOptions.paths ?? {}).length > 0` for an explicit, consistent check.

## Related

- Fixes samchon/nestia#1459

Note: [PR #1458](https://github.com/samchon/nestia/pull/1458) (`feat/go`) replaces this loader path with ttsc materialization; this change targets the **current `ts-node`-based** config load and remains relevant for maintenance branches / releases until that migration lands.

## Backwards compatibility

- `baseUrl` only → unchanged (still registers).
- `paths` only → **fixed** (previously broken).
- Neither → still no `require` (unchanged).