### PR TITLE
test(sdk): call query leaf accessor

### DIFF
--- a/tests/test-sdk/features/query/src/test/features/api/test_api_query_typed_repeated_enum_array.ts
+++ b/tests/test-sdk/features/query/src/test/features/api/test_api_query_typed_repeated_enum_array.ts
@@ -23,7 +23,10 @@ export const test_api_query_typed_repeated_enum_array = async (
     sellingType: ["COMPANY", "KENNITALA"],
   };
   const result: IBusinessListingFilters =
-    await api.functional.query.typed_enum_array(connection, input);
+    await api.functional.query.typed_enum_array.typedEnumArray(
+      connection,
+      input,
+    );
 
   typia.assertEquals(result);
   TestValidator.equals("typed repeated enum array", input, result);


### PR DESCRIPTION
## Summary
- call the generated `typed_enum_array.typedEnumArray` leaf function in the repeated query regression test
- fix the full `tests/test-sdk` query feature typecheck failure exposed by downstream CI

## Verification
- `git diff --check`
- `pnpm exec prettier --check tests/test-sdk/features/query/src/test/features/api/test_api_query_typed_repeated_enum_array.ts`
- `pnpm --filter @nestia/sdk run build`

## Notes
- Local `tests/test-sdk` query runtime remains blocked on Windows by `spawn EINVAL` before feature execution. The downstream CI log shows the generated `typed_enum_array` namespace and the lack of call signature; this PR calls the generated leaf function under that namespace.

Related: #1404