### PR TITLE
fix(sdk): validate keyword body assertions

### DIFF
--- a/packages/sdk/src/generates/internal/SdkHttpFunctionProgrammer.ts
+++ b/packages/sdk/src/generates/internal/SdkHttpFunctionProgrammer.ts
@@ -1,6 +1,12 @@
-import { Node, NodeFlags, SyntaxKind, TypeScriptFactory } from "@nestia/factory";
+import {
+  Node,
+  NodeFlags,
+  SyntaxKind,
+  TypeScriptFactory,
+} from "@nestia/factory";
 import { IdentifierFactory, TypeFactory } from "@nestia/factory";
 
+import { sizeOf } from "../../internal/legacy";
 import { INestiaProject } from "../../structures/INestiaProject";
 import { ITypedHttpRoute } from "../../structures/ITypedHttpRoute";
 import { StringUtil } from "../../utils/StringUtil";
@@ -8,7 +14,6 @@ import { ImportDictionary } from "./ImportDictionary";
 import { SdkAliasCollection } from "./SdkAliasCollection";
 import { SdkHttpParameterProgrammer } from "./SdkHttpParameterProgrammer";
 import { SdkImportWizard } from "./SdkImportWizard";
-import { sizeOf } from "../../internal/legacy";
 
 export namespace SdkHttpFunctionProgrammer {
   export const write =
@@ -202,12 +207,8 @@ export namespace SdkHttpFunctionProgrammer {
                     ),
                     "assert",
                   ),
-                  [
-                    TypeScriptFactory.createTypeQueryNode(
-                      TypeScriptFactory.createIdentifier(p.name),
-                    ),
-                  ],
-                  [TypeScriptFactory.createIdentifier(p.name)],
+                  [TypeScriptFactory.createTypeQueryNode(access(p.name))],
+                  [access(p.name)],
                 ),
               ),
             )
@@ -239,9 +240,7 @@ export namespace SdkHttpFunctionProgrammer {
       const assigners: Node[] = [
         TypeScriptFactory.createBinaryExpression(
           TypeScriptFactory.createIdentifier(headers),
-          TypeScriptFactory.createToken(
-            SyntaxKind.QuestionQuestionEqualsToken,
-          ),
+          TypeScriptFactory.createToken(SyntaxKind.QuestionQuestionEqualsToken),
           TypeScriptFactory.createObjectLiteralExpression([]),
         ),
         ...route.success.setHeaders.map((tuple) =>

--- a/tests/test-sdk/features/keyword/nestia.config.ts
+++ b/tests/test-sdk/features/keyword/nestia.config.ts
@@ -4,6 +4,7 @@ export const NESTIA_CONFIG: INestiaConfig = {
   input: ["src/controllers"],
   output: "src/api",
   keyword: true,
+  assert: true,
   e2e: "src/test",
   swagger: {
     output: "swagger.json",


### PR DESCRIPTION
## Summary

Fixes #1410.

- Reuses the generated SDK parameter accessor when emitting config-level `typia.assert` calls.
- Makes keyword-mode SDK clients assert `props.dto` instead of an out-of-scope `dto` identifier.
- Extends the `keyword` SDK fixture with `assert: true` so CI covers the combined mode.

## Verification

- `pnpm --filter @nestia/core run build`
- `pnpm --filter @nestia/sdk run build`
- Generator smoke script confirmed `typia.assert<typeof props.dto>(props.dto)` output.

## Not Run

- `tests/test-sdk` keyword fixture generation on this Windows checkout; blocked before SDK output by existing native plugin temp filename normalization diagnostics (`fileName should be normalized and absolute` for files under `%TEMP%`).
