### PR TITLE
feat(sdk): support Observable route returns

### DIFF
--- a/packages/core/native/transform/core_transform.go
+++ b/packages/core/native/transform/core_transform.go
@@ -1513,6 +1513,9 @@ func cleanupNestiaCorePrintedExpression(text string) string {
 var nestiaCoreSingleParameterArrowPattern = regexp.MustCompile(`(^|[\s(=,:?])([A-Za-z_$][A-Za-z0-9_$]*) =>`)
 
 func NestiaCoreMethodReturnType(prog *driver.Program, node *shimast.Node) *shimchecker.Type {
+	if typ := nestiaCoreExplicitAsyncReturnType(prog, node); typ != nil {
+		return typ
+	}
 	signature := prog.Checker.GetSignatureFromDeclaration(node)
 	if signature == nil {
 		return nil
@@ -1522,13 +1525,50 @@ func NestiaCoreMethodReturnType(prog *driver.Program, node *shimast.Node) *shimc
 		return nil
 	}
 	symbol := typ.Symbol()
-	if symbol != nil && symbol.Name == "Promise" {
+	if symbol != nil && nestiaCoreIsAsyncReturnWrapper(symbol.Name) {
 		args := prog.Checker.GetTypeArguments(typ)
 		if len(args) == 1 {
 			return args[0]
 		}
 	}
 	return typ
+}
+
+func nestiaCoreExplicitAsyncReturnType(prog *driver.Program, node *shimast.Node) *shimchecker.Type {
+	if prog == nil || prog.Checker == nil || node == nil || node.FunctionLikeData() == nil {
+		return nil
+	}
+	typeNode := node.FunctionLikeData().Type
+	if typeNode == nil || typeNode.Kind != shimast.KindTypeReference {
+		return nil
+	}
+	ref := typeNode.AsTypeReferenceNode()
+	if ref == nil || ref.TypeArguments == nil || len(ref.TypeArguments.Nodes) != 1 {
+		return nil
+	}
+	if nestiaCoreIsAsyncReturnWrapper(nestiaCoreTypeNodeText(ref.TypeName)) == false {
+		return nil
+	}
+	return prog.Checker.GetTypeFromTypeNode(ref.TypeArguments.Nodes[0])
+}
+
+func nestiaCoreIsAsyncReturnWrapper(name string) bool {
+	return name == "Promise" || name == "Observable"
+}
+
+func nestiaCoreTypeNodeText(node *shimast.Node) string {
+	if node == nil {
+		return ""
+	}
+	source, ok := SourceFileText(shimast.GetSourceFileOfNode(node))
+	if ok == false {
+		return ""
+	}
+	start, end := node.Pos(), node.End()
+	if start < 0 || end > len(source) || start >= end {
+		return ""
+	}
+	return strings.TrimSpace(source[start:end])
 }
 
 func nestiaCoreShouldSkipMethodDecorator(prog *driver.Program, call *shimast.CallExpression) bool {

--- a/packages/core/test/method_return_type_observable_test.go
+++ b/packages/core/test/method_return_type_observable_test.go
@@ -1,0 +1,92 @@
+package test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	shimast "github.com/microsoft/typescript-go/shim/ast"
+	"github.com/samchon/nestia/packages/core/native/transform"
+	"github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestMethodReturnTypeObservable verifies Observable<T> return types unwrap to
+// their payload type.
+//
+// Locks NestJS Observable route support in the native return-type helper. The
+// SDK and core transforms both consume this helper; if it treats Observable<T>
+// as the response object itself, generated SDK clients lose the controller
+// payload type and Swagger metadata points at the wrapper instead.
+//
+//  1. Load a temporary controller method returning Observable<{ foo: string }>.
+//  2. Resolve the method's return type through NestiaCoreMethodReturnType.
+//  3. Assert the resolved type is the payload rather than Observable<T>.
+func TestMethodReturnTypeObservable(t *testing.T) {
+	temp := t.TempDir()
+	writeFile(t, filepath.Join(temp, "tsconfig.json"), `{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "strict": true
+  },
+  "include": ["controller.ts"]
+}`)
+	writeFile(t, filepath.Join(temp, "controller.ts"), `
+type Observable<T> = { subscribe(): T };
+
+class ReproController {
+  public observable(): Observable<{ foo: string; bar?: number }> {
+    return null as any;
+  }
+}
+`)
+
+	prog, diags, err := driver.LoadProgram(temp, "tsconfig.json", driver.LoadProgramOptions{ForceNoEmit: true})
+	if err != nil {
+		t.Fatalf("LoadProgram failed: %v", err)
+	}
+	if len(diags) > 0 {
+		t.Fatalf("LoadProgram produced %d config diagnostics", len(diags))
+	}
+	defer prog.Close()
+
+	source := prog.SourceFile(filepath.ToSlash(filepath.Join(temp, "controller.ts")))
+	if source == nil {
+		t.Fatal("controller.ts not in program")
+	}
+
+	var method *shimast.Node
+	var walk func(node *shimast.Node)
+	walk = func(node *shimast.Node) {
+		if node == nil || method != nil {
+			return
+		}
+		if node.Kind == shimast.KindMethodDeclaration && transform.NodeName(node) == "observable" {
+			method = node
+			return
+		}
+		node.ForEachChild(func(child *shimast.Node) bool {
+			walk(child)
+			return method != nil
+		})
+	}
+	walk(source.AsNode())
+	if method == nil {
+		t.Fatal("observable method was not visited")
+	}
+
+	typ := transform.NestiaCoreMethodReturnType(prog, method)
+	if typ == nil {
+		t.Fatal("observable return type was not resolved")
+	}
+	text := prog.Checker.TypeToString(typ)
+	if text == "Observable<{ foo: string; bar?: number | undefined; }>" {
+		t.Fatalf("Observable wrapper was not unwrapped: %s", text)
+	}
+	if text == "Observable<{ foo: string; bar?: number; }>" {
+		t.Fatalf("Observable wrapper was not unwrapped: %s", text)
+	}
+	if strings.Contains(text, "foo") == false {
+		t.Fatalf("observable payload field was not preserved: %s", text)
+	}
+}

--- a/packages/sdk/native/sdk/sdk_transform.go
+++ b/packages/sdk/native/sdk/sdk_transform.go
@@ -1153,11 +1153,11 @@ func nestiaSDKReflectTypeNode(
 		ref := node.AsTypeReferenceNode()
 		name := nestiaSDKEntityNameText(ref.TypeName)
 		rootRefs := nestiaSDKReflectImports(name, imports)
-		if len(rootRefs) == 0 && name != "Promise" {
+		if len(rootRefs) == 0 && nestiaSDKIsAsyncReturnWrapper(name) == false {
 			rootRefs = nestiaSDKReflectTypeReferenceSymbolImport(prog, ref.TypeName, name)
 		}
 		if ref.TypeArguments != nil && len(ref.TypeArguments.Nodes) != 0 {
-			if name == "Promise" && len(ref.TypeArguments.Nodes) == 1 {
+			if nestiaSDKIsAsyncReturnWrapper(name) && len(ref.TypeArguments.Nodes) == 1 {
 				return nestiaSDKReflectTypeNode(prog, imports, ref.TypeArguments.Nodes[0])
 			}
 			args := make([]any, 0, len(ref.TypeArguments.Nodes))
@@ -1354,7 +1354,7 @@ func nestiaSDKMethodReturnTypeNode(method *shimast.Node) *shimast.Node {
 func nestiaSDKReturnTypeNode(node *shimast.Node) *shimast.Node {
 	if node != nil && node.Kind == shimast.KindTypeReference {
 		ref := node.AsTypeReferenceNode()
-		if ref != nil && ref.TypeArguments != nil && len(ref.TypeArguments.Nodes) == 1 && nestiaSDKEntityNameText(ref.TypeName) == "Promise" {
+		if ref != nil && ref.TypeArguments != nil && len(ref.TypeArguments.Nodes) == 1 && nestiaSDKIsAsyncReturnWrapper(nestiaSDKEntityNameText(ref.TypeName)) {
 			return ref.TypeArguments.Nodes[0]
 		}
 	}
@@ -1369,11 +1369,15 @@ func nestiaSDKReturnTypeNodeText(node *shimast.Node) string {
 	text := nestiaSDKTypeNodeText(node)
 	if node != nil && node.Kind == shimast.KindTypeReference {
 		ref := node.AsTypeReferenceNode()
-		if ref != nil && ref.TypeArguments != nil && len(ref.TypeArguments.Nodes) == 1 && strings.HasPrefix(strings.TrimSpace(text), "Promise<") {
+		if ref != nil && ref.TypeArguments != nil && len(ref.TypeArguments.Nodes) == 1 && nestiaSDKIsAsyncReturnWrapper(nestiaSDKEntityNameText(ref.TypeName)) {
 			return nestiaSDKTypeNodeText(ref.TypeArguments.Nodes[0])
 		}
 	}
 	return text
+}
+
+func nestiaSDKIsAsyncReturnWrapper(name string) bool {
+	return name == "Promise" || name == "Observable"
 }
 
 func nestiaSDKTypeNodeText(node *shimast.Node) string {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ catalogs:
     '@nestjs/platform-fastify':
       specifier: ^11.1.6
       version: 11.1.21
+    rxjs:
+      specifier: ^7.1.0
+      version: 7.8.2
   rollup:
     '@rollup/plugin-commonjs':
       specifier: ^29.0.0
@@ -788,6 +791,9 @@ importers:
       multer:
         specifier: ^2.0.2
         version: 2.1.1
+      rxjs:
+        specifier: catalog:nestjs
+        version: 7.8.2
       tgrid:
         specifier: catalog:samchon
         version: 1.2.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,7 @@ catalogs:
     '@nestjs/core': ^11.1.6
     '@nestjs/platform-express': ^11.1.6
     '@nestjs/platform-fastify': ^11.1.6
+    rxjs: ^7.1.0
   samchon:
     '@typia/interface': 13.0.0-dev.20260605.1
     '@typia/utils': 13.0.0-dev.20260605.1

--- a/tests/test-sdk/features/route/src/controllers/TypedRouteController.ts
+++ b/tests/test-sdk/features/route/src/controllers/TypedRouteController.ts
@@ -1,8 +1,17 @@
 import core from "@nestia/core";
 import { Controller } from "@nestjs/common";
+import { Observable, of } from "rxjs";
 import typia from "typia";
 
 import { IBbsArticle } from "@api/lib/structures/IBbsArticle";
+
+const createArticle = (): IBbsArticle => ({
+  id: "00000000-0000-4000-8000-000000000000" as IBbsArticle["id"],
+  title: "Observable route article" as IBbsArticle["title"],
+  body: "Observable routes should expose their payload type to generated SDKs.",
+  files: [],
+  created_at: "2026-06-11T00:00:00.000Z" as IBbsArticle["created_at"],
+});
 
 @Controller("route")
 export class TypedRouteController {
@@ -14,5 +23,10 @@ export class TypedRouteController {
         dummy: 1,
       },
     };
+  }
+
+  @core.TypedRoute.Get("observable")
+  public observable(): Observable<IBbsArticle> {
+    return of(createArticle());
   }
 }

--- a/tests/test-sdk/features/route/src/test/features/api/test_api_route_observable.ts
+++ b/tests/test-sdk/features/route/src/test/features/api/test_api_route_observable.ts
@@ -1,0 +1,25 @@
+import typia from "typia";
+
+import api from "@api";
+import { IBbsArticle } from "@api/lib/structures/IBbsArticle";
+
+/**
+ * Verifies Observable<T> controller returns generate SDK output as T.
+ *
+ * Locks the native return-type unwrap branch shared by Swagger metadata and
+ * generated SDK aliases. NestJS treats Observable<T> as an asynchronous route
+ * response just like Promise<T>; a regression would emit Promise<void> or an
+ * Observable-shaped schema instead of the resolved article type.
+ *
+ * 1. Call a controller method that returns Observable<IBbsArticle>.
+ * 2. Assign the generated SDK result to IBbsArticle.
+ * 3. Assert the runtime payload satisfies the article structure.
+ */
+export const test_api_route_observable = async (
+  connection: api.IConnection,
+): Promise<void> => {
+  const article: IBbsArticle =
+    await api.functional.route.observable(connection);
+
+  typia.assertEquals(article);
+};

--- a/tests/test-sdk/package.json
+++ b/tests/test-sdk/package.json
@@ -21,6 +21,7 @@
     "fastify": "^4.0.0",
     "fastify-multer": "^2.0.3",
     "multer": "^2.0.2",
+    "rxjs": "catalog:nestjs",
     "tgrid": "catalog:samchon",
     "tstl": "catalog:samchon",
     "typia": "catalog:samchon",


### PR DESCRIPTION
## Summary
- unwrap explicit `Observable<T>` route return annotations in the native core return-type helper
- mirror Promise/Observable unwrapping in SDK type-node reflection helpers
- add Go and test-sdk route regression coverage for generated SDK payload typing

## Verification
- `go test ./... -run TestMethodReturnTypeObservable -count=1` from `packages/core/test`
- `pnpm --filter @nestia/sdk run build`
- `pnpm exec prettier --check tests/test-sdk/features/route/src/controllers/TypedRouteController.ts tests/test-sdk/features/route/src/test/features/api/test_api_route_observable.ts`
- `git diff --check`

## Notes
- Local `tests/test-sdk` route runtime is blocked on Windows by `spawn EINVAL` before feature execution. CI should run the Linux fixture suite.

Fixes #747