### PR TITLE
fix(sdk): declare tgrid for websocket distribution

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -62,6 +62,7 @@
     "glob": "^11.0.3",
     "path-to-regexp": "^6.2.1",
     "prettier": "catalog:typescript",
+    "tgrid": "catalog:samchon",
     "ttsc": "catalog:typescript",
     "tstl": "catalog:samchon",
     "typia": "catalog:samchon"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -551,6 +551,9 @@ importers:
       prettier:
         specifier: catalog:typescript
         version: 3.8.3
+      tgrid:
+        specifier: catalog:samchon
+        version: 1.2.1
       tstl:
         specifier: catalog:samchon
         version: 3.0.0


### PR DESCRIPTION
﻿## Summary

Fixes #1499.

SdkDistributionComposer resolves install versions from @nestia/sdk/package.json when composing a distributable SDK package. WebSocket SDK distributions install tgrid, but @nestia/sdk did not declare a tgrid version, so generation could fail while validating or composing the distribution metadata.

This adds tgrid to @nestia/sdk dependencies through the existing catalog:samchon version and refreshes the lockfile importer entry.

## Validation

- node package metadata assertion for packages/sdk/package.json
- pnpm --filter @nestia/sdk build
- git diff --check

## Notes

pnpm exec prettier --check still mis-parses JSON/YAML in this workspace unless extra parser handling is used; I kept the generated lockfile diff minimal instead of reformatting unrelated file content.
