### PR TITLE
fix(core): preserve TypedRoute JSON content type

### DIFF
--- a/packages/core/src/decorators/TypedRoute.ts
+++ b/packages/core/src/decorators/TypedRoute.ts
@@ -3,6 +3,7 @@ import {
   Delete,
   ExecutionContext,
   Get,
+  Header,
   NestInterceptor,
   Patch,
   Post,
@@ -141,6 +142,7 @@ export namespace TypedRoute {
       )(...args);
       return applyDecorators(
         ROUTERS[method](path),
+        Header("Content-Type", "application/json"),
         UseInterceptors(new TypedRouteInterceptor(stringify)),
       );
     }

--- a/tests/test-sdk/features/route/src/controllers/TypedRouteController.ts
+++ b/tests/test-sdk/features/route/src/controllers/TypedRouteController.ts
@@ -1,5 +1,11 @@
 import core from "@nestia/core";
-import { Controller } from "@nestjs/common";
+import {
+  CallHandler,
+  Controller,
+  ExecutionContext,
+  NestInterceptor,
+  UseInterceptors,
+} from "@nestjs/common";
 import { Observable, of } from "rxjs";
 import typia from "typia";
 
@@ -12,6 +18,15 @@ const createArticle = (): IBbsArticle => ({
   files: [],
   created_at: "2026-06-11T00:00:00.000Z" as IBbsArticle["created_at"],
 });
+
+class SerializedCacheHitInterceptor implements NestInterceptor {
+  public intercept(
+    _context: ExecutionContext,
+    _next: CallHandler,
+  ): Observable<string> {
+    return of(JSON.stringify(createArticle()));
+  }
+}
 
 @Controller("route")
 export class TypedRouteController {
@@ -28,5 +43,11 @@ export class TypedRouteController {
   @core.TypedRoute.Get("observable")
   public observable(): Observable<IBbsArticle> {
     return of(createArticle());
+  }
+
+  @core.TypedRoute.Get("cached")
+  @UseInterceptors(new SerializedCacheHitInterceptor())
+  public cached(): IBbsArticle {
+    return createArticle();
   }
 }

--- a/tests/test-sdk/features/route/src/test/features/api/test_api_route_cached_content_type.ts
+++ b/tests/test-sdk/features/route/src/test/features/api/test_api_route_cached_content_type.ts
@@ -1,0 +1,38 @@
+import api from "@api";
+
+/**
+ * Verifies @TypedRoute keeps JSON content type when an outer interceptor
+ * returns a pre-serialized cached response.
+ *
+ * Locks the route-level `Content-Type` metadata used by Nest before the
+ * response body reaches the HTTP adapter. Cache-like interceptors can return a
+ * serialized string without running the `TypedRouteInterceptor`; without header
+ * metadata, Express can infer `text/plain` for that cache hit.
+ *
+ * 1. Call a `@TypedRoute.Get()` endpoint whose interceptor returns cached JSON
+ *    text without invoking the next handler.
+ * 2. Inspect the raw HTTP response instead of the generated SDK parser.
+ * 3. Assert the response succeeds and keeps an `application/json` object body.
+ */
+export const test_api_route_cached_content_type = async (
+  connection: api.IConnection,
+): Promise<void> => {
+  const response: Response = await fetch(`${connection.host}/route/cached`);
+  const contentType: string = response.headers.get("content-type") ?? "";
+  if (contentType.toLowerCase().startsWith("application/json") === false)
+    throw new Error(
+      `Expected application/json content type, got ${JSON.stringify(contentType)}`,
+    );
+  if (response.ok === false)
+    throw new Error(
+      `Expected cached route to succeed, got ${response.status}: ${await response.text()}`,
+    );
+
+  const body: unknown = await response.json();
+  if (
+    typeof body !== "object" ||
+    body === null ||
+    (body as { id?: unknown }).id !== "00000000-0000-4000-8000-000000000000"
+  )
+    throw new Error(`Expected cached JSON object, got ${JSON.stringify(body)}`);
+};


### PR DESCRIPTION
Fixes #766.

## Summary
- Register Nest route-level `Content-Type: application/json` metadata on every `@TypedRoute` decorator.
- Add a route feature regression where an outer interceptor returns pre-serialized cached JSON without calling the next handler.
- Assert the raw HTTP response still reports `application/json` instead of falling back to `text/plain`.

## Root Cause
`TypedRouteInterceptor` already writes the JSON content type, but cache-like interceptors can short-circuit the request before that interceptor path runs. When the response body is already serialized text and no route-level header metadata exists, the HTTP adapter can infer `text/plain`.

## Regression Shape
The fixture keeps the cache interceptor before `TypedRouteInterceptor` in Nest metadata order, matching the short-circuit path. This lets the generated SDK test parse the cached JSON body while the dedicated raw HTTP test verifies the response header.

## Verification
- `pnpm exec prettier --check packages/core/src/decorators/TypedRoute.ts tests/test-sdk/features/route/src/controllers/TypedRouteController.ts tests/test-sdk/features/route/src/test/features/api/test_api_route_cached_content_type.ts`
- `git diff --check`
- `pnpm --filter @nestia/core build`
- `pnpm --filter @nestia/sdk build` after `@nestia/core` build completed
- Direct metadata check against `packages/core/lib` confirmed the cache interceptor precedes `TypedRouteInterceptor` and `HEADERS_METADATA` contains `Content-Type: application/json`.

## Local Test Limit
- `node tests/test-sdk/start.js --only route --concurrency 1` is blocked on this Windows checkout by the existing TypeScript-Go native temp-path normalization failure before the route regression test runs: `fileName should be normalized and absolute: "C:\Users\samch\AppData\Local\Temp\...ts"`. The Linux CI `test-sdk` job should exercise the new regression end to end.