### PR TITLE
test(sdk): cover NestJS exception classes

### DIFF
--- a/packages/sdk/test/sdk_exception_metadata_inprocess_test.go
+++ b/packages/sdk/test/sdk_exception_metadata_inprocess_test.go
@@ -43,7 +43,8 @@ func TestSDKExceptionMetadataInProcess(t *testing.T) {
 		`"name":"TypeGuardErrorany"`,
 		`"value":"method"`,
 		`"value":"expected"`,
-		// The four named exception structures collected across decorators.
+		// The named exception structures collected across decorators.
+		`"name":"BadRequestException"`,
 		`"name":"INotFound"`,
 		`"name":"IUnprocessibleEntity"`,
 		`"name":"IInternalServerError"`,

--- a/tests/test-sdk/features/exception/src/controllers/ExceptionController.ts
+++ b/tests/test-sdk/features/exception/src/controllers/ExceptionController.ts
@@ -4,7 +4,7 @@ import {
   TypedParam,
   TypedRoute,
 } from "@nestia/core";
-import { Controller } from "@nestjs/common";
+import { BadRequestException, Controller } from "@nestjs/common";
 import typia, { TypeGuardError } from "typia";
 
 import { IBbsArticle } from "@api/lib/structures/IBbsArticle";
@@ -75,6 +75,15 @@ export class ExceptionController {
   ): Promise<IBbsArticle | INotFound | IUnprocessibleEntity> {
     section;
     return typia.random<IBbsArticle | INotFound | IUnprocessibleEntity>();
+  }
+
+  @TypedRoute.Get("nestjs-bad-request")
+  @TypedException<BadRequestException>({
+    status: 400,
+    description: "invalid parameter provided",
+  })
+  public async nestjs_bad_request(): Promise<string> {
+    return "ok";
   }
 
   /**

--- a/tests/test-sdk/features/exception/src/test/features/test_swagger.ts
+++ b/tests/test-sdk/features/exception/src/test/features/test_swagger.ts
@@ -49,6 +49,19 @@ export const test_swagger = async () => {
       ],
     },
   );
+  TestValidator.equals(
+    "nestjs bad request description",
+    content.paths["/exception/nestjs-bad-request"].get.responses[400]
+      .description,
+    "invalid parameter provided",
+  );
+  TestValidator.equals(
+    "nestjs bad request schema",
+    content.paths["/exception/nestjs-bad-request"].get.responses[400].content[
+      "application/json"
+    ].schema.$ref,
+    "#/components/schemas/BadRequestException",
+  );
 
   TestValidator.equals(
     "examples",


### PR DESCRIPTION
## Summary
- add an exception fixture route using `@TypedException<BadRequestException>` from `@nestjs/common`
- assert Swagger emits the 400 response description and `BadRequestException` schema reference
- extend the SDK native metadata in-process test to require the imported NestJS exception class metadata

## Verification
- `pnpm --filter @nestia/sdk run build`
- `go test ./... -run TestSDKExceptionMetadataInProcess -count=1` from `packages/sdk/test`
- `git diff --check`

## Notes
- Local full `tests/test-sdk` runtime remains blocked by Windows test runner/native path issues, so CI is the authoritative full-suite verification.

Related: #1186