### PR TITLE
fix(migrate): avoid API accessor shadowing

### DIFF
--- a/packages/migrate/src/NestiaMigrateApplication.ts
+++ b/packages/migrate/src/NestiaMigrateApplication.ts
@@ -1,5 +1,6 @@
 import {
   IHttpMigrateApplication,
+  IHttpMigrateRoute,
   OpenApi,
   OpenApiV3,
   OpenApiV3_1,
@@ -60,8 +61,7 @@ export class NestiaMigrateApplication {
         ),
       };
     } catch (exp) {
-      const message: string =
-        exp instanceof Error ? exp.message : String(exp);
+      const message: string = exp instanceof Error ? exp.message : String(exp);
       return {
         success: false,
         data: document,
@@ -144,14 +144,43 @@ const createContext = (
   application: IHttpMigrateApplication,
   config: INestiaMigrateConfig,
 ): INestiaMigrateContext => {
+  const routes: IHttpMigrateRoute[] = escapeConflictingAccessors(
+    application.routes
+      .filter((r) => r.method !== "query")
+      .map((r) => ({
+        ...r,
+        accessor: [...r.accessor],
+      })),
+  );
   return {
     mode,
     application: {
       ...application,
-      routes: application.routes.filter((r) => r.method !== "query"),
+      routes,
     },
     config,
   };
+};
+
+const escapeConflictingAccessors = (
+  routes: IHttpMigrateRoute[],
+): IHttpMigrateRoute[] => {
+  for (const route of routes)
+    while (true) {
+      const neighbor: IHttpMigrateRoute | undefined = routes.find(
+        (candidate) =>
+          candidate !== route &&
+          candidate.accessor.length < route.accessor.length &&
+          route.accessor
+            .slice(0, candidate.accessor.length)
+            .every((value, index) => value === candidate.accessor[index]),
+      );
+      if (neighbor === undefined) break;
+
+      const index: number = neighbor.accessor.length - 1;
+      route.accessor[index] = `_${route.accessor[index]}`;
+    }
+  return routes;
 };
 
 const renameSlug = (

--- a/tests/test-migrate/src/features/test_migrate_api_accessor_collision.ts
+++ b/tests/test-migrate/src/features/test_migrate_api_accessor_collision.ts
@@ -1,0 +1,73 @@
+import {
+  INestiaMigrateConfig,
+  NestiaMigrateApplication,
+} from "@nestia/migrate";
+import {
+  OpenApiV3,
+  OpenApiV3_1,
+  OpenApiV3_2,
+  SwaggerV2,
+} from "@typia/interface";
+
+type SwaggerDocument =
+  | SwaggerV2.IDocument
+  | OpenApiV3.IDocument
+  | OpenApiV3_1.IDocument
+  | OpenApiV3_2.IDocument;
+
+/**
+ * Verifies migrate SDK generation escapes function names that collide with
+ * child namespaces.
+ *
+ * Locks the final generator guard after the OpenAPI route accessor phase.
+ * Upstream accessors normally avoid prefix collisions, but custom accessors or
+ * future composer changes can still hand the migrate generator a shorter route
+ * whose function name matches a longer route's child namespace. Emitting both
+ * in the same index file creates duplicate exported bindings.
+ *
+ * 1. Build a migrate application from the fixture Swagger document.
+ * 2. Force two route accessors into a prefix collision.
+ * 3. Assert the generated SDK keeps the shorter function and escapes the child
+ *    namespace in functional files and e2e calls.
+ */
+export const test_migrate_api_accessor_collision = (
+  document: SwaggerDocument,
+): void => {
+  const app: NestiaMigrateApplication =
+    NestiaMigrateApplication.assert(document);
+  const routes = app
+    .getData()
+    .routes.filter((route) => route.method !== "query");
+  if (routes.length < 2)
+    throw new Error("Fixture must provide at least two migrate routes.");
+
+  routes[0]!.accessor = ["collision", "item"];
+  routes[1]!.accessor = ["collision", "item", "detail"];
+
+  const files: Record<string, string> = app.sdk({
+    keyword: true,
+    simulate: true,
+    e2e: true,
+    package: "fixture",
+  } satisfies INestiaMigrateConfig);
+  const root: string | undefined = files["src/functional/collision/index.ts"];
+  const child: string | undefined =
+    files["src/functional/collision/_item/index.ts"];
+  const nestedTest: string | undefined =
+    files["test/features/api/test_api_collision__item_detail.ts"];
+
+  if (root === undefined) throw new Error("Missing collision root API file.");
+  if (root.includes(`export async function item`) === false)
+    throw new Error("The shorter route function should keep its public name.");
+  if (root.includes(`export * as _item from "./_item/index";`) === false)
+    throw new Error(
+      "The child namespace should be escaped to avoid collision.",
+    );
+  if (root.includes(`export * as item from "./item/index";`))
+    throw new Error(
+      "The child namespace still collides with the route function.",
+    );
+  if (child === undefined) throw new Error("Missing escaped child API file.");
+  if (nestedTest?.includes("api.functional.collision._item.detail") !== true)
+    throw new Error("Generated e2e call did not follow the escaped accessor.");
+};

--- a/tests/test-migrate/src/index.ts
+++ b/tests/test-migrate/src/index.ts
@@ -14,6 +14,8 @@ import fs from "fs";
 import path from "path";
 import type { IValidation } from "typia";
 
+import { test_migrate_api_accessor_collision } from "./features/test_migrate_api_accessor_collision";
+
 const TEST_ROOT: string = process.cwd();
 const ROOT: string = path.resolve(TEST_ROOT, "../..");
 const FIXTURE: string = path.join(TEST_ROOT, "fixture");
@@ -79,10 +81,11 @@ const assertFixtureSwagger = (document: SwaggerDocument): void => {
   const text: string = JSON.stringify(document);
   const paths: string[] = Object.keys(current.paths ?? {});
   const operations: number = paths
-    .map((accessor) =>
-      Object.keys(current.paths?.[accessor] ?? {}).filter((method) =>
-        METHODS.has(method),
-      ).length,
+    .map(
+      (accessor) =>
+        Object.keys(current.paths?.[accessor] ?? {}).filter((method) =>
+          METHODS.has(method),
+        ).length,
     )
     .reduce((a, b) => a + b, 0);
   const schemas: number = Object.keys(current.components?.schemas ?? {}).length;
@@ -93,7 +96,8 @@ const assertFixtureSwagger = (document: SwaggerDocument): void => {
   const errors: string[] = [];
   if (current.openapi !== "3.1.0") errors.push("OpenAPI 3.1 fixture expected");
   if (paths.length < 7) errors.push("fixture must contain several paths");
-  if (operations < 10) errors.push("fixture must contain at least 10 operations");
+  if (operations < 10)
+    errors.push("fixture must contain at least 10 operations");
   if (schemas < 20) errors.push("fixture must contain rich schemas");
   if (text.includes('"oneOf"') === false)
     errors.push("fixture must contain union schemas");
@@ -200,6 +204,7 @@ const main = async (): Promise<void> => {
     if (filter(scenario.name) === false) continue;
     const document: SwaggerDocument = await readDocument(scenario.file);
     assertFixtureSwagger(document);
+    test_migrate_api_accessor_collision(document);
     for (const [mode, keyword] of [
       ["nest", true],
       ["nest", false],


### PR DESCRIPTION
## Summary
- clone and normalize migrate route accessors at context creation
- escape longer child namespace segments when a shorter route function would share the same exported binding
- add a test-migrate regression that forces a prefix accessor collision and checks functional/e2e output follows the escaped accessor

## Verification
- pnpm --filter @nestia/migrate run build
- pnpm exec ttsc --noEmit -p tests/test-migrate/tsconfig.json

## Local gaps
- pnpm --filter @nestia/test-migrate start is blocked locally on Windows by native transform temp-path normalization during fixture Swagger generation; CI runs the suite on Ubuntu.

Closes #1390