### PR TITLE
test(sdk): call generated query accessor

### DIFF
--- a/tests/test-sdk/features/query/src/test/features/api/test_api_query_typed_repeated_enum_array.ts
+++ b/tests/test-sdk/features/query/src/test/features/api/test_api_query_typed_repeated_enum_array.ts
@@ -23,7 +23,7 @@ export const test_api_query_typed_repeated_enum_array = async (
     sellingType: ["COMPANY", "KENNITALA"],
   };
   const result: IBusinessListingFilters =
-    await api.functional.query.typedEnumArray(connection, input);
+    await api.functional.query.typed_enum_array(connection, input);
 
   typia.assertEquals(result);
   TestValidator.equals("typed repeated enum array", input, result);


### PR DESCRIPTION
## Summary
- fix the repeated `@TypedQuery` regression test to call the generated snake_case SDK accessor
- restore the `tests/test-sdk` query feature type check after #1486

## Verification
- `git diff --check`
- `pnpm --filter @nestia/sdk run build`

## Notes
- Local `node tests/test-sdk/start.js --only query --concurrency 1` is still blocked on Windows by `spawn EINVAL` before feature execution. The failing CI log showed the generated export name as `typed_enum_array`, which this PR now uses.

Related: #1404