### PR TITLE
test(core): cover repeated TypedQuery arrays

### DIFF
--- a/tests/test-sdk/features/query/src/api/structures/IBusinessListingFilters.ts
+++ b/tests/test-sdk/features/query/src/api/structures/IBusinessListingFilters.ts
@@ -1,0 +1,9 @@
+import { tags } from "typia";
+
+export interface IBusinessListingFilters {
+  sellingType?: IBusinessListingFilters.SellingType[] & tags.MinItems<1>;
+}
+
+export namespace IBusinessListingFilters {
+  export type SellingType = "COMPANY" | "KENNITALA";
+}

--- a/tests/test-sdk/features/query/src/controllers/QueryController.ts
+++ b/tests/test-sdk/features/query/src/controllers/QueryController.ts
@@ -2,6 +2,7 @@ import { TypedQuery, TypedRoute } from "@nestia/core";
 import { Controller, Query } from "@nestjs/common";
 
 import { IBigQuery } from "@api/lib/structures/IBigQuery";
+import { IBusinessListingFilters } from "@api/lib/structures/IBusinessListingFilters";
 import { INestQuery } from "@api/lib/structures/INestQuery";
 import { IQuery } from "@api/lib/structures/IQuery";
 
@@ -10,6 +11,13 @@ export class QueryController {
   @TypedRoute.Get("typed")
   public async typed(@TypedQuery() query: IQuery): Promise<IQuery> {
     return query;
+  }
+
+  @TypedRoute.Get("typed-enum-array")
+  public async typedEnumArray(
+    @TypedQuery() filters: IBusinessListingFilters,
+  ): Promise<IBusinessListingFilters> {
+    return filters;
   }
 
   @TypedRoute.Get("nest")

--- a/tests/test-sdk/features/query/src/test/features/api/test_api_query_typed_repeated_enum_array.ts
+++ b/tests/test-sdk/features/query/src/test/features/api/test_api_query_typed_repeated_enum_array.ts
@@ -1,0 +1,30 @@
+import { TestValidator } from "@nestia/e2e";
+import typia from "typia";
+
+import api from "@api";
+import { IBusinessListingFilters } from "@api/lib/structures/IBusinessListingFilters";
+
+/**
+ * Verifies @TypedQuery preserves repeated enum-array query parameters.
+ *
+ * Locks the native HTTP query decoder branch that must call
+ * URLSearchParams.getAll for array DTO properties even when the array is
+ * intersected with typia tags. A regression would collapse repeated
+ * `sellingType` keys into only the first value and break multi-select filters.
+ *
+ * 1. Send a generated SDK request with two sellingType values.
+ * 2. Let @TypedQuery parse the repeated query keys into the tagged enum array.
+ * 3. Assert both values are returned as an array in request order.
+ */
+export const test_api_query_typed_repeated_enum_array = async (
+  connection: api.IConnection,
+): Promise<void> => {
+  const input: IBusinessListingFilters = {
+    sellingType: ["COMPANY", "KENNITALA"],
+  };
+  const result: IBusinessListingFilters =
+    await api.functional.query.typedEnumArray(connection, input);
+
+  typia.assertEquals(result);
+  TestValidator.equals("typed repeated enum array", input, result);
+};


### PR DESCRIPTION
## Summary
- add a query fixture matching #1404's enum-array DTO with typia MinItems tag
- assert generated SDK requests with repeated query keys round-trip through @TypedQuery as arrays

## Verification
- pnpm --filter @nestia/sdk run build

## Local gaps
- node tests/test-sdk/start.js --only query --concurrency 1 is blocked on Windows by native transform temp-path normalization and ttsx drive-letter URL handling; CI runs the feature on Ubuntu.

Closes #1404