### PR TITLE
fix(sdk): honor global prefix exclusions

### DIFF
--- a/packages/sdk/src/NestiaSdkApplication.ts
+++ b/packages/sdk/src/NestiaSdkApplication.ts
@@ -1,4 +1,3 @@
-import { IMetadataDictionary } from "./internal/legacy";
 import fs from "fs";
 import path from "path";
 import { HashSet, Pair, TreeMap } from "tstl";
@@ -13,13 +12,14 @@ import { TypedWebSocketRouteAnalyzer } from "./analyses/TypedWebSocketRouteAnaly
 import { E2eGenerator } from "./generates/E2eGenerator";
 import { SdkGenerator } from "./generates/SdkGenerator";
 import { SwaggerGenerator } from "./generates/SwaggerGenerator";
+import { IMetadataDictionary } from "./internal/legacy";
 import { INestiaProject } from "./structures/INestiaProject";
+import { IOperationMetadata } from "./structures/IOperationMetadata";
 import { IReflectController } from "./structures/IReflectController";
 import { IReflectOperationError } from "./structures/IReflectOperationError";
 import { ITypedApplication } from "./structures/ITypedApplication";
 import { ITypedHttpRoute } from "./structures/ITypedHttpRoute";
 import { ITypedWebSocketRoute } from "./structures/ITypedWebSocketRoute";
-import { IOperationMetadata } from "./structures/IOperationMetadata";
 import { StringUtil } from "./utils/StringUtil";
 import { VersioningStrategy } from "./utils/VersioningStrategy";
 
@@ -194,7 +194,6 @@ export class NestiaSdkApplication {
       TypedHttpRouteAnalyzer.dictionary(controllers);
 
     // CONVERT TO TYPED OPERATIONS
-    const globalPrefix: string = project.input.globalPrefix?.prefix ?? "";
     const routes: Array<ITypedHttpRoute | ITypedWebSocketRoute> = [];
     for (const c of controllers)
       for (const o of c.operations) {
@@ -206,10 +205,22 @@ export class NestiaSdkApplication {
         for (const v of versions)
           for (const prefix of wrapPaths(c.prefixes))
             for (const cPath of wrapPaths(c.paths))
-              for (const filePath of wrapPaths(o.paths))
-                pathList.add(
-                  PathAnalyzer.join(globalPrefix, v, prefix, cPath, filePath),
+              for (const filePath of wrapPaths(o.paths)) {
+                const localPath: string = PathAnalyzer.join(
+                  prefix,
+                  cPath,
+                  filePath,
                 );
+                pathList.add(
+                  PathAnalyzer.joinWithGlobalPrefix({
+                    globalPrefix: project.input.globalPrefix?.prefix ?? "",
+                    exclude: project.input.globalPrefix?.exclude,
+                    excludePath: localPath,
+                    method: o.protocol === "http" ? o.method : "",
+                    path: PathAnalyzer.join(v, localPath),
+                  }),
+                );
+              }
         if (o.protocol === "http")
           routes.push(
             ...TypedHttpRouteAnalyzer.analyze({

--- a/packages/sdk/src/NestiaSwaggerComposer.ts
+++ b/packages/sdk/src/NestiaSwaggerComposer.ts
@@ -1,5 +1,4 @@
 import { INestApplication } from "@nestjs/common";
-import { IMetadataDictionary } from "./internal/legacy";
 import { OpenApiV3, OpenApiV3_1, SwaggerV2 } from "@typia/interface";
 import { OpenApiConverter } from "@typia/utils";
 import path from "path";
@@ -13,12 +12,13 @@ import { PathAnalyzer } from "./analyses/PathAnalyzer";
 import { ReflectControllerAnalyzer } from "./analyses/ReflectControllerAnalyzer";
 import { TypedHttpRouteAnalyzer } from "./analyses/TypedHttpRouteAnalyzer";
 import { SwaggerGenerator } from "./generates/SwaggerGenerator";
+import { IMetadataDictionary } from "./internal/legacy";
 import { INestiaProject } from "./structures/INestiaProject";
 import { INestiaSdkInput } from "./structures/INestiaSdkInput";
+import { IOperationMetadata } from "./structures/IOperationMetadata";
 import { IReflectController } from "./structures/IReflectController";
 import { IReflectOperationError } from "./structures/IReflectOperationError";
 import { ITypedHttpRoute } from "./structures/ITypedHttpRoute";
-import { IOperationMetadata } from "./structures/IOperationMetadata";
 import { VersioningStrategy } from "./utils/VersioningStrategy";
 
 export namespace NestiaSwaggerComposer {
@@ -63,10 +63,10 @@ export namespace NestiaSwaggerComposer {
       TypedHttpRouteAnalyzer.dictionary(controllers);
 
     // CONVERT TO TYPED OPERATIONS
-    const globalPrefix: string = project.input.globalPrefix?.prefix ?? "";
     const routes: ITypedHttpRoute[] = [];
     for (const c of controllers)
       for (const o of c.operations) {
+        if (o.protocol !== "http") continue;
         const pathList: Set<string> = new Set();
         const versions: string[] = VersioningStrategy.merge(project)([
           ...(c.versions ?? []),
@@ -75,20 +75,31 @@ export namespace NestiaSwaggerComposer {
         for (const v of versions)
           for (const prefix of wrapPaths(c.prefixes))
             for (const cPath of wrapPaths(c.paths))
-              for (const filePath of wrapPaths(o.paths))
-                pathList.add(
-                  PathAnalyzer.join(globalPrefix, v, prefix, cPath, filePath),
+              for (const filePath of wrapPaths(o.paths)) {
+                const localPath: string = PathAnalyzer.join(
+                  prefix,
+                  cPath,
+                  filePath,
                 );
-        if (o.protocol === "http")
-          routes.push(
-            ...TypedHttpRouteAnalyzer.analyze({
-              controller: c,
-              errors: project.errors,
-              dictionary: collection,
-              operation: o,
-              paths: Array.from(pathList),
-            }),
-          );
+                pathList.add(
+                  PathAnalyzer.joinWithGlobalPrefix({
+                    globalPrefix: project.input.globalPrefix?.prefix ?? "",
+                    exclude: project.input.globalPrefix?.exclude,
+                    excludePath: localPath,
+                    method: o.method,
+                    path: PathAnalyzer.join(v, localPath),
+                  }),
+                );
+              }
+        routes.push(
+          ...TypedHttpRouteAnalyzer.analyze({
+            controller: c,
+            errors: project.errors,
+            dictionary: collection,
+            operation: o,
+            paths: Array.from(pathList),
+          }),
+        );
       }
     AccessorAnalyzer.analyze(routes);
     return routes;

--- a/packages/sdk/src/analyses/ConfigAnalyzer.ts
+++ b/packages/sdk/src/analyses/ConfigAnalyzer.ts
@@ -100,7 +100,7 @@ export namespace ConfigAnalyzer {
         typeof (app as any).config?.globalPrefix === "string"
           ? {
               prefix: (app as any).config.globalPrefix,
-              exclude: (app as any).config.globalPrefixOptions?.exclude ?? {},
+              exclude: (app as any).config.globalPrefixOptions?.exclude ?? [],
             }
           : undefined,
       versioning:

--- a/packages/sdk/src/analyses/PathAnalyzer.ts
+++ b/packages/sdk/src/analyses/PathAnalyzer.ts
@@ -1,3 +1,4 @@
+import { RequestMethod } from "@nestjs/common";
 import path from "path";
 import { Token, parse } from "path-to-regexp";
 
@@ -9,6 +10,24 @@ export namespace PathAnalyzer {
         .join(...args.filter((s) => !!s.length))
         .split("\\")
         .join("/"),
+    );
+
+  export const joinWithGlobalPrefix = (props: {
+    globalPrefix: string;
+    exclude: IGlobalPrefixExclude[] | undefined;
+    excludePath?: string;
+    method: string;
+    path: string;
+  }): string =>
+    join(
+      isGlobalPrefixExcluded(
+        props.exclude,
+        props.excludePath ?? props.path,
+        props.method,
+      )
+        ? ""
+        : props.globalPrefix,
+      props.path,
     );
 
   export const escape = (str: string): string | null => {
@@ -62,8 +81,50 @@ export namespace PathAnalyzer {
     return str;
   }
 
+  function isGlobalPrefixExcluded(
+    exclude: IGlobalPrefixExclude[] | undefined,
+    path: string,
+    method: string,
+  ): boolean {
+    if (exclude === undefined) return false;
+    const requestMethod: RequestMethod | undefined = REQUEST_METHODS[method];
+    if (requestMethod === undefined) return false;
+
+    const location: string = join(path);
+    return exclude.some((route) => {
+      const routeMethod: RequestMethod | undefined =
+        route.requestMethod ?? route.method;
+      if (
+        routeMethod !== undefined &&
+        routeMethod !== RequestMethod.ALL &&
+        routeMethod !== requestMethod
+      )
+        return false;
+      if (route.pathRegex instanceof RegExp)
+        return route.pathRegex.test(join(location));
+      return join(route.path) === location;
+    });
+  }
+
   interface IArgument {
     type: "param" | "path";
     value: string;
   }
+
+  interface IGlobalPrefixExclude {
+    path: string;
+    method?: RequestMethod;
+    requestMethod?: RequestMethod;
+    pathRegex?: RegExp;
+  }
 }
+
+const REQUEST_METHODS: Record<string, RequestMethod> = {
+  DELETE: RequestMethod.DELETE,
+  GET: RequestMethod.GET,
+  HEAD: RequestMethod.HEAD,
+  OPTIONS: RequestMethod.OPTIONS,
+  PATCH: RequestMethod.PATCH,
+  POST: RequestMethod.POST,
+  PUT: RequestMethod.PUT,
+};

--- a/packages/sdk/src/structures/INestiaSdkInput.ts
+++ b/packages/sdk/src/structures/INestiaSdkInput.ts
@@ -1,10 +1,11 @@
-import { RouteInfo, VersionValue } from "@nestjs/common/interfaces";
+import { RequestMethod } from "@nestjs/common";
+import { VersionValue } from "@nestjs/common/interfaces";
 
 export interface INestiaSdkInput {
   controllers: INestiaSdkInput.IController[];
   globalPrefix?: {
     prefix: string;
-    exclude?: Array<string | RouteInfo>;
+    exclude?: INestiaSdkInput.IGlobalPrefixExclude[];
   };
   versioning?: {
     prefix: string;
@@ -16,5 +17,11 @@ export namespace INestiaSdkInput {
     class: Function;
     location: string;
     prefixes: string[];
+  }
+  export interface IGlobalPrefixExclude {
+    path: string;
+    method?: RequestMethod;
+    requestMethod?: RequestMethod;
+    pathRegex?: RegExp;
   }
 }

--- a/tests/test-sdk/features/app-globalPrefix/src/Backend.ts
+++ b/tests/test-sdk/features/app-globalPrefix/src/Backend.ts
@@ -14,13 +14,15 @@ export class Backend {
           logger: false,
         },
       );
-      app.setGlobalPrefix("x");
+      app.setGlobalPrefix("x", { exclude: ["/_ah/warmup"] });
       await core.WebSocketAdaptor.upgrade(app);
       return app;
     });
 
   public async open(): Promise<void> {
-    return (await this.application.get()).listen(Number(process.env.TEST_SDK_PORT ?? 37_000));
+    return (await this.application.get()).listen(
+      Number(process.env.TEST_SDK_PORT ?? 37_000),
+    );
   }
 
   public async close(): Promise<void> {

--- a/tests/test-sdk/features/app-globalPrefix/src/controllers/WarmupController.ts
+++ b/tests/test-sdk/features/app-globalPrefix/src/controllers/WarmupController.ts
@@ -1,0 +1,10 @@
+import core from "@nestia/core";
+import { Controller } from "@nestjs/common";
+
+@Controller("_ah")
+export class WarmupController {
+  @core.TypedRoute.Get("warmup")
+  public warmup(): string {
+    return "ok";
+  }
+}

--- a/tests/test-sdk/features/app-globalPrefix/src/modules/HealthModule.ts
+++ b/tests/test-sdk/features/app-globalPrefix/src/modules/HealthModule.ts
@@ -1,8 +1,9 @@
 import { Module } from "@nestjs/common";
 
 import { HealthController } from "../controllers/HealthController";
+import { WarmupController } from "../controllers/WarmupController";
 
 @Module({
-  controllers: [HealthController],
+  controllers: [HealthController, WarmupController],
 })
 export class HealthModule {}

--- a/tests/test-sdk/features/app-globalPrefix/src/test/features/api/test_api_global_prefix_exclude.ts
+++ b/tests/test-sdk/features/app-globalPrefix/src/test/features/api/test_api_global_prefix_exclude.ts
@@ -1,0 +1,43 @@
+import { TestValidator } from "@nestia/e2e";
+import fs from "fs";
+import path from "path";
+
+import api from "@api";
+
+/**
+ * Verifies global prefix exclusions keep matching routes unprefixed in SDK and
+ * Swagger output.
+ *
+ * Locks the `setGlobalPrefix(prefix, { exclude })` branch used by NestJS for
+ * health-check style endpoints. The SDK analyzer already reads the global
+ * prefix metadata, so this test pins the missing step: deciding per route
+ * whether the prefix applies before composing generated accessors and Swagger
+ * paths.
+ *
+ * 1. Generate an app with global prefix `x` and `/_ah/warmup` excluded.
+ * 2. Call the generated SDK accessor for the unprefixed warmup route.
+ * 3. Assert Swagger exposes `/_ah/warmup` and not `/x/_ah/warmup`.
+ */
+export const test_api_global_prefix_exclude = async (
+  connection: api.IConnection,
+): Promise<void> => {
+  const output: string = await api.functional._ah.warmup(connection);
+  TestValidator.equals("output", output, "ok");
+
+  const swagger = JSON.parse(
+    await fs.promises.readFile(
+      path.join(__dirname, "../../../../swagger.json"),
+      "utf8",
+    ),
+  );
+  TestValidator.equals(
+    "unprefixed swagger path",
+    swagger.paths["/_ah/warmup"] !== undefined,
+    true,
+  );
+  TestValidator.equals(
+    "prefixed swagger path",
+    swagger.paths["/x/_ah/warmup"],
+    undefined,
+  );
+};


### PR DESCRIPTION
Closes #746.

## Summary
- apply Nest's `setGlobalPrefix(..., { exclude })` metadata while composing SDK and Swagger paths
- compare exclusions against the local unprefixed route path, matching Nest's URI-versioning behavior
- add an `app-globalPrefix` regression route for `/_ah/warmup` and assert SDK + Swagger stay unprefixed

## Tests
- `pnpm --filter @nestia/sdk run build` with absolute `TTSC_GO_BINARY`
- Node smoke test for excluded, prefixed, and versioned `PathAnalyzer.joinWithGlobalPrefix` cases

## Not Run
- `node tests/test-sdk/start.js --only app-globalPrefix --concurrency 1` could not complete locally on Windows because the native transform rejected generated temp filenames before fixture generation (`fileName should be normalized and absolute`).