### PR TITLE
feat(sdk): support binary response streams

### DIFF
--- a/packages/fetcher/src/IFetchRoute.ts
+++ b/packages/fetcher/src/IFetchRoute.ts
@@ -54,7 +54,8 @@ export namespace IFetchRoute {
       | "application/json"
       | "application/x-www-form-urlencoded"
       | "multipart/form-data"
-      | "text/plain";
+      | "text/plain"
+      | (string & {});
     encrypted?: boolean;
   }
 }

--- a/packages/fetcher/src/internal/FetcherBase.ts
+++ b/packages/fetcher/src/internal/FetcherBase.ts
@@ -3,6 +3,7 @@ import { IConnection } from "../IConnection";
 import { IFetchEvent } from "../IFetchEvent";
 import { IFetchRoute } from "../IFetchRoute";
 import { IPropagation } from "../IPropagation";
+import { is_binary_response_content_type } from "./is_binary_response_content_type";
 
 /** @internal */
 export namespace FetcherBase {
@@ -175,7 +176,9 @@ export namespace FetcherBase {
               await response.text(),
             );
             result.data = route.parseQuery ? route.parseQuery(query) : query;
-          } else
+          } else if (is_binary_response_content_type(route.response?.type))
+            result.data = response.body ?? new ReadableStream<Uint8Array>();
+          else
             result.data = props.decode(await response.text(), result.headers);
         }
         event.output = result.data;

--- a/packages/fetcher/src/internal/is_binary_response_content_type.ts
+++ b/packages/fetcher/src/internal/is_binary_response_content_type.ts
@@ -1,0 +1,14 @@
+export const is_binary_response_content_type = (
+  input: string | null | undefined,
+): input is string => {
+  if (typeof input !== "string") return false;
+
+  const value: string = input.split(";")[0]!.trim().toLowerCase();
+  return (
+    value.startsWith("image/") ||
+    value.startsWith("video/") ||
+    value.startsWith("audio/") ||
+    value === "application/octet-stream" ||
+    value === "application/pdf"
+  );
+};

--- a/packages/sdk/src/analyses/ReflectHttpOperationAnalyzer.ts
+++ b/packages/sdk/src/analyses/ReflectHttpOperationAnalyzer.ts
@@ -2,12 +2,12 @@ import { METHOD_METADATA, PATH_METADATA } from "@nestjs/common/constants";
 import { ranges } from "tstl";
 
 import { INestiaProject } from "../structures/INestiaProject";
+import { IOperationMetadata } from "../structures/IOperationMetadata";
 import { IReflectController } from "../structures/IReflectController";
 import { IReflectHttpOperation } from "../structures/IReflectHttpOperation";
 import { IReflectHttpOperationParameter } from "../structures/IReflectHttpOperationParameter";
 import { IReflectHttpOperationSuccess } from "../structures/IReflectHttpOperationSuccess";
 import { IReflectOperationError } from "../structures/IReflectOperationError";
-import { IOperationMetadata } from "../structures/IOperationMetadata";
 import { ArrayUtil } from "../utils/ArrayUtil";
 import { ImportAnalyzer } from "./ImportAnalyzer";
 import { PathAnalyzer } from "./PathAnalyzer";
@@ -106,7 +106,7 @@ export namespace ReflectHttpOperationAnalyzer {
           ...props.metadata.parameters
             .filter((x) => parameters.some((y) => x.index === y.index))
             .map((x) => x.imports),
-          ...props.metadata.success.imports,
+          ...(success.binary === true ? [] : props.metadata.success.imports),
           ...Object.values(props.metadata.exceptions).map((e) => e.imports),
         ].flat(),
       ),

--- a/packages/sdk/src/analyses/ReflectHttpOperationResponseAnalyzer.ts
+++ b/packages/sdk/src/analyses/ReflectHttpOperationResponseAnalyzer.ts
@@ -4,12 +4,17 @@ import {
   HTTP_CODE_METADATA,
   INTERCEPTORS_METADATA,
 } from "@nestjs/common/constants";
-import { HttpQueryProgrammer, JsonMetadataFactory, sizeOf } from "../internal/legacy";
 
+import {
+  HttpQueryProgrammer,
+  JsonMetadataFactory,
+  sizeOf,
+} from "../internal/legacy";
+import { IOperationMetadata } from "../structures/IOperationMetadata";
 import { IReflectController } from "../structures/IReflectController";
 import { IReflectHttpOperationSuccess } from "../structures/IReflectHttpOperationSuccess";
 import { IReflectOperationError } from "../structures/IReflectOperationError";
-import { IOperationMetadata } from "../structures/IOperationMetadata";
+import { HttpResponseContentTypeUtil } from "../utils/HttpResponseContentTypeUtil";
 import { TextPlainValidator } from "../validators/TextPlainValidator";
 
 export namespace ReflectHttpOperationResponseAnalyzer {
@@ -57,23 +62,25 @@ export namespace ReflectHttpOperationResponseAnalyzer {
           Reflect.getMetadata("swagger/apiProduces", ctx.function)?.[0] ??
           (ctx.httpMethod === "HEAD" ? null : "application/json"));
 
-    const schema =
-      contentType === "application/json"
+    const binary: boolean = HttpResponseContentTypeUtil.isBinary(contentType);
+    const schema = binary
+      ? { success: true as const, data: EMPTY_SCHEMA }
+      : contentType === "application/json"
         ? ctx.metadata.success.primitive
         : ctx.metadata.success.resolved;
     if (schema.success === false) errors.push(...schema.errors);
     if (ctx.httpMethod === "HEAD" && contentType !== null)
       errors.push(`HEAD method must not have a content type.`);
-    if (isContentType(contentType) === false)
+    if (HttpResponseContentTypeUtil.isSupported(contentType) === false)
       errors.push(
         `@nestia/sdk does not support ${JSON.stringify(contentType)} content type.`,
       );
 
     if (errors.length) return report();
     else if (
-      ctx.metadata.success.type === null ||
+      (binary === false && ctx.metadata.success.type === null) ||
       schema.success === false ||
-      !isContentType(contentType)
+      !HttpResponseContentTypeUtil.isSupported(contentType)
     )
       return null;
 
@@ -83,22 +90,25 @@ export namespace ReflectHttpOperationResponseAnalyzer {
     );
     return {
       contentType,
+      binary,
       encrypted,
       status:
         getStatus(ctx.function) ?? (ctx.httpMethod === "POST" ? 201 : 200),
-      type: ctx.metadata.success.type,
+      type: ctx.metadata.success.type ?? { name: "ReadableStream" },
       ...schema.data,
       validate:
-        contentType === "application/json" || encrypted === true
-          ? JsonMetadataFactory.validate
-          : contentType === "application/x-www-form-urlencoded"
-            ? HttpQueryProgrammer.validate
-            : contentType === "text/plain"
-              ? TextPlainValidator.validate
-              : (next) =>
-                  sizeOf(next.metadata) !== 0
-                    ? ["HEAD method must not have any return value."]
-                    : [],
+        binary === true
+          ? () => []
+          : contentType === "application/json" || encrypted === true
+            ? JsonMetadataFactory.validate
+            : contentType === "application/x-www-form-urlencoded"
+              ? HttpQueryProgrammer.validate
+              : contentType === "text/plain"
+                ? TextPlainValidator.validate
+                : (next) =>
+                    sizeOf(next.metadata) !== 0
+                      ? ["HEAD method must not have any return value."]
+                      : [],
       example: example?.example,
       examples: example?.examples,
     };
@@ -120,11 +130,34 @@ export namespace ReflectHttpOperationResponseAnalyzer {
     return meta.some((elem) => elem?.constructor?.name === props.name);
   };
 
-  const isContentType = (
-    input: string | null,
-  ): input is IReflectHttpOperationSuccess["contentType"] =>
-    input === null ||
-    input === "application/json" ||
-    input === "text/plain" ||
-    input === "application/x-www-form-urlencoded";
+  const EMPTY_SCHEMA: IOperationMetadata.ISchema = {
+    components: {
+      aliases: [],
+      arrays: [],
+      objects: [],
+      tuples: [],
+    },
+    metadata: {
+      aliases: [],
+      any: false,
+      arrays: [],
+      atomics: [],
+      constants: [],
+      escaped: null,
+      functions: [],
+      maps: [],
+      natives: [],
+      nullable: false,
+      objects: [],
+      optional: false,
+      required: true,
+      rest: null,
+      sets: [],
+      templates: [],
+      tuples: [],
+      size: 0,
+      name: "void",
+      empty: true,
+    } as IOperationMetadata.ISchema["metadata"],
+  };
 }

--- a/packages/sdk/src/generates/SdkGenerator.ts
+++ b/packages/sdk/src/generates/SdkGenerator.ts
@@ -144,7 +144,10 @@ export namespace SdkGenerator {
             from: `exception ${JSON.stringify(key)}`,
             contents: [`implicit (unnamed) exception type.`],
           });
-    if (isImplicitType(props.route.success.type))
+    if (
+      props.route.success.binary === false &&
+      isImplicitType(props.route.success.type)
+    )
       props.errors.push({
         file: props.route.controller.file,
         class: props.route.controller.class.name,

--- a/packages/sdk/src/generates/internal/E2eFileProgrammer.ts
+++ b/packages/sdk/src/generates/internal/E2eFileProgrammer.ts
@@ -1,4 +1,9 @@
-import { Node, NodeFlags, SyntaxKind, TypeScriptFactory } from "@nestia/factory";
+import {
+  Node,
+  NodeFlags,
+  SyntaxKind,
+  TypeScriptFactory,
+} from "@nestia/factory";
 import { IdentifierFactory, LiteralFactory } from "@nestia/factory";
 
 import { INestiaProject } from "../../structures/INestiaProject";
@@ -186,7 +191,9 @@ export namespace E2eFileProgrammer {
               NodeFlags.Const,
             ),
           ),
-          TypeScriptFactory.createExpressionStatement(assert),
+          ...(route.success.binary === true
+            ? []
+            : [TypeScriptFactory.createExpressionStatement(assert)]),
         ]),
       );
     };

--- a/packages/sdk/src/generates/internal/SdkAliasCollection.ts
+++ b/packages/sdk/src/generates/internal/SdkAliasCollection.ts
@@ -1,7 +1,7 @@
 import { Node, SyntaxKind, TypeScriptFactory } from "@nestia/factory";
 import { TypeFactory } from "@nestia/factory";
-import { MetadataSchema, sizeOf } from "../../internal/legacy";
 
+import { MetadataSchema, sizeOf } from "../../internal/legacy";
 import { INestiaProject } from "../../structures/INestiaProject";
 import { IReflectType } from "../../structures/IReflectType";
 import { ITypedHttpRoute } from "../../structures/ITypedHttpRoute";
@@ -20,6 +20,16 @@ export namespace SdkAliasCollection {
         ? type.typeArguments.map((a) => name({ type: a }))
         : undefined,
     );
+
+  export const binaryChunk = (): Node =>
+    TypeScriptFactory.createTypeReferenceNode("Uint8Array", [
+      TypeScriptFactory.createTypeReferenceNode("ArrayBufferLike"),
+    ]);
+
+  export const binaryResponse = (): Node =>
+    TypeScriptFactory.createTypeReferenceNode("ReadableStream", [
+      binaryChunk(),
+    ]);
 
   export const from =
     (project: INestiaProject) =>
@@ -40,15 +50,14 @@ export namespace SdkAliasCollection {
           prefix: false,
         })
           .map((e) => {
-            const signature: Node =
-              TypeScriptFactory.createPropertySignature(
-                undefined,
-                e.key,
-                e.required
-                  ? undefined
-                  : TypeScriptFactory.createToken(SyntaxKind.QuestionToken),
-                e.type,
-              );
+            const signature: Node = TypeScriptFactory.createPropertySignature(
+              undefined,
+              e.key,
+              e.required
+                ? undefined
+                : TypeScriptFactory.createToken(SyntaxKind.QuestionToken),
+              e.type,
+            );
             const description: string | null =
               e.parameter.description ??
               route.jsDocTags
@@ -188,14 +197,18 @@ export namespace SdkAliasCollection {
                   [name(p)],
                 )
               : name(p);
-      if (project.config.propagate !== true) return schema(route.success);
+      const success: Node =
+        route.success.binary === true
+          ? binaryResponse()
+          : schema(route.success);
+      if (project.config.propagate !== true) return success;
 
       const branches: IBranch[] = [
         {
           status: String(
             route.success.status ?? (route.method === "POST" ? 201 : 200),
           ),
-          type: schema(route.success),
+          type: success,
         },
         ...Object.entries(route.exceptions).map(([status, value]) => ({
           status,

--- a/packages/sdk/src/generates/internal/SdkHttpCloneReferencer.ts
+++ b/packages/sdk/src/generates/internal/SdkHttpCloneReferencer.ts
@@ -49,12 +49,13 @@ export namespace SdkHttpCloneReferencer {
         type: v.type,
         name: (name) => (v.type = { name }),
       });
-    visitType({
-      unique,
-      metadata: props.route.success.metadata,
-      type: props.route.success.type,
-      name: (name) => (props.route.success.type = { name }),
-    });
+    if (props.route.success.binary === false)
+      visitType({
+        unique,
+        metadata: props.route.success.metadata,
+        type: props.route.success.type,
+        name: (name) => (props.route.success.type = { name }),
+      });
     props.route.imports = Array.from(unique).map((str) => ({
       file: `${props.directory}/${str}`,
       asterisk: null,

--- a/packages/sdk/src/generates/internal/SdkHttpFunctionProgrammer.ts
+++ b/packages/sdk/src/generates/internal/SdkHttpFunctionProgrammer.ts
@@ -52,6 +52,7 @@ export namespace SdkHttpFunctionProgrammer {
         ],
         TypeScriptFactory.createTypeReferenceNode("Promise", [
           project.config.propagate === true ||
+          route.success.binary === true ||
           sizeOf(route.success.metadata) !== 0
             ? TypeScriptFactory.createTypeReferenceNode(`${route.name}.Output`)
             : TypeScriptFactory.createTypeReferenceNode("void"),

--- a/packages/sdk/src/generates/internal/SdkHttpNamespaceProgrammer.ts
+++ b/packages/sdk/src/generates/internal/SdkHttpNamespaceProgrammer.ts
@@ -1,7 +1,18 @@
-import { Node, NodeFlags, SyntaxKind, TypeScriptFactory } from "@nestia/factory";
-import { ExpressionFactory, IdentifierFactory, LiteralFactory, TypeFactory } from "@nestia/factory";
+import {
+  Node,
+  NodeFlags,
+  SyntaxKind,
+  TypeScriptFactory,
+} from "@nestia/factory";
+import {
+  ExpressionFactory,
+  IdentifierFactory,
+  LiteralFactory,
+  TypeFactory,
+} from "@nestia/factory";
 import { NamingConvention } from "@typia/utils";
 
+import { sizeOf } from "../../internal/legacy";
 import { INestiaProject } from "../../structures/INestiaProject";
 import { ITypedHttpRoute } from "../../structures/ITypedHttpRoute";
 import { FilePrinter } from "./FilePrinter";
@@ -10,15 +21,13 @@ import { SdkAliasCollection } from "./SdkAliasCollection";
 import { SdkHttpParameterProgrammer } from "./SdkHttpParameterProgrammer";
 import { SdkHttpSimulationProgrammer } from "./SdkHttpSimulationProgrammer";
 import { SdkImportWizard } from "./SdkImportWizard";
-import { sizeOf } from "../../internal/legacy";
 
 export namespace SdkHttpNamespaceProgrammer {
   export const write =
     (project: INestiaProject) =>
     (importer: ImportDictionary) =>
     (route: ITypedHttpRoute): Node => {
-      const types: Node[] =
-        writeTypes(project)(importer)(route);
+      const types: Node[] = writeTypes(project)(importer)(route);
       return TypeScriptFactory.createModuleDeclaration(
         [TypeScriptFactory.createToken(SyntaxKind.ExportKeyword)],
         TypeScriptFactory.createIdentifier(route.name),
@@ -81,6 +90,7 @@ export namespace SdkHttpNamespaceProgrammer {
         declare("Body", SdkAliasCollection.body(project)(importer)(route.body));
       if (
         project.config.propagate === true ||
+        route.success.binary === true ||
         sizeOf(route.success.metadata) !== 0
       )
         declare(

--- a/packages/sdk/src/generates/internal/SdkHttpSimulationProgrammer.ts
+++ b/packages/sdk/src/generates/internal/SdkHttpSimulationProgrammer.ts
@@ -1,13 +1,24 @@
-import { Node, NodeFlags, SyntaxKind, TypeScriptFactory } from "@nestia/factory";
-import { ExpressionFactory, IdentifierFactory, LiteralFactory, StatementFactory, TypeFactory } from "@nestia/factory";
+import {
+  Node,
+  NodeFlags,
+  SyntaxKind,
+  TypeScriptFactory,
+} from "@nestia/factory";
+import {
+  ExpressionFactory,
+  IdentifierFactory,
+  LiteralFactory,
+  StatementFactory,
+  TypeFactory,
+} from "@nestia/factory";
 
+import { sizeOf } from "../../internal/legacy";
 import { INestiaProject } from "../../structures/INestiaProject";
 import { ITypedHttpRoute } from "../../structures/ITypedHttpRoute";
 import { ImportDictionary } from "./ImportDictionary";
 import { SdkAliasCollection } from "./SdkAliasCollection";
 import { SdkHttpParameterProgrammer } from "./SdkHttpParameterProgrammer";
 import { SdkImportWizard } from "./SdkImportWizard";
-import { sizeOf } from "../../internal/legacy";
 
 export namespace SdkHttpSimulationProgrammer {
   export const random =
@@ -20,23 +31,29 @@ export namespace SdkHttpSimulationProgrammer {
           undefined,
           undefined,
           [],
-          project.config.primitive === false
+          project.config.primitive === false || route.success.binary === true
             ? output
             : TypeScriptFactory.createTypeReferenceNode(
                 SdkImportWizard.Resolved(importer),
                 [output],
               ),
           undefined,
-          TypeScriptFactory.createCallExpression(
-            IdentifierFactory.access(
-              TypeScriptFactory.createIdentifier(
-                SdkImportWizard.typia(importer),
+          route.success.binary === true
+            ? TypeScriptFactory.createNewExpression(
+                TypeScriptFactory.createIdentifier("ReadableStream"),
+                [SdkAliasCollection.binaryChunk()],
+                [],
+              )
+            : TypeScriptFactory.createCallExpression(
+                IdentifierFactory.access(
+                  TypeScriptFactory.createIdentifier(
+                    SdkImportWizard.typia(importer),
+                  ),
+                  "random",
+                ),
+                [output],
+                undefined,
               ),
-              "random",
-            ),
-            [output],
-            undefined,
-          ),
         ),
       );
     };
@@ -47,6 +64,7 @@ export namespace SdkHttpSimulationProgrammer {
     (route: ITypedHttpRoute): Node => {
       const output: boolean =
         project.config.propagate === true ||
+        route.success.binary === true ||
         sizeOf(route.success.metadata) !== 0;
       const caller = () =>
         TypeScriptFactory.createCallExpression(
@@ -232,69 +250,68 @@ export namespace SdkHttpSimulationProgrammer {
       ];
     };
 
-  const tryAndCatch =
-    (importer: ImportDictionary) => (individual: Node[]) =>
-      TypeScriptFactory.createTryStatement(
-        TypeScriptFactory.createBlock(individual, true),
-        TypeScriptFactory.createCatchClause(
-          "exp",
-          TypeScriptFactory.createBlock(
-            [
-              TypeScriptFactory.createIfStatement(
-                TypeScriptFactory.createLogicalNot(
-                  TypeScriptFactory.createCallExpression(
-                    IdentifierFactory.access(
-                      TypeScriptFactory.createIdentifier(
-                        SdkImportWizard.typia(importer),
-                      ),
-                      "is",
+  const tryAndCatch = (importer: ImportDictionary) => (individual: Node[]) =>
+    TypeScriptFactory.createTryStatement(
+      TypeScriptFactory.createBlock(individual, true),
+      TypeScriptFactory.createCatchClause(
+        "exp",
+        TypeScriptFactory.createBlock(
+          [
+            TypeScriptFactory.createIfStatement(
+              TypeScriptFactory.createLogicalNot(
+                TypeScriptFactory.createCallExpression(
+                  IdentifierFactory.access(
+                    TypeScriptFactory.createIdentifier(
+                      SdkImportWizard.typia(importer),
                     ),
-                    [
-                      TypeScriptFactory.createTypeReferenceNode(
-                        SdkImportWizard.HttpError(importer),
-                      ),
-                    ],
-                    [TypeScriptFactory.createIdentifier("exp")],
+                    "is",
                   ),
-                ),
-                TypeScriptFactory.createThrowStatement(
-                  TypeScriptFactory.createIdentifier("exp"),
+                  [
+                    TypeScriptFactory.createTypeReferenceNode(
+                      SdkImportWizard.HttpError(importer),
+                    ),
+                  ],
+                  [TypeScriptFactory.createIdentifier("exp")],
                 ),
               ),
-              TypeScriptFactory.createReturnStatement(
-                TypeScriptFactory.createAsExpression(
-                  TypeScriptFactory.createObjectLiteralExpression(
-                    [
-                      TypeScriptFactory.createPropertyAssignment(
-                        "success",
-                        TypeScriptFactory.createFalse(),
-                      ),
-                      TypeScriptFactory.createPropertyAssignment(
-                        "status",
-                        TypeScriptFactory.createIdentifier("exp.status"),
-                      ),
-                      TypeScriptFactory.createPropertyAssignment(
-                        "headers",
-                        TypeScriptFactory.createIdentifier("exp.headers"),
-                      ),
-                      TypeScriptFactory.createPropertyAssignment(
-                        "data",
-                        TypeScriptFactory.createIdentifier(
-                          "exp.toJSON().message",
-                        ),
-                      ),
-                    ],
-                    true,
-                  ),
-                  TypeFactory.keyword("any"),
-                ),
+              TypeScriptFactory.createThrowStatement(
+                TypeScriptFactory.createIdentifier("exp"),
               ),
-            ],
-            true,
-          ),
+            ),
+            TypeScriptFactory.createReturnStatement(
+              TypeScriptFactory.createAsExpression(
+                TypeScriptFactory.createObjectLiteralExpression(
+                  [
+                    TypeScriptFactory.createPropertyAssignment(
+                      "success",
+                      TypeScriptFactory.createFalse(),
+                    ),
+                    TypeScriptFactory.createPropertyAssignment(
+                      "status",
+                      TypeScriptFactory.createIdentifier("exp.status"),
+                    ),
+                    TypeScriptFactory.createPropertyAssignment(
+                      "headers",
+                      TypeScriptFactory.createIdentifier("exp.headers"),
+                    ),
+                    TypeScriptFactory.createPropertyAssignment(
+                      "data",
+                      TypeScriptFactory.createIdentifier(
+                        "exp.toJSON().message",
+                      ),
+                    ),
+                  ],
+                  true,
+                ),
+                TypeFactory.keyword("any"),
+              ),
+            ),
+          ],
+          true,
         ),
-        undefined,
-      );
+      ),
+      undefined,
+    );
 }
 
 const constant = (name: string) => (expression: Node) =>

--- a/packages/sdk/src/generates/internal/SwaggerOperationResponseComposer.ts
+++ b/packages/sdk/src/generates/internal/SwaggerOperationResponseComposer.ts
@@ -1,7 +1,7 @@
-import { MetadataSchema } from "../../internal/legacy";
 import { OpenApi } from "@typia/interface";
 import { VariadicSingleton } from "tstl";
 
+import { MetadataSchema } from "../../internal/legacy";
 import { ITypedHttpRoute } from "../../structures/ITypedHttpRoute";
 import { StringUtil } from "../../utils/StringUtil";
 import { SwaggerDescriptionComposer } from "./SwaggerDescriptionComposer";
@@ -80,7 +80,12 @@ export namespace SwaggerOperationResponseComposer {
       content: props.route.success.contentType
         ? {
             [props.route.success.contentType]: {
-              schema: props.schema(props.route.success.metadata),
+              schema: props.route.success.binary
+                ? {
+                    format: "binary",
+                    type: "string",
+                  }
+                : props.schema(props.route.success.metadata),
               example: props.route.success.example,
               examples: props.route.success.examples,
             },

--- a/packages/sdk/src/structures/IReflectHttpOperationSuccess.ts
+++ b/packages/sdk/src/structures/IReflectHttpOperationSuccess.ts
@@ -1,17 +1,14 @@
-import { MetadataFactory } from "../internal/legacy";
 import { IMetadataComponents, IMetadataSchema } from "@typia/interface";
 
+import { MetadataFactory } from "../internal/legacy";
+import { HttpResponseContentTypeUtil } from "../utils/HttpResponseContentTypeUtil";
 import { IReflectType } from "./IReflectType";
 
 export interface IReflectHttpOperationSuccess {
   type: IReflectType;
   status: number;
-  contentType:
-    | "application/json"
-    | "text/plain"
-    | "application/x-www-form-urlencoded"
-    | "application/json"
-    | null;
+  contentType: HttpResponseContentTypeUtil.Response;
+  binary: boolean;
   encrypted: boolean;
   components: IMetadataComponents;
   metadata: IMetadataSchema;

--- a/packages/sdk/src/structures/ITypedHttpRouteSuccess.ts
+++ b/packages/sdk/src/structures/ITypedHttpRouteSuccess.ts
@@ -1,16 +1,12 @@
 import { MetadataSchema } from "../internal/legacy";
-
+import { HttpResponseContentTypeUtil } from "../utils/HttpResponseContentTypeUtil";
 import { IReflectType } from "./IReflectType";
 
 export interface ITypedHttpRouteSuccess {
   type: IReflectType;
   status: number | null;
-  contentType:
-    | "application/json"
-    | "text/plain"
-    | "application/x-www-form-urlencoded"
-    | "application/json"
-    | null;
+  contentType: HttpResponseContentTypeUtil.Response;
+  binary: boolean;
   encrypted: boolean;
   metadata: MetadataSchema;
   example?: any;

--- a/packages/sdk/src/utils/HttpResponseContentTypeUtil.ts
+++ b/packages/sdk/src/utils/HttpResponseContentTypeUtil.ts
@@ -1,0 +1,30 @@
+export namespace HttpResponseContentTypeUtil {
+  export type Response =
+    | "application/json"
+    | "text/plain"
+    | "application/x-www-form-urlencoded"
+    | (string & {})
+    | null;
+
+  export const isSupported = (input: string | null): input is Response =>
+    input === null ||
+    input === "application/json" ||
+    input === "text/plain" ||
+    input === "application/x-www-form-urlencoded" ||
+    isBinary(input);
+
+  export const isBinary = (
+    input: string | null | undefined,
+  ): input is string => {
+    if (typeof input !== "string") return false;
+
+    const value: string = input.split(";")[0]!.trim().toLowerCase();
+    return (
+      value.startsWith("image/") ||
+      value.startsWith("video/") ||
+      value.startsWith("audio/") ||
+      value === "application/octet-stream" ||
+      value === "application/pdf"
+    );
+  };
+}

--- a/tests/test-sdk/features/stream-response/nestia.config.ts
+++ b/tests/test-sdk/features/stream-response/nestia.config.ts
@@ -1,0 +1,11 @@
+import { INestiaConfig } from "@nestia/sdk";
+
+export const NESTIA_CONFIG: INestiaConfig = {
+  input: ["src/controllers"],
+  output: "src/api",
+  simulate: true,
+  swagger: {
+    output: "swagger.json",
+  },
+};
+export default NESTIA_CONFIG;

--- a/tests/test-sdk/features/stream-response/src/controllers/StreamController.ts
+++ b/tests/test-sdk/features/stream-response/src/controllers/StreamController.ts
@@ -1,0 +1,10 @@
+import { Controller, Get, Header, StreamableFile } from "@nestjs/common";
+
+@Controller("stream")
+export class StreamController {
+  @Header("Content-Type", "image/png")
+  @Get("image")
+  public image(): StreamableFile {
+    return new StreamableFile(Buffer.from([1, 2, 3, 4]));
+  }
+}

--- a/tests/test-sdk/features/stream-response/src/test/features/api/test_api_stream_response.ts
+++ b/tests/test-sdk/features/stream-response/src/test/features/api/test_api_stream_response.ts
@@ -1,0 +1,83 @@
+import { TestValidator } from "@nestia/e2e";
+import fs from "fs";
+
+import api from "@api";
+
+/**
+ * Verifies binary response content types generate stream-aware SDK output.
+ *
+ * Locks the file-response branch requested for image/video style content types.
+ * When a controller declares a binary `Content-Type`, the generated Swagger
+ * document must describe a binary string, the SDK output type must be a
+ * `ReadableStream`, and the fetcher must return `Response.body` instead of
+ * decoding the payload as text.
+ *
+ * 1. Call the generated SDK function with a custom fetch returning an `image/png`
+ *    stream response.
+ * 2. Read the returned stream and assert the response bytes are preserved.
+ * 3. Assert a bodyless binary response becomes an empty stream, not `null`.
+ * 4. Assert generated Swagger and SDK source describe the binary stream shape.
+ */
+export const test_api_stream_response = async (
+  connection: api.IConnection,
+): Promise<void> => {
+  const output: ReadableStream<Uint8Array<ArrayBufferLike>> =
+    await api.functional.stream.image(connection);
+  const bytes: number[] = await read(output);
+  TestValidator.equals("stream bytes", bytes, [1, 2, 3, 4]);
+
+  const empty: ReadableStream<Uint8Array<ArrayBufferLike>> =
+    await api.functional.stream.image({
+      ...connection,
+      fetch: async () =>
+        new Response(null, {
+          headers: {
+            "Content-Type": "image/png",
+          },
+          status: 200,
+        }),
+    });
+  TestValidator.equals("empty stream bytes", await read(empty), []);
+
+  const swagger = JSON.parse(
+    await fs.promises.readFile(`${__dirname}/../../../../swagger.json`, "utf8"),
+  );
+  TestValidator.equals(
+    "swagger binary response",
+    swagger.paths["/stream/image"].get.responses[200].content["image/png"]
+      .schema,
+    {
+      format: "binary",
+      type: "string",
+    },
+  );
+
+  const source: string = await fs.promises.readFile(
+    `${__dirname}/../../../api/functional/stream/index.ts`,
+    "utf8",
+  );
+  TestValidator.predicate("sdk stream output", () =>
+    source.includes(
+      "export type Output = ReadableStream<Uint8Array<ArrayBufferLike>>;",
+    ),
+  );
+  TestValidator.predicate(
+    "sdk avoids controller return import",
+    () => source.includes("StreamableFile") === false,
+  );
+};
+
+const read = async (
+  stream: ReadableStream<Uint8Array<ArrayBufferLike>>,
+): Promise<number[]> => {
+  const reader: ReadableStreamDefaultReader<Uint8Array<ArrayBufferLike>> =
+    stream.getReader();
+  const output: number[] = [];
+  while (true) {
+    const next: ReadableStreamReadResult<Uint8Array<ArrayBufferLike>> =
+      await reader.read();
+    if (next.done === true) break;
+    output.push(...next.value);
+  }
+  return output;
+};

--- a/tests/test-sdk/features/stream-response/src/test/index.ts
+++ b/tests/test-sdk/features/stream-response/src/test/index.ts
@@ -1,0 +1,43 @@
+import { DynamicExecutor } from "@nestia/e2e";
+
+import api from "@api";
+
+const main = async (): Promise<void> => {
+  const report: DynamicExecutor.IReport = await DynamicExecutor.validate({
+    extension: __filename.substring(__filename.length - 2),
+    prefix: "test",
+    parameters: () => [
+      {
+        host: "http://127.0.0.1",
+        fetch: async () =>
+          new Response(
+            new ReadableStream<Uint8Array<ArrayBufferLike>>({
+              start: (controller) => {
+                controller.enqueue(new Uint8Array([1, 2, 3, 4]));
+                controller.close();
+              },
+            }),
+            {
+              headers: {
+                "Content-Type": "image/png",
+              },
+              status: 200,
+            },
+          ),
+      } satisfies api.IConnection,
+    ],
+    location: `${__dirname}/features`,
+  });
+
+  const exceptions: Error[] = report.executions
+    .filter((exec) => exec.error !== null)
+    .map((exec) => exec.error!);
+  if (exceptions.length !== 0) {
+    for (const exp of exceptions) console.log(exp);
+    process.exit(-1);
+  }
+};
+main().catch((exp) => {
+  console.log(exp);
+  process.exit(-1);
+});

--- a/tests/test-sdk/features/stream-response/tsconfig.json
+++ b/tests/test-sdk/features/stream-response/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../config/tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      "@api": ["./src/api"],
+      "@api/lib/*": ["./src/api/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/website/src/content/docs/sdk/index.mdx
+++ b/website/src/content/docs/sdk/index.mdx
@@ -84,6 +84,32 @@ Nothing in this file is hand-written.
 
 ---
 
+## Binary responses
+
+When a route declares a binary response `Content-Type` with Nest's
+`@Header("Content-Type", "...")` or Swagger's `@ApiProduces("...")`, generated
+SDK functions return `ReadableStream<Uint8Array<ArrayBufferLike>>` instead of
+trying to parse the body as JSON or text.
+
+```ts copy
+import { Controller, Get, Header, StreamableFile } from "@nestjs/common";
+
+@Controller("files")
+export class FileController {
+  @Header("Content-Type", "image/png")
+  @Get("thumbnail")
+  public thumbnail(): StreamableFile {
+    return new StreamableFile(/* readable source */);
+  }
+}
+```
+
+The generated Swagger response is emitted as `type: "string"` with
+`format: "binary"`. Binary detection currently covers `image/*`, `video/*`,
+`audio/*`, `application/octet-stream`, and `application/pdf`.
+
+---
+
 ## `INestiaConfig` keys
 
 | Key            | Type                                                              | Purpose                                                              |


### PR DESCRIPTION
Fixes #1216.

## Changes
- Treat binary response media types as stream responses in generated SDKs.
- Return `ReadableStream<Uint8Array<ArrayBufferLike>>` for binary route outputs.
- Decode successful binary responses from `Response.body` instead of `response.text()`.
- Emit OpenAPI response schemas as `{ type: string, format: binary }`.
- Avoid leaking controller return types such as `StreamableFile` into generated SDK imports/clone output.
- Skip typia random/assert paths for stream bodies and use a generated empty `ReadableStream` for simulator output.
- Document binary response behavior in the SDK reference.
- Add `test-sdk/features/stream-response` covering runtime stream bytes, Swagger schema, generated output type, and avoided controller return import.

## Binary content types
The binary branch currently covers:
- `image/*`
- `video/*`
- `audio/*`
- `application/octet-stream`
- `application/pdf`

## Verification
- `pnpm exec prettier --check ...` for changed TS files and the new test fixture files
- `git diff --check`
- `pnpm --filter @nestia/fetcher build`
- `pnpm --filter @nestia/sdk build`
- `node tests/test-sdk/start.js --only stream-response --concurrency 1`

## Local limitation
- `pnpm build` in `website` could not run locally because this workspace's `website` install is missing `jszip` for `build/editor`; CI should cover website build with its normal install path.