### PR TITLE
ci: run checks for native and fixtures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/build.yml'
+      - 'packages/*/native/**'
       - 'packages/*/src/**'
       - 'packages/*/package.json'
       - 'packages/*/tsconfig.json'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,12 @@ on:
   pull_request:
     paths:
       - '.github/workflows/test.yml'
+      - 'packages/*/native/**'
       - 'packages/*/src/**'
+      - 'packages/*/test/**'
       - 'packages/*/package.json'
       - 'packages/*/tsconfig.json'
+      - 'tests/test-*/**'
       - 'tests/*/src/**'
       - 'tests/*/tsconfig.json'
       - 'tests/*/package.json'


### PR DESCRIPTION
## Summary
- include `packages/*/native/**` in build/test pull_request path filters
- include `packages/*/test/**` and nested `tests/test-*` workspaces in the test workflow path filter
- ensure native transform and test fixture PRs create the expected CI jobs instead of only website/spell checks

## Verification
- `git diff --check`

## Notes
- This was discovered while preparing #1492: native and nested test-sdk fixture changes did not trigger the full test workflow.