### PR TITLE
fix(sdk): expose readonly array OpenAPI extension

### DIFF
--- a/packages/sdk/native/sdk/sdk_transform.go
+++ b/packages/sdk/native/sdk/sdk_transform.go
@@ -17,6 +17,7 @@ import (
 	"github.com/samchon/ttsc/packages/ttsc/driver"
 	nativecontext "github.com/samchon/typia/packages/typia/native/core/context"
 	nativefactories "github.com/samchon/typia/packages/typia/native/core/factories"
+	nativeiterate "github.com/samchon/typia/packages/typia/native/core/programmers/iterate"
 	nativejson "github.com/samchon/typia/packages/typia/native/core/programmers/json"
 	schemametadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
 )
@@ -704,7 +705,7 @@ func nestiaSDKSchemaPipe(context *nestiaSDKContext, typ *shimchecker.Type, typeN
 	// and omit the field — the sdk generator falls back to its own derived
 	// schema path. This must never mask a real bug, so re-raise anything we
 	// don't recognize as a transformer error from the typia runtime.
-	if baked := nestiaSDKTryBakeJsonSchema(result.Data); baked != nil {
+	if baked := nestiaSDKTryBakeJsonSchema(prog, typeNode, result.Data); baked != nil {
 		metadataLiteral["jsonSchema"] = baked
 	}
 	value := map[string]any{
@@ -723,7 +724,11 @@ func nestiaSDKSchemaPipe(context *nestiaSDKContext, typ *shimchecker.Type, typeN
 // when typia signals the metadata has no JSON-schema representation (e.g.
 // `void` returns, function-only types) — the JS-side reader handles missing
 // `jsonSchema` fields. Any other panic is re-raised so real bugs surface.
-func nestiaSDKTryBakeJsonSchema(metadata *schemametadata.MetadataSchema) (baked map[string]any) {
+func nestiaSDKTryBakeJsonSchema(
+	prog *driver.Program,
+	typeNode *shimast.Node,
+	metadata *schemametadata.MetadataSchema,
+) (baked map[string]any) {
 	defer func() {
 		if r := recover(); r != nil {
 			if _, ok := r.(*nativecontext.TransformerError); ok {
@@ -754,11 +759,262 @@ func nestiaSDKTryBakeJsonSchema(metadata *schemametadata.MetadataSchema) (baked 
 		}
 		componentsLiteral["schemas"] = schemasLiteral
 	}
-	return map[string]any{
+	baked = map[string]any{
 		"version":    collection.Version,
 		"components": componentsLiteral,
 		"schema":     map[string]any(collection.Schemas[0]),
 	}
+	nestiaSDKMarkReadonlyArrayJsonSchema(prog, typeNode, baked)
+	return baked
+}
+
+func nestiaSDKMarkReadonlyArrayJsonSchema(prog *driver.Program, typeNode *shimast.Node, baked map[string]any) {
+	components, _ := baked["components"].(map[string]any)
+	schemas, _ := components["schemas"].(map[string]any)
+	schema := nestiaSDKSchemaMap(baked["schema"])
+	nestiaSDKMarkReadonlyArraySchemaNode(
+		prog,
+		typeNode,
+		schema,
+		schemas,
+		map[*shimast.Node]bool{},
+	)
+}
+
+func nestiaSDKMarkReadonlyArraySchemaNode(
+	prog *driver.Program,
+	typeNode *shimast.Node,
+	schema map[string]any,
+	components map[string]any,
+	visiting map[*shimast.Node]bool,
+) {
+	if typeNode == nil || schema == nil {
+		return
+	}
+	if visiting[typeNode] {
+		return
+	}
+	visiting[typeNode] = true
+	defer delete(visiting, typeNode)
+
+	switch typeNode.Kind {
+	case shimast.KindArrayType:
+		child := nestiaSDKSchemaMap(schema["items"])
+		nestiaSDKMarkReadonlyArraySchemaNode(
+			prog,
+			typeNode.AsArrayTypeNode().ElementType,
+			child,
+			components,
+			visiting,
+		)
+	case shimast.KindTupleType:
+		tuple := typeNode.AsTupleTypeNode()
+		items := nestiaSDKSchemaList(schema["prefixItems"])
+		if tuple.Elements != nil {
+			for i, elem := range tuple.Elements.Nodes {
+				if i >= len(items) {
+					break
+				}
+				child := nestiaSDKSchemaMap(items[i])
+				nestiaSDKMarkReadonlyArraySchemaNode(prog, elem, child, components, visiting)
+			}
+		}
+	case shimast.KindParenthesizedType:
+		nestiaSDKMarkReadonlyArraySchemaNode(
+			prog,
+			typeNode.AsParenthesizedTypeNode().Type,
+			schema,
+			components,
+			visiting,
+		)
+	case shimast.KindTypeOperator:
+		operator := typeNode.AsTypeOperatorNode()
+		if nestiaSDKTypeOperatorPrefix(typeNode, operator.Type) == "readonly" &&
+			nestiaSDKReadonlyArrayOperand(operator.Type) {
+			schema["x-readonly-array"] = true
+		}
+		nestiaSDKMarkReadonlyArraySchemaNode(
+			prog,
+			operator.Type,
+			schema,
+			components,
+			visiting,
+		)
+	case shimast.KindTypeReference:
+		nestiaSDKMarkReadonlyArrayTypeReference(
+			prog,
+			typeNode,
+			schema,
+			components,
+			visiting,
+		)
+	case shimast.KindTypeLiteral:
+		nestiaSDKMarkReadonlyArrayTypeElements(
+			prog,
+			typeNode.AsTypeLiteralNode().Members,
+			schema,
+			components,
+			visiting,
+		)
+	}
+}
+
+func nestiaSDKMarkReadonlyArrayTypeReference(
+	prog *driver.Program,
+	typeNode *shimast.Node,
+	schema map[string]any,
+	components map[string]any,
+	visiting map[*shimast.Node]bool,
+) {
+	ref := typeNode.AsTypeReferenceNode()
+	name := nestiaSDKEntityNameText(ref.TypeName)
+	if name == "ReadonlyArray" {
+		schema["x-readonly-array"] = true
+	}
+	if (name == "Array" || name == "ReadonlyArray") && ref.TypeArguments != nil &&
+		len(ref.TypeArguments.Nodes) != 0 {
+		child := nestiaSDKSchemaMap(schema["items"])
+		nestiaSDKMarkReadonlyArraySchemaNode(
+			prog,
+			ref.TypeArguments.Nodes[0],
+			child,
+			components,
+			visiting,
+		)
+	}
+	for _, decl := range nestiaSDKTypeReferenceDeclarations(prog, ref.TypeName) {
+		switch decl.Kind {
+		case shimast.KindInterfaceDeclaration:
+			target := nestiaSDKReferencedSchema(schema, components, name)
+			nestiaSDKMarkReadonlyArrayTypeElements(
+				prog,
+				decl.AsInterfaceDeclaration().Members,
+				target,
+				components,
+				visiting,
+			)
+		case shimast.KindTypeAliasDeclaration:
+			target := nestiaSDKReferencedSchema(schema, components, name)
+			nestiaSDKMarkReadonlyArraySchemaNode(
+				prog,
+				decl.AsTypeAliasDeclaration().Type,
+				target,
+				components,
+				visiting,
+			)
+		}
+	}
+}
+
+func nestiaSDKMarkReadonlyArrayTypeElements(
+	prog *driver.Program,
+	members *shimast.TypeElementList,
+	schema map[string]any,
+	components map[string]any,
+	visiting map[*shimast.Node]bool,
+) {
+	if members == nil || schema == nil {
+		return
+	}
+	properties := nestiaSDKSchemaMap(schema["properties"])
+	if properties == nil {
+		return
+	}
+	for _, member := range members.Nodes {
+		if member == nil || member.Kind != shimast.KindPropertySignature {
+			continue
+		}
+		property := member.AsPropertySignatureDeclaration()
+		name := nestiaSDKSchemaPropertyName(property.Name())
+		child := nestiaSDKSchemaMap(properties[name])
+		nestiaSDKMarkReadonlyArraySchemaNode(
+			prog,
+			property.Type,
+			child,
+			components,
+			visiting,
+		)
+	}
+}
+
+func nestiaSDKTypeReferenceDeclarations(prog *driver.Program, node *shimast.Node) []*shimast.Node {
+	if prog == nil || prog.Checker == nil || node == nil {
+		return nil
+	}
+	symbol := prog.Checker.GetSymbolAtLocation(node)
+	if symbol == nil {
+		typ := prog.Checker.GetTypeFromTypeNode(node)
+		if typ != nil {
+			symbol = typ.Symbol()
+		}
+	}
+	if symbol == nil {
+		return nil
+	}
+	return symbol.Declarations
+}
+
+func nestiaSDKReferencedSchema(schema map[string]any, components map[string]any, name string) map[string]any {
+	ref, _ := schema["$ref"].(string)
+	if ref == "" {
+		return schema
+	}
+	const prefix = "#/components/schemas/"
+	if strings.HasPrefix(ref, prefix) {
+		name = strings.TrimPrefix(ref, prefix)
+	}
+	target := nestiaSDKSchemaMap(components[name])
+	if target != nil {
+		return target
+	}
+	return schema
+}
+
+func nestiaSDKSchemaMap(input any) map[string]any {
+	switch value := input.(type) {
+	case map[string]any:
+		return value
+	case nativeiterate.JsonSchema:
+		return map[string]any(value)
+	default:
+		return nil
+	}
+}
+
+func nestiaSDKSchemaList(input any) []any {
+	switch value := input.(type) {
+	case []any:
+		return value
+	case []nativeiterate.JsonSchema:
+		output := make([]any, len(value))
+		for i, elem := range value {
+			output[i] = elem
+		}
+		return output
+	default:
+		return nil
+	}
+}
+
+func nestiaSDKReadonlyArrayOperand(node *shimast.Node) bool {
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case shimast.KindArrayType, shimast.KindTupleType:
+		return true
+	case shimast.KindTypeReference:
+		return nestiaSDKEntityNameText(node.AsTypeReferenceNode().TypeName) == "Array"
+	case shimast.KindParenthesizedType:
+		return nestiaSDKReadonlyArrayOperand(node.AsParenthesizedTypeNode().Type)
+	default:
+		return false
+	}
+}
+
+func nestiaSDKSchemaPropertyName(node *shimast.Node) string {
+	text := nestiaSDKTypeNodeText(node)
+	return strings.Trim(text, "\"'")
 }
 
 func nestiaSDKRestoreUnionOrder(typeNode *shimast.Node, metadata *schemametadata.MetadataSchema) {

--- a/packages/sdk/src/generates/SwaggerGenerator.ts
+++ b/packages/sdk/src/generates/SwaggerGenerator.ts
@@ -23,6 +23,7 @@ import { ITypedHttpRoute } from "../structures/ITypedHttpRoute";
 import { FileRetriever } from "../utils/FileRetriever";
 import { SdkHttpParameterProgrammer } from "./internal/SdkHttpParameterProgrammer";
 import { SwaggerOperationComposer } from "./internal/SwaggerOperationComposer";
+import { SwaggerReadonlyArrayEmender } from "./internal/SwaggerReadonlyArrayEmender";
 
 export namespace SwaggerGenerator {
   export const generate = async (app: ITypedApplication): Promise<void> => {
@@ -101,6 +102,13 @@ export namespace SwaggerGenerator {
       version: "3.1",
       metadatas,
     });
+    json.schemas.forEach((schema, i) =>
+      SwaggerReadonlyArrayEmender.emend({
+        components: json.components,
+        schema,
+        metadata: metadatas[i]!,
+      }),
+    );
     const dict: WeakMap<MetadataSchema, OpenApi.IJsonSchema> = new WeakMap();
     json.schemas.forEach((schema, i) => dict.set(metadatas[i]!, schema));
     const schema = (

--- a/packages/sdk/src/generates/internal/SwaggerOperationParameterComposer.ts
+++ b/packages/sdk/src/generates/internal/SwaggerOperationParameterComposer.ts
@@ -1,11 +1,15 @@
-import { JsonSchemasProgrammer, MetadataObjectType } from "../../internal/legacy";
 import { OpenApi } from "@typia/interface";
 import { VariadicSingleton } from "tstl";
 import { IJsDocTagInfo, IJsonSchemaCollection } from "typia";
 
 import { INestiaConfig } from "../../INestiaConfig";
+import {
+  JsonSchemasProgrammer,
+  MetadataObjectType,
+} from "../../internal/legacy";
 import { ITypedHttpRouteParameter } from "../../structures/ITypedHttpRouteParameter";
 import { SwaggerDescriptionComposer } from "./SwaggerDescriptionComposer";
+import { SwaggerReadonlyArrayEmender } from "./SwaggerReadonlyArrayEmender";
 
 export namespace SwaggerOperationParameterComposer {
   export interface IProps<Parameter extends ITypedHttpRouteParameter> {
@@ -112,35 +116,44 @@ export namespace SwaggerOperationParameterComposer {
       props.parameter.metadata.objects.length === 0
     )
       return [param];
-    return (props.parameter.metadata.objects[0]!.type as MetadataObjectType).properties.filter((p) =>
-      p.jsDocTags.every(
-        (tag) => tag.name !== "hidden" && tag.name !== "ignore",
-      ),
-    ).map((p) => {
-      const json: IJsonSchemaCollection = JsonSchemasProgrammer.writeSchemas({
-        version: "3.1",
-        metadatas: [p.value],
-      }) as IJsonSchemaCollection;
-      if (Object.keys(json.components.schemas ?? {}).length !== 0) {
-        props.document.components ??= {};
-        props.document.components.schemas ??= {};
-        Object.assign(
-          props.document.components.schemas,
-          json.components.schemas,
-        );
-      }
-      return {
-        name: p.key.constants[0]!.values[0]!.value as string,
-        in: props.parameter.category === "query" ? "query" : "header",
-        schema: json.schemas[0]!,
-        required: p.value.required,
-        description: SwaggerDescriptionComposer.compose({
-          description: p.description ?? null,
-          jsDocTags: p.jsDocTags,
-          kind: "title",
-        }).description,
-      };
-    });
+    return (
+      props.parameter.metadata.objects[0]!.type as MetadataObjectType
+    ).properties
+      .filter((p) =>
+        p.jsDocTags.every(
+          (tag) => tag.name !== "hidden" && tag.name !== "ignore",
+        ),
+      )
+      .map((p) => {
+        const json: IJsonSchemaCollection = JsonSchemasProgrammer.writeSchemas({
+          version: "3.1",
+          metadatas: [p.value],
+        }) as IJsonSchemaCollection;
+        SwaggerReadonlyArrayEmender.emend({
+          components: json.components,
+          schema: json.schemas[0],
+          metadata: p.value,
+        });
+        if (Object.keys(json.components.schemas ?? {}).length !== 0) {
+          props.document.components ??= {};
+          props.document.components.schemas ??= {};
+          Object.assign(
+            props.document.components.schemas,
+            json.components.schemas,
+          );
+        }
+        return {
+          name: p.key.constants[0]!.values[0]!.value as string,
+          in: props.parameter.category === "query" ? "query" : "header",
+          schema: json.schemas[0]!,
+          required: p.value.required,
+          description: SwaggerDescriptionComposer.compose({
+            description: p.description ?? null,
+            jsDocTags: p.jsDocTags,
+            kind: "title",
+          }).description,
+        };
+      });
   };
 }
 

--- a/packages/sdk/src/generates/internal/SwaggerReadonlyArrayEmender.ts
+++ b/packages/sdk/src/generates/internal/SwaggerReadonlyArrayEmender.ts
@@ -1,0 +1,262 @@
+import { OpenApi } from "@typia/interface";
+
+import {
+  MetadataAliasType,
+  MetadataArrayType,
+  MetadataObjectType,
+  MetadataSchema,
+  MetadataTupleType,
+} from "../../internal/legacy";
+
+type JsonSchemaObject = OpenApi.IJsonSchema & Record<string, any>;
+
+export namespace SwaggerReadonlyArrayEmender {
+  export const emend = (props: {
+    components: OpenApi.IComponents;
+    schema: OpenApi.IJsonSchema | undefined;
+    metadata: MetadataSchema;
+  }): void => {
+    const visited: IVisited = {
+      aliases: new WeakSet(),
+      arrays: new WeakSet(),
+      objects: new WeakSet(),
+      schemas: new WeakSet(),
+      tuples: new WeakSet(),
+    };
+    visitMetadata({
+      components: props.components,
+      schema: props.schema,
+      metadata: props.metadata,
+      visited,
+    });
+  };
+}
+
+interface IVisited {
+  aliases: WeakSet<MetadataAliasType>;
+  arrays: WeakSet<MetadataArrayType>;
+  objects: WeakSet<MetadataObjectType>;
+  schemas: WeakSet<MetadataSchema>;
+  tuples: WeakSet<MetadataTupleType>;
+}
+
+const visitMetadata = (props: {
+  components: OpenApi.IComponents;
+  schema: OpenApi.IJsonSchema | undefined;
+  metadata: MetadataSchema;
+  visited: IVisited;
+}): void => {
+  if (props.schema !== undefined && isReadonlyArrayLike(props.metadata))
+    setReadonlyArray(props.schema);
+
+  if (props.visited.schemas.has(props.metadata)) return;
+  props.visited.schemas.add(props.metadata);
+
+  for (const array of props.metadata.arrays) {
+    const type: MetadataArrayType | undefined = array.type as
+      | MetadataArrayType
+      | undefined;
+    if (type !== undefined)
+      visitArrayType({
+        components: props.components,
+        schema: arraySchema(props.schema),
+        type,
+        visited: props.visited,
+      });
+  }
+  for (const tuple of props.metadata.tuples) {
+    const type: MetadataTupleType | undefined = tuple.type as
+      | MetadataTupleType
+      | undefined;
+    if (type !== undefined)
+      visitTupleType({
+        components: props.components,
+        schema: props.schema,
+        type,
+        visited: props.visited,
+      });
+  }
+  for (const alias of props.metadata.aliases) {
+    const type: MetadataAliasType | undefined = alias.type as
+      | MetadataAliasType
+      | undefined;
+    if (type !== undefined)
+      visitAliasType({
+        components: props.components,
+        schema: componentSchema(props.components, type.name),
+        type,
+        visited: props.visited,
+      });
+  }
+  for (const object of props.metadata.objects) {
+    const type: MetadataObjectType | undefined = object.type as
+      | MetadataObjectType
+      | undefined;
+    if (type !== undefined)
+      visitObjectType({
+        components: props.components,
+        type,
+        visited: props.visited,
+      });
+  }
+};
+
+const visitAliasType = (props: {
+  components: OpenApi.IComponents;
+  schema: OpenApi.IJsonSchema | undefined;
+  type: MetadataAliasType;
+  visited: IVisited;
+}): void => {
+  if (props.visited.aliases.has(props.type)) return;
+  props.visited.aliases.add(props.type);
+  if (props.schema !== undefined && isReadonlyArrayLike(props.type.value))
+    setReadonlyArray(props.schema);
+  visitMetadata({
+    components: props.components,
+    schema: props.schema,
+    metadata: props.type.value,
+    visited: props.visited,
+  });
+};
+
+const visitArrayType = (props: {
+  components: OpenApi.IComponents;
+  schema: OpenApi.IJsonSchema | undefined;
+  type: MetadataArrayType;
+  visited: IVisited;
+}): void => {
+  if (props.visited.arrays.has(props.type)) return;
+  props.visited.arrays.add(props.type);
+  const component: OpenApi.IJsonSchema | undefined = componentSchema(
+    props.components,
+    props.type.name,
+  );
+  if (component !== undefined && isReadonlyArrayName(props.type.name))
+    setReadonlyArray(component);
+  visitMetadata({
+    components: props.components,
+    schema: arraySchema(props.schema ?? component),
+    metadata: props.type.value,
+    visited: props.visited,
+  });
+};
+
+const visitTupleType = (props: {
+  components: OpenApi.IComponents;
+  schema: OpenApi.IJsonSchema | undefined;
+  type: MetadataTupleType;
+  visited: IVisited;
+}): void => {
+  if (props.visited.tuples.has(props.type)) return;
+  props.visited.tuples.add(props.type);
+  const component: OpenApi.IJsonSchema | undefined = componentSchema(
+    props.components,
+    props.type.name,
+  );
+  if (component !== undefined && isReadonlyArrayName(props.type.name))
+    setReadonlyArray(component);
+  const schema: JsonSchemaObject | undefined = objectSchema(
+    props.schema ?? component,
+  );
+  props.type.elements.forEach((metadata, index) =>
+    visitMetadata({
+      components: props.components,
+      schema: Array.isArray(schema?.prefixItems)
+        ? schema.prefixItems[index]
+        : undefined,
+      metadata,
+      visited: props.visited,
+    }),
+  );
+};
+
+const visitObjectType = (props: {
+  components: OpenApi.IComponents;
+  type: MetadataObjectType;
+  visited: IVisited;
+}): void => {
+  if (props.visited.objects.has(props.type)) return;
+  props.visited.objects.add(props.type);
+
+  const schema: JsonSchemaObject | undefined = objectSchema(
+    componentSchema(props.components, props.type.name),
+  );
+  const properties: Record<string, OpenApi.IJsonSchema> | undefined =
+    schema?.properties as Record<string, OpenApi.IJsonSchema> | undefined;
+  for (const property of props.type.properties) {
+    const key: string | undefined = propertyKey(property.key);
+    const child: OpenApi.IJsonSchema | undefined =
+      key === undefined ? undefined : properties?.[key];
+    visitMetadata({
+      components: props.components,
+      schema: child,
+      metadata: property.value,
+      visited: props.visited,
+    });
+  }
+};
+
+const isReadonlyArrayLike = (
+  metadata: MetadataSchema,
+  visited: WeakSet<MetadataSchema> = new WeakSet(),
+): boolean => {
+  if (visited.has(metadata)) return false;
+  visited.add(metadata);
+  const name: unknown = (metadata as { name?: unknown }).name;
+  return (
+    (typeof name === "string" && isReadonlyArrayName(name)) ||
+    metadata.arrays.some((array) => isReadonlyArrayName(array.name)) ||
+    metadata.tuples.some((tuple) => isReadonlyArrayName(tuple.name)) ||
+    metadata.aliases.some((alias) => {
+      const type: MetadataAliasType | undefined = alias.type as
+        | MetadataAliasType
+        | undefined;
+      return type !== undefined && isReadonlyArrayLike(type.value, visited);
+    })
+  );
+};
+
+const isReadonlyArrayName = (name: string): boolean => {
+  const trimmed: string = name.trim();
+  const compact: string = name.replace(/\s+/g, "");
+  return (
+    compact === "ReadonlyArray" ||
+    compact.startsWith("ReadonlyArray<") ||
+    compact.startsWith("readonly[") ||
+    trimmed.startsWith("readonly ")
+  );
+};
+
+const componentSchema = (
+  components: OpenApi.IComponents,
+  name: string,
+): OpenApi.IJsonSchema | undefined =>
+  (components.schemas ?? {})[name] as OpenApi.IJsonSchema | undefined;
+
+const arraySchema = (
+  schema: OpenApi.IJsonSchema | undefined,
+): OpenApi.IJsonSchema | undefined => {
+  const obj: JsonSchemaObject | undefined = objectSchema(schema);
+  return obj?.items as OpenApi.IJsonSchema | undefined;
+};
+
+const objectSchema = (
+  schema: OpenApi.IJsonSchema | undefined,
+): JsonSchemaObject | undefined =>
+  typeof schema === "object" && schema !== null
+    ? (schema as JsonSchemaObject)
+    : undefined;
+
+const propertyKey = (metadata: MetadataSchema): string | undefined => {
+  const value: unknown = metadata.constants[0]?.values[0]?.value;
+  return typeof value === "string"
+    ? value
+    : typeof value === "number"
+      ? String(value)
+      : undefined;
+};
+
+const setReadonlyArray = (schema: OpenApi.IJsonSchema): void => {
+  const obj: JsonSchemaObject | undefined = objectSchema(schema);
+  if (obj !== undefined) obj["x-readonly-array"] = true;
+};

--- a/tests/test-sdk/features/swagger-customizer/src/controllers/SwaggerController.ts
+++ b/tests/test-sdk/features/swagger-customizer/src/controllers/SwaggerController.ts
@@ -4,6 +4,22 @@ import { tags } from "typia";
 
 import { SelectorParam } from "../decorators/SelectorParam";
 
+export interface IReadonlyArrayDto {
+  mutable: string[];
+  readonlyArray: readonly string[];
+  readonlyGeneric: ReadonlyArray<string>;
+  readonly readonlyProperty: string[];
+  readonly readonlyBoth: readonly string[];
+}
+
+export type IReadonlyArrayAliasDto = {
+  mutable: string[];
+  readonlyArray: readonly string[];
+  readonlyGeneric: ReadonlyArray<string>;
+  readonly readonlyProperty: string[];
+  readonly readonlyBoth: readonly string[];
+};
+
 @Controller("custom")
 export class CustomController {
   @SwaggerCustomizer((props: SwaggerCustomizer.IProps) => {
@@ -31,5 +47,27 @@ export class CustomController {
   @TypedRoute.Get(":id/normal")
   public normal(@TypedParam("id") id: string & tags.Format<"uuid">): string {
     return id.toString();
+  }
+
+  @TypedRoute.Get("readonly-array")
+  public readonlyArray(): IReadonlyArrayDto {
+    return {
+      mutable: [],
+      readonlyArray: [],
+      readonlyGeneric: [],
+      readonlyProperty: [],
+      readonlyBoth: [],
+    };
+  }
+
+  @TypedRoute.Get("readonly-array-alias")
+  public readonlyArrayAlias(): IReadonlyArrayAliasDto {
+    return {
+      mutable: [],
+      readonlyArray: [],
+      readonlyGeneric: [],
+      readonlyProperty: [],
+      readonlyBoth: [],
+    };
   }
 }

--- a/tests/test-sdk/features/swagger-customizer/src/test/features/test_swagger_readonly_array.ts
+++ b/tests/test-sdk/features/swagger-customizer/src/test/features/test_swagger_readonly_array.ts
@@ -1,0 +1,89 @@
+import { TestValidator } from "@nestia/e2e";
+import fs from "fs";
+import { OpenApi } from "typia";
+
+/**
+ * Verifies readonly array type positions are emitted as a vendor extension
+ * without conflating them with readonly object properties.
+ *
+ * Locks the generated Swagger distinction between `prop: readonly T[]` and
+ * `readonly prop: T[]` for both interface and type-alias DTO declarations.
+ * OpenAPI `readOnly` already means response-only property, so the SDK must
+ * expose TypeScript array immutability through `x-readonly-array` while
+ * preserving existing property mutability behavior.
+ *
+ * 1. Generate Swagger from a controller returning interface and type-alias shapes
+ *    containing both readonly arrays and readonly properties.
+ * 2. Read the generated component schemas from `swagger.json`.
+ * 3. Assert only the array-type cases carry `x-readonly-array`.
+ */
+export const test_swagger_readonly_array = async (): Promise<void> => {
+  const content: string = await fs.promises.readFile(
+    `${__dirname}/../../../swagger.json`,
+    "utf8",
+  );
+  const swagger: OpenApi.IDocument = JSON.parse(content);
+  assertReadonlyArraySchema(
+    "interface",
+    swagger.components!.schemas!.IReadonlyArrayDto as any,
+  );
+  assertReadonlyArraySchema(
+    "type alias",
+    swagger.components!.schemas!.IReadonlyArrayAliasDto as any,
+  );
+};
+
+const assertReadonlyArraySchema = (label: string, schema: any): void => {
+  const properties = schema.properties as Record<string, any>;
+  const mutable = properties.mutable!;
+  const readonlyArray = properties.readonlyArray!;
+  const readonlyGeneric = properties.readonlyGeneric!;
+  const readonlyProperty = properties.readonlyProperty!;
+  const readonlyBoth = properties.readonlyBoth!;
+
+  TestValidator.equals(
+    `${label} mutable`,
+    mutable["x-readonly-array"],
+    undefined,
+  );
+  TestValidator.equals(
+    `${label} readonlyArray extension`,
+    readonlyArray["x-readonly-array"],
+    true,
+  );
+  TestValidator.equals(
+    `${label} readonlyArray readOnly`,
+    readonlyArray.readOnly,
+    undefined,
+  );
+  TestValidator.equals(
+    `${label} readonlyGeneric extension`,
+    readonlyGeneric["x-readonly-array"],
+    true,
+  );
+  TestValidator.equals(
+    `${label} readonlyGeneric readOnly`,
+    readonlyGeneric.readOnly,
+    undefined,
+  );
+  TestValidator.equals(
+    `${label} readonlyProperty extension`,
+    readonlyProperty["x-readonly-array"],
+    undefined,
+  );
+  TestValidator.equals(
+    `${label} readonlyProperty readOnly`,
+    readonlyProperty.readOnly,
+    true,
+  );
+  TestValidator.equals(
+    `${label} readonlyBoth extension`,
+    readonlyBoth["x-readonly-array"],
+    true,
+  );
+  TestValidator.equals(
+    `${label} readonlyBoth readOnly`,
+    readonlyBoth.readOnly,
+    true,
+  );
+};

--- a/website/src/content/docs/swagger/index.mdx
+++ b/website/src/content/docs/swagger/index.mdx
@@ -127,6 +127,7 @@ The transformer walks each `@Typed*` decorator and produces:
 - **Error responses** from `@TypedException()` decorators.
 - **`summary` / `description`** from the controller method's JSDoc.
 - **Field descriptions, examples, titles** from JSDoc on DTO properties.
+- **Readonly array hints** through `x-readonly-array` for TypeScript `readonly T[]` and `ReadonlyArray<T>` positions. Property-level `readonly prop` still maps to OpenAPI `readOnly`.
 - **Constraints** (`minLength`, `format`, `pattern`, …) from `tags.*` intersections.
 
 If a route uses vanilla `@Get` / `@Body`, it is **invisible** to the generator — only `@Typed*` routes appear in the schema.


### PR DESCRIPTION
## Summary

- add native SDK schema-bake handling that annotates TypeScript `readonly T[]` / `ReadonlyArray<T>` schema positions with `x-readonly-array: true`
- keep OpenAPI `readOnly` reserved for readonly object properties so response-only semantics are not conflated with array immutability
- guard the native readonly-array schema walker against recursive DTO graphs, handle both interface and type-alias DTO components, preserve the vendor extension through Swagger generation, cover it with a generated-Swagger `swagger-customizer` regression test, and document the extension

Fixes #1403.

## Verification

- `pnpm exec prettier --check packages/sdk/src/generates/SwaggerGenerator.ts packages/sdk/src/generates/internal/SwaggerOperationParameterComposer.ts packages/sdk/src/generates/internal/SwaggerReadonlyArrayEmender.ts tests/test-sdk/features/swagger-customizer/src/controllers/SwaggerController.ts tests/test-sdk/features/swagger-customizer/src/test/features/test_swagger_readonly_array.ts`
- `pnpm --filter @nestia/sdk build`
- `pnpm exec ttsc --noEmit --project tests/test-sdk/features/swagger-customizer/tsconfig.json`
- `git diff --check`

## Local limitation

- `gofmt` and direct `go test` are unavailable locally because the Go toolchain is not on PATH; `ttsc --noEmit` did compile the native source-plugin contributor.
- `node tests/test-sdk/start.js --only clone-and-keyword --concurrency 1` and `node tests/test-sdk/start.js --only swagger-customizer --concurrency 1` currently fail on local Windows before generated tests run with native TypeScript-Go temp-file path normalization: `fileName should be normalized and absolute: "C:\\Users\\samch\\AppData\\Local\\Temp\\...ts"`.
