### PR TITLE
feat(sdk): add swagger watch mode

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -9,7 +9,7 @@ npx nestia [command] [options?]
   4. npx nestia dependencies
   5. npx nestia init
   6. npx nestia sdk
-  7. npx nestia swagger
+  7. npx nestia swagger [--watch]
   8. npx nestia e2e
   9. npx nestia all
 `;
@@ -32,9 +32,9 @@ async function main(): Promise<void> {
       await import("./NestiaTemplate.js")
     ).NestiaTemplate.clone((msg) => halt(msg ?? USAGE))(argv);
   } else if (type === "setup") {
-    await (await import("./NestiaSetupWizard.js")).NestiaSetupWizard.setup(
-      argv,
-    );
+    await (
+      await import("./NestiaSetupWizard.js")
+    ).NestiaSetupWizard.setup(argv);
   } else if (
     type === "dependencies" ||
     type === "init" ||

--- a/packages/sdk/src/executable/internal/NestiaSdkCommand.ts
+++ b/packages/sdk/src/executable/internal/NestiaSdkCommand.ts
@@ -1,6 +1,7 @@
 import { INestiaConfig } from "../../INestiaConfig";
 import { NestiaSdkApplication } from "../../NestiaSdkApplication";
 import { NestiaConfigLoader } from "./NestiaConfigLoader";
+import { NestiaSdkWatcher } from "./NestiaSdkWatcher";
 
 export namespace NestiaSdkCommand {
   export const sdk = () =>
@@ -17,6 +18,7 @@ export namespace NestiaSdkCommand {
       generate: (app) => app.swagger(),
       validate: (config) => !!config.swagger?.output,
       solution: "configure INestiaConfig.swagger property.",
+      watch: hasFlagArgument("watch"),
     });
 
   export const e2e = () =>
@@ -50,6 +52,7 @@ export namespace NestiaSdkCommand {
     solution: string;
     generate: (app: NestiaSdkApplication) => Promise<void>;
     validate: (config: INestiaConfig) => boolean;
+    watch?: boolean;
   }) => {
     // LOAD CONFIG INFO
     const project: string =
@@ -58,32 +61,44 @@ export namespace NestiaSdkCommand {
         extension: "json",
       }) ?? "tsconfig.json";
     process.env.NESTIA_PROJECT = project;
-    const command: NestiaConfigLoader.ICompilerOptions =
-      await NestiaConfigLoader.compilerOptions(project);
-
-    const configurations: INestiaConfig[] =
-      await NestiaConfigLoader.configurations(
-        getFileArgument({
-          type: "config",
-          extension: "ts",
-        }) ?? "nestia.config.ts",
+    const configFile: string =
+      getFileArgument({
+        type: "config",
+        extension: "ts",
+      }) ?? "nestia.config.ts";
+    const configurations = async (): Promise<INestiaConfig[]> => {
+      const command: NestiaConfigLoader.ICompilerOptions =
+        await NestiaConfigLoader.compilerOptions(project);
+      return NestiaConfigLoader.configurations(
+        configFile,
         command.raw.compilerOptions ?? {},
       );
+    };
+    const generate = async (configurations: INestiaConfig[]): Promise<void> => {
+      if (
+        configurations.length > 1 &&
+        configurations.some(props.validate) === false
+      )
+        throw new Error(
+          `Every configurations are invalid to generate ${props.title}, ${props.solution}`,
+        );
+      for (const config of configurations) {
+        if (configurations.length > 1 && props.validate(config) === false)
+          continue;
+        const app: NestiaSdkApplication = new NestiaSdkApplication(config);
+        await props.generate(app);
+      }
+    };
 
-    // GENERATE
-    if (
-      configurations.length > 1 &&
-      configurations.some(props.validate) === false
-    )
-      throw new Error(
-        `Every configurations are invalid to generate ${props.title}, ${props.solution}`,
-      );
-    for (const config of configurations) {
-      if (configurations.length > 1 && props.validate(config) === false)
-        continue;
-      const app: NestiaSdkApplication = new NestiaSdkApplication(config);
-      await props.generate(app);
-    }
+    if (props.watch === true)
+      return NestiaSdkWatcher.watch({
+        configFile,
+        configurations,
+        generate,
+        projectFile: project,
+      });
+
+    await generate(await configurations());
   };
 
   const getFileArgument = (props: {
@@ -103,4 +118,7 @@ export namespace NestiaSdkCommand {
       throw new Error(`${props.type} file must be ${props.extension} file`);
     return file;
   };
+
+  const hasFlagArgument = (type: string): boolean =>
+    process.argv.slice(3).some((str) => str === `--${type}`);
 }

--- a/packages/sdk/src/executable/internal/NestiaSdkWatcher.ts
+++ b/packages/sdk/src/executable/internal/NestiaSdkWatcher.ts
@@ -1,0 +1,342 @@
+import fs from "fs";
+import { glob } from "glob";
+import path from "path";
+
+import { INestiaConfig } from "../../INestiaConfig";
+
+export namespace NestiaSdkWatcher {
+  export interface IProps {
+    configFile: string;
+    configurations: () => Promise<INestiaConfig[]>;
+    generate: (configurations: INestiaConfig[]) => Promise<void>;
+    projectFile: string;
+  }
+
+  export const watch = async (props: IProps): Promise<void> => {
+    const session = new WatchSession(props);
+    session.registerSignals();
+    await session.regenerate("initial generation");
+    await new Promise<void>(() => {});
+  };
+}
+
+class WatchSession {
+  private readonly watchers: Map<string, fs.FSWatcher> = new Map();
+  private debounce: NodeJS.Timeout | null = null;
+  private ignored: string[] = [];
+  private pending: string | null = null;
+  private running: boolean = false;
+  private stopped: boolean = false;
+
+  public constructor(private readonly props: NestiaSdkWatcher.IProps) {}
+
+  public registerSignals(): void {
+    const stop = (): void => {
+      this.dispose();
+      process.exit(0);
+    };
+    process.once("SIGINT", stop);
+    process.once("SIGTERM", stop);
+  }
+
+  public async regenerate(reason: string): Promise<void> {
+    if (this.stopped) return;
+    if (this.running) {
+      this.pending = reason;
+      return;
+    }
+
+    this.running = true;
+    let nextReason: string | null = reason;
+    do {
+      const current: string = nextReason;
+      nextReason = null;
+      this.pending = null;
+      let configurations: INestiaConfig[] = [];
+      try {
+        if (current === "initial generation")
+          console.log("Starting nestia swagger watch mode");
+        else console.log(`Change detected (${current}); regenerating swagger`);
+
+        configurations = await this.props.configurations();
+        await this.props.generate(configurations);
+        await this.refresh(configurations);
+        console.log(
+          `Watching ${this.watchers.size} directories. Press Ctrl+C to stop.`,
+        );
+      } catch (error) {
+        await this.refresh(configurations);
+        console.error("Nestia swagger watch generation failed:");
+        printError(error);
+      }
+      nextReason = this.pending;
+    } while (nextReason !== null && !this.stopped);
+    this.running = false;
+  }
+
+  private schedule(reason: string): void {
+    if (this.stopped) return;
+    if (this.debounce !== null) clearTimeout(this.debounce);
+    this.debounce = setTimeout(() => {
+      this.debounce = null;
+      void this.regenerate(reason);
+    }, 250);
+  }
+
+  private async refresh(configurations: INestiaConfig[]): Promise<void> {
+    const next = await collectWatchPlan({
+      configurations,
+      configFile: this.props.configFile,
+      projectFile: this.props.projectFile,
+    });
+    this.ignored = next.ignored;
+
+    const directories: Set<string> = new Set();
+    for (const target of next.targets)
+      await collectDirectories({
+        directories,
+        ignored: next.ignored,
+        target,
+      });
+    this.sync(directories);
+  }
+
+  private sync(next: Set<string>): void {
+    for (const [directory, watcher] of this.watchers)
+      if (next.has(directory) === false) {
+        watcher.close();
+        this.watchers.delete(directory);
+      }
+
+    for (const directory of next) {
+      if (this.watchers.has(directory)) continue;
+      try {
+        const watcher = fs.watch(directory, (event, filename) => {
+          const target =
+            filename === null || filename === undefined
+              ? directory
+              : path.resolve(directory, String(filename));
+          if (shouldIgnore(target, this.ignored)) return;
+          if (shouldReact({ event, target }) === false) return;
+          this.schedule(relative(target));
+        });
+        watcher.on("error", () => {
+          watcher.close();
+          this.watchers.delete(directory);
+          this.schedule(relative(directory));
+        });
+        this.watchers.set(directory, watcher);
+      } catch {
+        continue;
+      }
+    }
+  }
+
+  private dispose(): void {
+    this.stopped = true;
+    if (this.debounce !== null) clearTimeout(this.debounce);
+    for (const watcher of this.watchers.values()) watcher.close();
+    this.watchers.clear();
+  }
+}
+
+interface IWatchPlan {
+  ignored: string[];
+  targets: string[];
+}
+
+const collectWatchPlan = async (props: {
+  configurations: INestiaConfig[];
+  configFile: string;
+  projectFile: string;
+}): Promise<IWatchPlan> => {
+  const targets: Set<string> = new Set([
+    path.resolve(props.configFile),
+    path.resolve(props.projectFile),
+  ]);
+  const ignored: Set<string> = new Set([
+    path.resolve("node_modules"),
+    path.resolve(".git"),
+  ]);
+
+  for (const config of props.configurations) {
+    for (const target of await inputTargets(config.input)) targets.add(target);
+    for (const target of outputTargets(config)) ignored.add(target);
+  }
+  return {
+    ignored: [...ignored],
+    targets: [...targets],
+  };
+};
+
+const inputTargets = async (
+  input: INestiaConfig["input"],
+): Promise<string[]> => {
+  if (typeof input === "function") {
+    const fallback: string = path.resolve("src");
+    return [fs.existsSync(fallback) ? fallback : process.cwd()];
+  }
+
+  const patterns: string[] = Array.isArray(input)
+    ? input
+    : typeof input === "object"
+      ? input.include
+      : [input];
+  const output: Set<string> = new Set();
+  for (const pattern of patterns) {
+    for (const target of await patternTargets(pattern)) output.add(target);
+  }
+  return [...output];
+};
+
+const patternTargets = async (pattern: string): Promise<string[]> => {
+  const output: Set<string> = new Set();
+  const direct: string = path.resolve(pattern);
+  if (fs.existsSync(direct)) output.add(direct);
+
+  if (hasGlobMagic(pattern)) {
+    const root: string = staticRoot(pattern);
+    if (fs.existsSync(root)) output.add(root);
+    for (const match of await glob(pattern)) output.add(path.resolve(match));
+  }
+  return [...output];
+};
+
+const outputTargets = (config: INestiaConfig): string[] => {
+  const output: string[] = [];
+  for (const value of [config.output, config.e2e, config.distribute])
+    if (typeof value === "string") output.push(path.resolve(value));
+  if (config.swagger?.output !== undefined) {
+    const parsed: path.ParsedPath = path.parse(config.swagger.output);
+    output.push(
+      parsed.ext
+        ? path.resolve(config.swagger.output)
+        : path.resolve(config.swagger.output, "swagger.json"),
+    );
+  }
+  return output;
+};
+
+const collectDirectories = async (props: {
+  directories: Set<string>;
+  ignored: string[];
+  target: string;
+}): Promise<void> => {
+  const stats: fs.Stats | null = await safeStat(props.target);
+  if (stats === null) return;
+  const root: string = stats.isDirectory()
+    ? props.target
+    : path.dirname(props.target);
+  await iterateDirectories({
+    directories: props.directories,
+    ignored: props.ignored,
+    root,
+  });
+};
+
+const iterateDirectories = async (props: {
+  directories: Set<string>;
+  ignored: string[];
+  root: string;
+}): Promise<void> => {
+  const location: string = path.resolve(props.root);
+  if (shouldIgnore(location, props.ignored)) return;
+  props.directories.add(location);
+
+  let entries: fs.Dirent[];
+  try {
+    entries = await fs.promises.readdir(location, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    if (entry.isDirectory() === false) continue;
+    if (SKIPPED_DIRECTORIES.has(entry.name)) continue;
+    await iterateDirectories({
+      directories: props.directories,
+      ignored: props.ignored,
+      root: path.join(location, entry.name),
+    });
+  }
+};
+
+const safeStat = async (location: string): Promise<fs.Stats | null> => {
+  try {
+    return await fs.promises.stat(location);
+  } catch {
+    return null;
+  }
+};
+
+const shouldReact = (props: { event: string; target: string }): boolean => {
+  const ext: string = path.extname(props.target).toLowerCase();
+  if (SOURCE_EXTENSIONS.has(ext)) return true;
+  return props.event === "rename" && ext.length === 0;
+};
+
+const shouldIgnore = (location: string, ignored: string[]): boolean =>
+  ignored.some((elem) => isSameOrInside(location, elem));
+
+const isSameOrInside = (child: string, parent: string): boolean => {
+  const left: string = comparable(child);
+  const right: string = comparable(parent);
+  return left === right || left.startsWith(`${right}${path.sep}`);
+};
+
+const comparable = (location: string): string => {
+  const resolved: string = path.resolve(location);
+  return process.platform === "win32" ? resolved.toLowerCase() : resolved;
+};
+
+const staticRoot = (pattern: string): string => {
+  const absolute: string = path.resolve(pattern);
+  const parsed: path.ParsedPath = path.parse(absolute);
+  const segments: string[] = absolute
+    .slice(parsed.root.length)
+    .split(/[\\/]+/)
+    .filter((segment) => segment.length !== 0);
+  const stable: string[] = [];
+  for (const segment of segments) {
+    if (hasGlobMagic(segment)) break;
+    stable.push(segment);
+  }
+  return stable.length === 0 ? parsed.root : path.join(parsed.root, ...stable);
+};
+
+const hasGlobMagic = (pattern: string): boolean => /[*?[\]{}]/.test(pattern);
+
+const relative = (location: string): string => {
+  const output: string = path.relative(process.cwd(), location);
+  return output.length === 0 ? "." : output.split(path.sep).join("/");
+};
+
+const printError = (error: unknown): void => {
+  let current: unknown = error;
+  let depth: number = 0;
+  while (current !== undefined && current !== null && depth < 10) {
+    const message: string =
+      current instanceof Error ? current.message : String(current);
+    console.error(
+      `${"  ".repeat(depth)}${depth === 0 ? "" : "caused by: "}${message}`,
+    );
+    if (current instanceof Error && current.cause !== undefined) {
+      current = current.cause;
+      ++depth;
+    } else break;
+  }
+};
+
+const SOURCE_EXTENSIONS: Set<string> = new Set([
+  ".cts",
+  ".json",
+  ".mts",
+  ".ts",
+  ".tsx",
+]);
+
+const SKIPPED_DIRECTORIES: Set<string> = new Set([
+  ".git",
+  ".nestia",
+  "node_modules",
+]);

--- a/packages/sdk/src/executable/sdk.ts
+++ b/packages/sdk/src/executable/sdk.ts
@@ -15,7 +15,7 @@ npx @nestia/sdk [command] [options?]
     - npx @nestia/sdk dependencies --manager pnpm
   2. npx @nestia/sdk init
   3. npx @nestia/sdk sdk --config? [config file] --project? [project file]
-  4. npx @nestia/sdk swagger --config? [config file] --project? [project file]
+  4. npx @nestia/sdk swagger --watch? --config? [config file] --project? [project file]
   5. npx @nestia/sdk e2e --config? [config file] --project? [project file]
   6. npx @nestia/sdk all --config? [config file] --project? [project file]
 `;
@@ -78,7 +78,9 @@ main().catch((exp) => {
   while (current !== undefined && current !== null && depth < 10) {
     const message: string =
       current instanceof Error ? current.message : String(current);
-    console.error(`${"  ".repeat(depth)}${depth === 0 ? "" : "caused by: "}${message}`);
+    console.error(
+      `${"  ".repeat(depth)}${depth === 0 ? "" : "caused by: "}${message}`,
+    );
     if (current instanceof Error && current.cause !== undefined) {
       current = current.cause;
       depth++;

--- a/tests/test-sdk/start.js
+++ b/tests/test-sdk/start.js
@@ -11,6 +11,7 @@ const CLI_BIN = path.join(ROOT, "packages/cli/bin/index.js");
 const TTSC_BIN = packageBin("ttsc", "ttsc");
 const TTSX_BIN = packageBin("ttsc", "ttsx");
 const BASE_PORT = 37_000;
+const WATCH_TIMEOUT = 90_000;
 
 process.env.NODE_OPTIONS = [
   process.env.NODE_OPTIONS ?? "",
@@ -90,6 +91,8 @@ const runNestia = (cwd, args, stdio = "ignore") =>
 const runTsc = (cwd, stdio = "ignore") => runNode(cwd, TTSC_BIN, [], stdio);
 
 const feature = async (name, port) => {
+  if (name === "swagger-watch") return runSwaggerWatchFeature();
+
   const cwd = featureDirectory(name);
   const configFile =
     name === "cli-config" || name === "cli-config-project"
@@ -221,6 +224,180 @@ const assertGeneratedImportsAreExtensionless = (cwd) => {
       ].join("\n"),
     );
 };
+
+const runSwaggerWatchFeature = async () => {
+  const cwd = featureDirectory(`.tmp-swagger-watch-${process.pid}`);
+  await fs.promises.rm(cwd, { force: true, recursive: true });
+  await writeSwaggerWatchFixture(cwd);
+
+  const child = cp.spawn(NODE, [CLI_BIN, "swagger", "--watch"], {
+    cwd,
+    env: { ...process.env },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let output = "";
+  let exit = null;
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk) => (output += chunk));
+  child.stderr.on("data", (chunk) => (output += chunk));
+  child.on("exit", (code, signal) => {
+    exit = { code, signal };
+  });
+
+  try {
+    const swagger = path.join(cwd, "swagger.json");
+    await waitUntil(
+      "initial swagger watch generation",
+      () => swaggerHasPath(swagger, "/health"),
+      () => exit,
+      () => output,
+    );
+
+    const controller = path.join(cwd, "src/controllers/HealthController.ts");
+    const original = fs.readFileSync(controller, "utf8");
+    const updated = original.replace(
+      "  public get(): void {}",
+      [
+        "  public get(): void {}",
+        "",
+        '  @core.TypedRoute.Get("watch")',
+        "  public watch(): void {}",
+      ].join("\n"),
+    );
+    if (updated === original)
+      throw new Error("Unable to update HealthController.ts watch route.");
+    fs.writeFileSync(controller, updated, "utf8");
+
+    await waitUntil(
+      "swagger watch regeneration",
+      () => swaggerHasPath(swagger, "/health/watch"),
+      () => exit,
+      () => output,
+    );
+  } finally {
+    await stopChild(child);
+    await fs.promises.rm(cwd, { force: true, recursive: true });
+  }
+};
+
+const writeSwaggerWatchFixture = async (cwd) => {
+  await fs.promises.mkdir(path.join(cwd, "src/controllers"), {
+    recursive: true,
+  });
+  await fs.promises.writeFile(
+    path.join(cwd, "package.json"),
+    JSON.stringify(
+      {
+        name: "@nestia/test-sdk-swagger-watch",
+        version: "0.0.0",
+        private: true,
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  await fs.promises.writeFile(
+    path.join(cwd, "tsconfig.json"),
+    JSON.stringify(
+      {
+        extends: "../../../config/tsconfig.json",
+        include: ["src"],
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  await fs.promises.writeFile(
+    path.join(cwd, "nestia.config.ts"),
+    [
+      'import { INestiaConfig } from "@nestia/sdk";',
+      "",
+      "export const NESTIA_CONFIG: INestiaConfig = {",
+      '  input: ["src/controllers"],',
+      "  swagger: {",
+      '    output: "swagger.json",',
+      "    info: {",
+      '      title: "Swagger Watch Test",',
+      "    },",
+      "  },",
+      "};",
+      "export default NESTIA_CONFIG;",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  await fs.promises.writeFile(
+    path.join(cwd, "src/controllers/HealthController.ts"),
+    [
+      'import core from "@nestia/core";',
+      'import { Controller } from "@nestjs/common";',
+      "",
+      '@Controller("health")',
+      "export class HealthController {",
+      "  @core.TypedRoute.Get()",
+      "  public get(): void {}",
+      "}",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+};
+
+const swaggerHasPath = (file, accessor) => {
+  if (!fs.existsSync(file)) return false;
+  const document = JSON.parse(fs.readFileSync(file, "utf8"));
+  return document.paths?.[accessor] !== undefined;
+};
+
+const waitUntil = async (title, predicate, exit, output) => {
+  const started = Date.now();
+  let lastError = null;
+  while (Date.now() - started < WATCH_TIMEOUT) {
+    const status = exit();
+    if (status !== null)
+      throw new Error(
+        [
+          `${title} failed because watch process exited with ${
+            status.signal ?? `code ${status.code}`
+          }.`,
+          output().slice(-4_000),
+        ].join("\n"),
+      );
+    try {
+      if (predicate()) return;
+    } catch (error) {
+      lastError = error;
+    }
+    await delay(250);
+  }
+  throw new Error(
+    [
+      `${title} timed out.`,
+      lastError instanceof Error ? lastError.message : "",
+      output().slice(-4_000),
+    ]
+      .filter(Boolean)
+      .join("\n"),
+  );
+};
+
+const stopChild = async (child) => {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  const exited = new Promise((resolve) => child.once("exit", resolve));
+  child.kill();
+  await Promise.race([
+    exited,
+    delay(2_000).then(() => {
+      if (child.exitCode === null && child.signalCode === null)
+        child.kill("SIGKILL");
+    }),
+  ]);
+};
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const runTtsxTest = async (cwd, stdio = "ignore", port = BASE_PORT) => {
   const project = ".ttsx.tsconfig.json";
@@ -444,7 +621,9 @@ const main = async () => {
     const filter = featureFilter();
     const names = (await fs.promises.readdir(featureDirectory()))
       .sort()
+      .filter((name) => !name.startsWith(".tmp-"))
       .filter(filter);
+    if (filter("swagger-watch")) names.push("swagger-watch");
     await runFeatures(names);
   });
 };

--- a/website/src/content/docs/swagger/index.mdx
+++ b/website/src/content/docs/swagger/index.mdx
@@ -112,6 +112,14 @@ npx nestia all
 
 Output: `dist/swagger.json`. Feed it to Swagger UI, Redoc, Postman imports, the [Nestia Editor](./editor), or `@nestia/chat`.
 
+For local live reload workflows, run the swagger generator in watch mode:
+
+```bash filename="Terminal" copy
+npx nestia swagger --watch
+```
+
+Watch mode writes the initial document, then regenerates it when controller, `nestia.config.ts`, or `tsconfig.json` inputs change. Point your dev server or Swagger UI reload tooling at the generated file.
+
 ### OpenAPI versions
 
 The `openapi` field accepts `"3.1"` (default), `"3.0"`, or `"2.0"`. Nestia generates the spec at 3.1 internally and downgrades on the way out — your type fidelity is highest at 3.1, but the document is still legal at older versions.

--- a/website/src/content/docs/tutorial/swagger.mdx
+++ b/website/src/content/docs/tutorial/swagger.mdx
@@ -47,6 +47,14 @@ npx nestia swagger
 
 Output: `dist/swagger.json`. You can drop that file straight into Swagger UI, Redoc, Postman, or any OpenAPI tool.
 
+During local development, keep the file fresh while editing controllers:
+
+```bash filename="Terminal" copy
+npx nestia swagger --watch
+```
+
+The watcher runs the same generator immediately, then regenerates the document when controller, config, or project files change.
+
 ---
 
 ## 2. What ends up in the schema


### PR DESCRIPTION
﻿## Summary

Closes #703.

Adds `npx nestia swagger --watch` / `npx @nestia/sdk swagger --watch` for local live reload workflows. The command runs the normal swagger generator immediately, then watches controller inputs, `nestia.config.ts`, and `tsconfig.json`-style project inputs and reruns the same generator after a debounced file change.

## Implementation

- adds `NestiaSdkWatcher` using Node `fs.watch` and the existing `glob` package, with no new dependencies
- keeps one-shot generation and watch generation on the same `NestiaSdkApplication.swagger()` path
- ignores generated SDK/swagger output paths, `node_modules`, `.git`, and `.nestia` so output writes do not loop the watcher
- adds a `swagger-watch` synthetic test-sdk feature that starts the real CLI watch process, writes an isolated temporary fixture, edits its controller, and waits for `swagger.json` to gain the new route
- documents `nestia swagger --watch` in the tutorial and swagger reference pages

## Validation

- `pnpm --filter @nestia/sdk build`
- `pnpm --filter nestia build`
- `TEST_SDK_SKIP_BUILD=1 node tests/test-sdk/start.js --only swagger-watch --concurrency 1`
- `pnpm exec prettier --check packages/sdk/src/executable/internal/NestiaSdkWatcher.ts packages/sdk/src/executable/internal/NestiaSdkCommand.ts packages/sdk/src/executable/sdk.ts packages/cli/src/index.ts tests/test-sdk/start.js`
- `git diff --cached --check`

## Local limitations

- `node tests/test-sdk/start.js --only swagger --concurrency 1` still fails locally on existing Windows tsgo temp-path normalization issues unrelated to this change. The new `swagger-watch` synthetic case passes when executed alone.
- `npm --prefix website run build` fails before docs compile because `website/build/editor.js` cannot resolve `jszip` in this checkout.
- `pnpm exec prettier --check --parser mdx ...` warns on the touched MDX files because the existing docs formatting does not match Prettier output; the MDX change is intentionally minimal.
