### PR TITLE
fix(sdk): respect Swagger exclusion decorators

### DIFF
--- a/packages/sdk/src/generates/SwaggerGenerator.ts
+++ b/packages/sdk/src/generates/SwaggerGenerator.ts
@@ -1,5 +1,4 @@
 import { SwaggerCustomizer } from "@nestia/core";
-import { JsonSchemasProgrammer, MetadataSchema, sizeOf } from "../internal/legacy";
 import {
   OpenApi,
   OpenApiV3,
@@ -14,6 +13,11 @@ import { Singleton } from "tstl";
 import type { IJsonSchemaCollection } from "typia";
 
 import { INestiaConfig } from "../INestiaConfig";
+import {
+  JsonSchemasProgrammer,
+  MetadataSchema,
+  sizeOf,
+} from "../internal/legacy";
 import { ITypedApplication } from "../structures/ITypedApplication";
 import { ITypedHttpRoute } from "../structures/ITypedHttpRoute";
 import { FileRetriever } from "../utils/FileRetriever";
@@ -77,10 +81,11 @@ export namespace SwaggerGenerator {
     document: OpenApi.IDocument;
   }): OpenApi.IDocument => {
     // GATHER METADATA
-    const routes: ITypedHttpRoute[] = props.routes.filter((r) =>
-      r.jsDocTags.every(
-        (tag) => tag.name !== "internal" && tag.name !== "hidden",
-      ),
+    const routes: ITypedHttpRoute[] = props.routes.filter(
+      (r) =>
+        r.jsDocTags.every(
+          (tag) => tag.name !== "internal" && tag.name !== "hidden",
+        ) && isSwaggerExcluded(r) === false,
     );
     const metadatas: MetadataSchema[] = routes
       .map((r) => [
@@ -296,6 +301,25 @@ export namespace SwaggerGenerator {
     for (const param of route.pathParameters)
       str = str.replace(`:${param.field}`, `{${param.field}}`);
     return str;
+  };
+
+  const isSwaggerExcluded = (route: ITypedHttpRoute): boolean => {
+    const controller: unknown = Reflect.getMetadata(
+      "swagger/apiExcludeController",
+      route.controller.class,
+    );
+    if (Array.isArray(controller) && controller[0] === true) return true;
+
+    const endpoint: unknown = Reflect.getMetadata(
+      "swagger/apiExcludeEndpoint",
+      route.function,
+    );
+    return (
+      endpoint !== undefined &&
+      (typeof endpoint !== "object" ||
+        endpoint === null ||
+        (endpoint as { disable?: boolean }).disable !== false)
+    );
   };
 }
 

--- a/tests/test-sdk/features/swagger-hidden/src/controllers/AppController.ts
+++ b/tests/test-sdk/features/swagger-hidden/src/controllers/AppController.ts
@@ -1,4 +1,5 @@
 import { Controller, Get } from "@nestjs/common";
+import { ApiExcludeController, ApiExcludeEndpoint } from "@nestjs/swagger";
 
 @Controller()
 export class AppController {
@@ -17,6 +18,27 @@ export class AppController {
   /** @ignore */
   @Get("ignore")
   public ignore(): Array<number> {
+    return [0];
+  }
+
+  @ApiExcludeEndpoint()
+  @Get("swagger-excluded-endpoint")
+  public swagger_excluded_endpoint(): Array<number> {
+    return [0];
+  }
+
+  @ApiExcludeEndpoint(false)
+  @Get("swagger-visible-endpoint")
+  public swagger_visible_endpoint(): Array<number> {
+    return [0];
+  }
+}
+
+@ApiExcludeController()
+@Controller("swagger-excluded-controller")
+export class SwaggerExcludedController {
+  @Get()
+  public swagger_excluded_controller(): Array<number> {
     return [0];
   }
 }

--- a/tests/test-sdk/features/swagger-hidden/src/test/features/test_sdk.ts
+++ b/tests/test-sdk/features/swagger-hidden/src/test/features/test_sdk.ts
@@ -5,5 +5,8 @@ import api from "@api";
 export async function test_sdk(): Promise<void> {
   TestValidator.equals("functions", Object.keys(api.functional).sort(), [
     "internal",
+    "swagger_excluded_controller",
+    "swagger_excluded_endpoint",
+    "swagger_visible_endpoint",
   ]);
 }

--- a/tests/test-sdk/features/swagger-hidden/src/test/features/test_swagger.ts
+++ b/tests/test-sdk/features/swagger-hidden/src/test/features/test_swagger.ts
@@ -1,7 +1,11 @@
-import fs from "fs";
 import { TestValidator } from "@nestia/e2e";
+import fs from "fs";
 
 export async function test_swagger(): Promise<void> {
-  const swagger = JSON.parse(await fs.promises.readFile(__dirname + "/../../../swagger.json", "utf8"));
-  TestValidator.equals("paths", swagger.paths ?? {}, {});
+  const swagger = JSON.parse(
+    await fs.promises.readFile(__dirname + "/../../../swagger.json", "utf8"),
+  );
+  TestValidator.equals("paths", Object.keys(swagger.paths ?? {}).sort(), [
+    "/swagger-visible-endpoint",
+  ]);
 }


### PR DESCRIPTION
Closes #1178.

## Summary
- filter `@ApiExcludeController()` and `@ApiExcludeEndpoint()` from Swagger document generation
- keep those routes in generated SDK output because the decorators are Swagger-only metadata
- extend the `swagger-hidden` fixture to cover controller exclusion, endpoint exclusion, and `ApiExcludeEndpoint(false)`

## Tests
- `pnpm --filter @nestia/sdk run build` with absolute `TTSC_GO_BINARY`
- generated `swagger-hidden` output manually inspected: Swagger contains only `/swagger-visible-endpoint`; SDK keeps the excluded routes

## Not Run
- full `swagger-hidden` runtime test on local Windows; after generation, `ttsx` failed with `ERR_UNSUPPORTED_ESM_URL_SCHEME` for a drive-letter loader path.