### PR TITLE
fix(test): benchmark, spawn servant from .ts under ttsx

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,9 @@ on:
       - 'pnpm-workspace.yaml'
       - 'package.json'
 
+permissions:
+  contents: read
+
 concurrency:
   group: test-${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/tests/test-benchmark/src/index.ts
+++ b/tests/test-benchmark/src/index.ts
@@ -10,7 +10,7 @@ const main = async (): Promise<void> => {
   await app.listen(3_000);
 
   const report: DynamicBenchmarker.IReport = await DynamicBenchmarker.master({
-    servant: `${__dirname}/servant.js`,
+    servant: `${__dirname}/servant.ts`,
     count: 10,
     threads: 2,
     simultaneous: 4,


### PR DESCRIPTION
The benchmark's `DynamicBenchmarker.master` spawned `${__dirname}/servant.js`, but under the ttsx source-run there is no compiled `servant.js` — only `servant.ts`. The servant processes never started, so the master waited on workers that never came up and the `benchmark` CI job hung indefinitely.

Point the servant path at `servant.ts`; the spawned process inherits the ttsx runtime hooks via `NODE_OPTIONS`, so it loads the transformed source like the master.

This unblocks the only remaining red/hanging CI job after the @next ttsx AST-integration migration (#1475).

🤖 Generated with [Claude Code](https://claude.com/claude-code)