### PR TITLE
fix(benchmark): make servant feature-file extension configurable

### DIFF
--- a/packages/benchmark/src/DynamicBenchmarker.ts
+++ b/packages/benchmark/src/DynamicBenchmarker.ts
@@ -121,6 +121,19 @@ export namespace DynamicBenchmarker {
     location: string;
 
     /**
+     * Extension of the benchmark function files to load, without the leading
+     * dot.
+     *
+     * The servant reads {@link location} and imports every file ending with
+     * this extension. Set it to match how the feature files are actually run:
+     * `"js"` when they are built JavaScript, or `"ts"` when they are executed
+     * from TypeScript source (for example under `ttsx`).
+     *
+     * @default "js"
+     */
+    extension?: string;
+
+    /**
      * Prefix of the benchmark functions.
      *
      * Every prefixed function will be executed in the servant.
@@ -378,7 +391,16 @@ const iterate =
       const location: string = `${path}/${file}`;
       const stat: fs.Stats = await fs.promises.stat(location);
       if (stat.isDirectory() === true) await iterate(ctx)(location);
-      else if (file.endsWith(__filename.substr(-3)) === true) {
+      // Load feature files whose extension matches `props.extension`. This is
+      // configurable instead of inferred from the servant's own module
+      // extension, because the benchmark library may be built (`.js`) while the
+      // feature files it drives are run from source (`.ts`, e.g. under `ttsx`);
+      // inferring would look for `.js` features that do not exist, load
+      // nothing, and spin forever.
+      else if (
+        file.endsWith(`.${ctx.props.extension ?? "js"}`) &&
+        file.endsWith(".d.ts") === false
+      ) {
         const modulo = await import(location);
         for (const [key, value] of Object.entries(modulo)) {
           if (typeof value !== "function") continue;

--- a/tests/test-benchmark/src/servant.ts
+++ b/tests/test-benchmark/src/servant.ts
@@ -7,6 +7,8 @@ DynamicBenchmarker.servant({
   location: `${__dirname}/features`,
   parameters: (connection) => [connection],
   prefix: "test_api_",
+  // Feature files are executed from TypeScript source under ttsx.
+  extension: "ts",
 }).catch((exp) => {
   console.error(exp);
   process.exit(-1);


### PR DESCRIPTION
Follow-up to the ttsx benchmark fix: `DynamicBenchmarker` spawned the servant with a hard-coded `.js` extension, so under the ttsx source-run (where only `servant.ts` exists) the servants never started and the master hung. Make the servant feature-file extension configurable and point the benchmark at `servant.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)