### PR TITLE
fix(core): post-migration diagnostics, profiling, and disk-cleanup patches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ packages/openapi
 packages/*/*.tgz
 packages/*/docs
 packages/*/native/ttsc-*
+packages/*/native/go.work.sum
 packages/*/test/go.work
 packages/*/test/go.work.sum
 packages/*/README.md

--- a/packages/core/MIGRATION.md
+++ b/packages/core/MIGRATION.md
@@ -141,6 +141,10 @@ ttsc-nestia profile: sdk-cache hits=567 misses=89
 
 Informational only — the counters do not affect compilation output or exit code. Useful when investigating large-codebase build times.
 
+### 12. Panic stack opt-in: `NESTIA_NATIVE_DEBUG_STACK`
+
+If the Go binary aborts with `nestia.internal.panic`, set `NESTIA_NATIVE_DEBUG_STACK=1` to also print the full Go stack alongside the diagnostic. Off by default to keep build output clean; turn it on only when reproducing a panic for triage.
+
 ## Quickest upgrade recipe
 
 ```bash
@@ -150,7 +154,7 @@ npm uninstall ts-patch
 # 2. Reinstall dependencies in the new order — same effect as `npx nestia setup`
 npm i -D ttsc @typescript/native-preview
 npm i typia
-npm i @nestia/core @nestia/sdk @nestia/fetcher
+npm i @nestia/core @nestia/sdk @nestia/e2e @nestia/fetcher
 npm i -D nestia
 
 # 3. Update the build script (see §2)

--- a/packages/core/native/cmd/ttsc-nestia/build.go
+++ b/packages/core/native/cmd/ttsc-nestia/build.go
@@ -119,11 +119,12 @@ func runBuild(args []string) int {
 		writeTypiaTransformDiagnostics(stderr, transformDiags, cwd)
 		return 3
 	}
+	beforeCore := rewrites.Len()
 	if profile {
 		started = time.Now()
 	}
 	coreDiags := collectNestiaCoreBuildRewrites(prog, plan, rewrites)
-	profileBuildStepCount(profile, "core-rewrites", started, rewrites.Len())
+	profileBuildStepCount(profile, "core-rewrites", started, rewrites.Len()-beforeCore)
 	if len(coreDiags) > 0 {
 		writeTypiaTransformDiagnostics(stderr, coreDiags, cwd)
 		return 3

--- a/packages/core/native/cmd/ttsc-nestia/core_transform.go
+++ b/packages/core/native/cmd/ttsc-nestia/core_transform.go
@@ -14,6 +14,7 @@ import (
 
 	shimast "github.com/microsoft/typescript-go/shim/ast"
 	shimchecker "github.com/microsoft/typescript-go/shim/checker"
+	shimscanner "github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/samchon/nestia/packages/core/native/plugin"
 	"github.com/samchon/ttsc/packages/ttsc/driver"
 	nativecontext "github.com/samchon/typia/packages/typia/native/core/context"
@@ -1688,8 +1689,17 @@ func commonJSImportAliasBase(module string) string {
 }
 
 func nestiaCoreDiagnostic(site nestiaCoreSite, message string) typiaTransformDiagnostic {
+	line, column := 0, 0
+	if site.File != nil && site.Call != nil {
+		if pos := site.Call.AsNode().Pos(); pos >= 0 {
+			l, c := shimscanner.GetECMALineAndByteOffsetOfPosition(site.File, pos)
+			line, column = l+1, c+1
+		}
+	}
 	return typiaTransformDiagnostic{
 		File:    site.FilePath,
+		Line:    line,
+		Column:  column,
 		Code:    "nestia.core." + site.Kind,
 		Message: message,
 	}

--- a/packages/core/native/cmd/ttsc-nestia/core_websocket.go
+++ b/packages/core/native/cmd/ttsc-nestia/core_websocket.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	shimast "github.com/microsoft/typescript-go/shim/ast"
+	shimscanner "github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/samchon/ttsc/packages/ttsc/driver"
 )
 
@@ -23,7 +24,7 @@ func validateNestiaCoreWebSocketRoute(
 	accepted := false
 	methodDecl := method.AsMethodDeclaration()
 	if methodDecl == nil || methodDecl.Parameters == nil {
-		return []typiaTransformDiagnostic{nestiaCoreWebSocketDiagnostic(context.file, "WebSocketRoute", fmt.Sprintf(
+		return []typiaTransformDiagnostic{nestiaCoreWebSocketDiagnostic(context.file, method, "WebSocketRoute", fmt.Sprintf(
 			"method %q must have at least one parameter decorated by @WebSocketRoute.Acceptor().",
 			nestiaSDKMethodName(method),
 		))}
@@ -32,7 +33,7 @@ func validateNestiaCoreWebSocketRoute(
 		category := nestiaCoreWebSocketParameterCategory(prog, param)
 		name := nestiaSDKParameterName(param)
 		if category == "" {
-			diagnostics = append(diagnostics, nestiaCoreWebSocketDiagnostic(context.file, "WebSocketRoute", fmt.Sprintf(
+			diagnostics = append(diagnostics, nestiaCoreWebSocketDiagnostic(context.file, param, "WebSocketRoute", fmt.Sprintf(
 				"parameter %q is not decorated with nested function of WebSocketRoute module.",
 				name,
 			)))
@@ -42,14 +43,14 @@ func validateNestiaCoreWebSocketRoute(
 		case "Acceptor":
 			accepted = true
 			if strings.HasPrefix(nestiaCoreWebSocketParameterTypeName(param), "WebSocketAcceptor") == false {
-				diagnostics = append(diagnostics, nestiaCoreWebSocketDiagnostic(context.file, "WebSocketRoute", fmt.Sprintf(
+				diagnostics = append(diagnostics, nestiaCoreWebSocketDiagnostic(context.file, param, "WebSocketRoute", fmt.Sprintf(
 					"parameter %q must have WebSocketAcceptor<Header, Provider, Listener> type.",
 					name,
 				)))
 			}
 		case "Driver":
 			if strings.HasPrefix(nestiaCoreWebSocketParameterTypeName(param), "Driver") == false {
-				diagnostics = append(diagnostics, nestiaCoreWebSocketDiagnostic(context.file, "WebSocketRoute", fmt.Sprintf(
+				diagnostics = append(diagnostics, nestiaCoreWebSocketDiagnostic(context.file, param, "WebSocketRoute", fmt.Sprintf(
 					"parameter %q must have Driver<Listener> type.",
 					name,
 				)))
@@ -57,7 +58,7 @@ func validateNestiaCoreWebSocketRoute(
 		}
 	}
 	if accepted == false {
-		diagnostics = append(diagnostics, nestiaCoreWebSocketDiagnostic(context.file, "WebSocketRoute", fmt.Sprintf(
+		diagnostics = append(diagnostics, nestiaCoreWebSocketDiagnostic(context.file, method, "WebSocketRoute", fmt.Sprintf(
 			"method %q must have at least one parameter decorated by @WebSocketRoute.Acceptor().",
 			nestiaSDKMethodName(method),
 		)))
@@ -92,13 +93,22 @@ func nestiaCoreWebSocketParameterTypeName(param *shimast.Node) string {
 	return text
 }
 
-func nestiaCoreWebSocketDiagnostic(file *shimast.SourceFile, kind string, message string) typiaTransformDiagnostic {
+func nestiaCoreWebSocketDiagnostic(file *shimast.SourceFile, node *shimast.Node, kind string, message string) typiaTransformDiagnostic {
 	filePath := ""
+	line, column := 0, 0
 	if file != nil {
 		filePath = file.FileName()
+		if node != nil {
+			if pos := node.Pos(); pos >= 0 {
+				l, c := shimscanner.GetECMALineAndByteOffsetOfPosition(file, pos)
+				line, column = l+1, c+1
+			}
+		}
 	}
 	return typiaTransformDiagnostic{
 		File:    filePath,
+		Line:    line,
+		Column:  column,
 		Code:    "nestia.core." + kind,
 		Message: message,
 	}

--- a/packages/core/native/cmd/ttsc-nestia/main.go
+++ b/packages/core/native/cmd/ttsc-nestia/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime/debug"
 )
 
 var (
@@ -12,7 +13,28 @@ var (
 )
 
 func main() {
-	os.Exit(run(os.Args[1:]))
+	os.Exit(runSafe(os.Args[1:]))
+}
+
+// runSafe wraps run() in a panic recovery envelope so that any unexpected
+// panic surfaces as a parseable transform-diagnostic line on stderr instead
+// of a raw Go stack trace that ttsc's compiler-diagnostic regex cannot read.
+// The full stack is preserved behind NESTIA_NATIVE_DEBUG_STACK for triage.
+func runSafe(args []string) (code int) {
+	defer func() {
+		if exp := recover(); exp != nil {
+			diag := typiaTransformDiagnostic{
+				Code:    "nestia.internal.panic",
+				Message: fmt.Sprintf("ttsc-nestia panicked: %v", exp),
+			}
+			writeTypiaTransformDiagnostics(stderr, []typiaTransformDiagnostic{diag}, "")
+			if os.Getenv("NESTIA_NATIVE_DEBUG_STACK") != "" {
+				fmt.Fprintln(stderr, string(debug.Stack()))
+			}
+			code = 3
+		}
+	}()
+	return run(args)
 }
 
 func run(args []string) int {

--- a/packages/core/native/cmd/ttsc-nestia/sdk_transform.go
+++ b/packages/core/native/cmd/ttsc-nestia/sdk_transform.go
@@ -11,6 +11,7 @@ import (
 
 	shimast "github.com/microsoft/typescript-go/shim/ast"
 	shimchecker "github.com/microsoft/typescript-go/shim/checker"
+	shimscanner "github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/samchon/nestia/packages/core/native/plugin"
 	"github.com/samchon/ttsc/packages/ttsc/driver"
 	nativefactories "github.com/samchon/typia/packages/typia/native/core/factories"
@@ -676,10 +677,12 @@ func nestiaSDKSchemaPipe(context *nestiaSDKContext, typ *shimchecker.Type, typeN
 				"messages": err.Messages,
 			})
 		}
-		return map[string]any{
+		failure := map[string]any{
 			"success": false,
 			"errors":  errors,
 		}
+		context.schemaCache[key] = failure
+		return failure
 	}
 	nestiaSDKRestoreUnionOrder(typeNode, result.Data)
 	value := map[string]any{
@@ -1426,8 +1429,17 @@ func sourceLineIndent(source string, pos int) string {
 }
 
 func nestiaSDKDiagnostic(site nestiaSDKSite, message string) typiaTransformDiagnostic {
+	line, column := 0, 0
+	if site.File != nil && site.Method != nil {
+		if pos := site.Method.Pos(); pos >= 0 {
+			l, c := shimscanner.GetECMALineAndByteOffsetOfPosition(site.File, pos)
+			line, column = l+1, c+1
+		}
+	}
 	return typiaTransformDiagnostic{
 		File:    site.FilePath,
+		Line:    line,
+		Column:  column,
 		Code:    "nestia.sdk.OperationMetadata",
 		Message: message,
 	}

--- a/packages/sdk/src/analyses/ConfigAnalyzer.ts
+++ b/packages/sdk/src/analyses/ConfigAnalyzer.ts
@@ -131,6 +131,7 @@ class RuntimeCompiler {
       "runtime",
     );
     await fs.promises.mkdir(runtimeRoot, { recursive: true });
+    ensureRuntimeCleanup(runtimeRoot);
     const outDir: string = await fs.promises.mkdtemp(
       path.join(runtimeRoot, "run-"),
     );
@@ -186,6 +187,33 @@ class RuntimeCompiler {
     return emitted;
   }
 }
+
+const RUNTIME_ROOTS: Set<string> = new Set();
+let RUNTIME_CLEANUP_REGISTERED: boolean = false;
+
+const ensureRuntimeCleanup = (runtimeRoot: string): void => {
+  RUNTIME_ROOTS.add(runtimeRoot);
+  if (RUNTIME_CLEANUP_REGISTERED === true) return;
+  RUNTIME_CLEANUP_REGISTERED = true;
+  const sweep = (): void => {
+    for (const location of RUNTIME_ROOTS)
+      fs.rmSync(location, { force: true, recursive: true });
+  };
+  process.once("exit", sweep);
+  // process.once("exit", …) does not fire on SIGINT/SIGTERM. Without these
+  // handlers a Ctrl-C during codegen leaves `run-*` mkdtemp directories
+  // behind under node_modules/.nestia/runtime/ until a subsequent clean exit.
+  const onSignal = (signal: NodeJS.Signals): void => {
+    sweep();
+    process.kill(process.pid, signal);
+  };
+  for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"] as const) {
+    if (typeof process.listenerCount === "function" &&
+        process.listenerCount(signal) > 0)
+      continue;
+    process.once(signal, onSignal);
+  }
+};
 
 type RuntimePlugin = Record<string, unknown> & { transform?: unknown };
 


### PR DESCRIPTION
This pull request introduces several improvements to error diagnostics, resource cleanup, and documentation in the `ttsc-nestia` toolchain. The most significant changes are enhanced diagnostic reporting with precise file/line/column information, more robust runtime directory cleanup in the SDK, improved panic handling with optional stack traces, and updated documentation and migration instructions.

**Diagnostics and Error Reporting Improvements:**
- All diagnostic creation functions (`nestiaCoreDiagnostic`, `nestiaCoreWebSocketDiagnostic`, `nestiaSDKDiagnostic`) now include line and column numbers in their output, making error messages more actionable and easier to trace in source files. [[1]](diffhunk://#diff-c858fa409464466a6a390adda475b15383ffbe884db4f049261f678133524a33R1692-R1702) [[2]](diffhunk://#diff-e8be9b2bbe9c74cbbd3684ef85c77d3e02db4a46ed36a2977d1aa31727a906a9L95-R111) [[3]](diffhunk://#diff-5dc13876d62fa5eebd2a783c2f89c29dba28ea4b33e57dd7d8253ae542c0fc91R1432-R1442)
- The `run` entrypoint in `main.go` is now wrapped in a panic recovery handler (`runSafe`). On panic, a parseable diagnostic message is emitted; if `NESTIA_NATIVE_DEBUG_STACK=1` is set, the full Go stack trace is also printed for debugging. [[1]](diffhunk://#diff-fe41cb296456bd5cbbf5cf8d17368fcedae4ad6c7209ffc58fc1c6fac77cb5eaL15-R37) [[2]](diffhunk://#diff-3baf3740a5ce79e0f55ce46d51915d459748470842838dd0a4c56f28e2d38580R144-R147)

**Resource Management Enhancements:**
- The SDK's runtime compilation now ensures temporary runtime directories are cleaned up on process exit and on signals like SIGINT/SIGTERM, preventing leftover files after interrupted runs. [[1]](diffhunk://#diff-c8a57828e08f6f3a74e547bdfb072b31f146e646345a636642ccb332a7ca01c6R134) [[2]](diffhunk://#diff-c8a57828e08f6f3a74e547bdfb072b31f146e646345a636642ccb332a7ca01c6R191-R217)

**Documentation and Migration Updates:**
- The migration guide (`MIGRATION.md`) documents the new `NESTIA_NATIVE_DEBUG_STACK` environment variable and updates dependency installation instructions to include `@nestia/e2e`. [[1]](diffhunk://#diff-3baf3740a5ce79e0f55ce46d51915d459748470842838dd0a4c56f28e2d38580R144-R147) [[2]](diffhunk://#diff-3baf3740a5ce79e0f55ce46d51915d459748470842838dd0a4c56f28e2d38580L153-R157)

**Other Notable Fixes:**
- Diagnostic reporting in WebSocket route validation now provides more precise location information by passing the relevant AST node. [[1]](diffhunk://#diff-e8be9b2bbe9c74cbbd3684ef85c77d3e02db4a46ed36a2977d1aa31727a906a9L26-R27) [[2]](diffhunk://#diff-e8be9b2bbe9c74cbbd3684ef85c77d3e02db4a46ed36a2977d1aa31727a906a9L35-R36) [[3]](diffhunk://#diff-e8be9b2bbe9c74cbbd3684ef85c77d3e02db4a46ed36a2977d1aa31727a906a9L45-R61)
- SDK schema cache now stores failure results to avoid redundant error computation.
- Profiling for build steps now accurately measures only the core rewrite phase.

**Summary of Most Important Changes:**

**Diagnostics and Error Reporting:**
- Added line and column info to diagnostics from core, SDK, and WebSocket transforms for more actionable error messages. [[1]](diffhunk://#diff-c858fa409464466a6a390adda475b15383ffbe884db4f049261f678133524a33R1692-R1702) [[2]](diffhunk://#diff-e8be9b2bbe9c74cbbd3684ef85c77d3e02db4a46ed36a2977d1aa31727a906a9L95-R111) [[3]](diffhunk://#diff-5dc13876d62fa5eebd2a783c2f89c29dba28ea4b33e57dd7d8253ae542c0fc91R1432-R1442)
- Wrapped the CLI entrypoint in a panic recovery function (`runSafe`) to emit parseable diagnostics and optionally show Go stack traces with `NESTIA_NATIVE_DEBUG_STACK`. [[1]](diffhunk://#diff-fe41cb296456bd5cbbf5cf8d17368fcedae4ad6c7209ffc58fc1c6fac77cb5eaL15-R37) [[2]](diffhunk://#diff-3baf3740a5ce79e0f55ce46d51915d459748470842838dd0a4c56f28e2d38580R144-R147)

**Resource Management:**
- Implemented robust cleanup of temporary runtime directories in the SDK, including on process exit and common termination signals. [[1]](diffhunk://#diff-c8a57828e08f6f3a74e547bdfb072b31f146e646345a636642ccb332a7ca01c6R134) [[2]](diffhunk://#diff-c8a57828e08f6f3a74e547bdfb072b31f146e646345a636642ccb332a7ca01c6R191-R217)

**Documentation:**
- Updated migration docs to describe the new debug stack environment variable and revised dependency installation steps. [[1]](diffhunk://#diff-3baf3740a5ce79e0f55ce46d51915d459748470842838dd0a4c56f28e2d38580R144-R147) [[2]](diffhunk://#diff-3baf3740a5ce79e0f55ce46d51915d459748470842838dd0a4c56f28e2d38580L153-R157)

**Bug Fixes and Misc:**
- Improved WebSocket diagnostics by reporting errors at the precise AST node. [[1]](diffhunk://#diff-e8be9b2bbe9c74cbbd3684ef85c77d3e02db4a46ed36a2977d1aa31727a906a9L26-R27) [[2]](diffhunk://#diff-e8be9b2bbe9c74cbbd3684ef85c77d3e02db4a46ed36a2977d1aa31727a906a9L35-R36) [[3]](diffhunk://#diff-e8be9b2bbe9c74cbbd3684ef85c77d3e02db4a46ed36a2977d1aa31727a906a9L45-R61)
- Cached SDK schema failures to avoid repeated error processing.