### PR TITLE
fix(sdk): harden release review follow-ups

### DIFF
--- a/packages/core/native/transform/core_transform.go
+++ b/packages/core/native/transform/core_transform.go
@@ -1585,7 +1585,8 @@ func NestiaCoreMethodReturnType(prog *driver.Program, node *shimast.Node) *shimc
 		return nil
 	}
 	symbol := typ.Symbol()
-	if symbol != nil && nestiaCoreIsAsyncReturnWrapper(symbol.Name) {
+	if symbol != nil &&
+		nestiaCoreIsAsyncReturnWrapperSymbol(symbol.Name, symbol.Declarations) {
 		args := prog.Checker.GetTypeArguments(typ)
 		if len(args) == 1 {
 			return args[0]
@@ -1606,15 +1607,91 @@ func nestiaCoreExplicitAsyncReturnType(prog *driver.Program, node *shimast.Node)
 	if ref == nil || ref.TypeArguments == nil || len(ref.TypeArguments.Nodes) != 1 {
 		return nil
 	}
-	if nestiaCoreIsAsyncReturnWrapper(nestiaCoreTypeNodeText(ref.TypeName)) == false {
+	if nestiaCoreIsAsyncReturnWrapperReference(prog, ref.TypeName) == false {
 		return nil
 	}
 	return prog.Checker.GetTypeFromTypeNode(ref.TypeArguments.Nodes[0])
 }
 
-func nestiaCoreIsAsyncReturnWrapper(name string) bool {
-	return name == "Promise" || name == "Observable"
+func nestiaCoreIsAsyncReturnWrapperReference(
+	prog *driver.Program,
+	node *shimast.Node,
+) bool {
+	name := nestiaCoreTypeNodeText(node)
+	if name == "Promise" {
+		return true
+	}
+	if name != "Observable" || prog == nil || prog.Checker == nil {
+		return false
+	}
+	symbol := prog.Checker.GetSymbolAtLocation(node)
+	return nestiaCoreIsRxjsObservableImport(node) ||
+		(symbol != nil && nestiaCoreIsRxjsDeclarations(symbol.Declarations))
 }
+
+func nestiaCoreIsAsyncReturnWrapperSymbol(
+	name string,
+	declarations []*shimast.Node,
+) bool {
+	if name == "Promise" {
+		return true
+	}
+	return name == "Observable" && nestiaCoreIsRxjsDeclarations(declarations)
+}
+
+func nestiaCoreIsRxjsDeclarations(declarations []*shimast.Node) bool {
+	for _, decl := range declarations {
+		sourceFile := shimast.GetSourceFileOfNode(decl)
+		if sourceFile == nil {
+			continue
+		}
+		file := filepath.ToSlash(sourceFile.FileName())
+		if strings.Contains(file, "/node_modules/rxjs/") {
+			return true
+		}
+	}
+	return false
+}
+
+func nestiaCoreIsRxjsObservableImport(node *shimast.Node) bool {
+	source, ok := SourceFileText(shimast.GetSourceFileOfNode(node))
+	return ok && nestiaCoreHasNamedImport(source, "rxjs", "Observable", "Observable")
+}
+
+func nestiaCoreHasNamedImport(
+	source string,
+	module string,
+	imported string,
+	local string,
+) bool {
+	for _, match := range nestiaCoreImportFromPattern.FindAllStringSubmatch(source, -1) {
+		if len(match) < 3 || match[2] != module {
+			continue
+		}
+		open := strings.Index(match[1], "{")
+		close := strings.LastIndex(match[1], "}")
+		if open < 0 || close <= open {
+			continue
+		}
+		for _, part := range strings.Split(match[1][open+1:close], ",") {
+			fields := strings.Fields(strings.TrimPrefix(strings.TrimSpace(part), "type "))
+			if len(fields) == 1 && fields[0] == local && imported == local {
+				return true
+			}
+			if len(fields) == 3 &&
+				fields[0] == imported &&
+				fields[1] == "as" &&
+				fields[2] == local {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+var nestiaCoreImportFromPattern = regexp.MustCompile(
+	`(?s)import\s+(?:type\s+)?(.+?)\s+from\s+["']([^"']+)["']`,
+)
 
 func nestiaCoreTypeNodeText(node *shimast.Node) string {
 	if node == nil {

--- a/packages/core/test/method_return_type_observable_test.go
+++ b/packages/core/test/method_return_type_observable_test.go
@@ -10,17 +10,17 @@ import (
 	"github.com/samchon/ttsc/packages/ttsc/driver"
 )
 
-// TestMethodReturnTypeObservable verifies Observable<T> return types unwrap to
-// their payload type.
+// TestMethodReturnTypeObservable verifies local Observable<T> aliases do not
+// unwrap as RxJS route payloads.
 //
-// Locks NestJS Observable route support in the native return-type helper. The
-// SDK and core transforms both consume this helper; if it treats Observable<T>
-// as the response object itself, generated SDK clients lose the controller
-// payload type and Swagger metadata points at the wrapper instead.
+// Locks the guard around NestJS Observable route support in the native
+// return-type helper. RxJS Observable<T> is an asynchronous NestJS response
+// wrapper, but an unrelated user-defined type with the same name is just a
+// normal DTO and must not be unwrapped by name alone.
 //
-//  1. Load a temporary controller method returning Observable<{ foo: string }>.
+//  1. Load a temporary controller method returning a local Observable<T> type.
 //  2. Resolve the method's return type through NestiaCoreMethodReturnType.
-//  3. Assert the resolved type is the payload rather than Observable<T>.
+//  3. Assert the resolved type remains the Observable wrapper.
 func TestMethodReturnTypeObservable(t *testing.T) {
 	temp := t.TempDir()
 	writeFile(t, filepath.Join(temp, "tsconfig.json"), `{
@@ -80,13 +80,7 @@ class ReproController {
 		t.Fatal("observable return type was not resolved")
 	}
 	text := prog.Checker.TypeToString(typ)
-	if text == "Observable<{ foo: string; bar?: number | undefined; }>" {
-		t.Fatalf("Observable wrapper was not unwrapped: %s", text)
-	}
-	if text == "Observable<{ foo: string; bar?: number; }>" {
-		t.Fatalf("Observable wrapper was not unwrapped: %s", text)
-	}
-	if strings.Contains(text, "foo") == false {
-		t.Fatalf("observable payload field was not preserved: %s", text)
+	if strings.Contains(text, "Observable") == false {
+		t.Fatalf("local Observable wrapper was unexpectedly unwrapped: %s", text)
 	}
 }

--- a/packages/sdk/native/sdk/sdk_transform.go
+++ b/packages/sdk/native/sdk/sdk_transform.go
@@ -270,7 +270,7 @@ func nestiaSDKMetadataText(context *nestiaSDKContext, file *shimast.SourceFile, 
 		}
 	}
 	returnType := transform.NestiaCoreMethodReturnType(prog, method)
-	returnTypeNode := nestiaSDKMethodReturnTypeNode(method)
+	returnTypeNode := nestiaSDKMethodReturnTypeNode(prog, method)
 	exceptions := nestiaSDKExceptionResponses(context, imports, method)
 	metadata := map[string]any{
 		"parameters":  parameters,
@@ -1409,11 +1409,11 @@ func nestiaSDKReflectTypeNode(
 		ref := node.AsTypeReferenceNode()
 		name := nestiaSDKEntityNameText(ref.TypeName)
 		rootRefs := nestiaSDKReflectImports(name, imports)
-		if len(rootRefs) == 0 && nestiaSDKIsAsyncReturnWrapper(name) == false {
+		if len(rootRefs) == 0 && nestiaSDKIsAsyncReturnWrapper(prog, ref.TypeName, name) == false {
 			rootRefs = nestiaSDKReflectTypeReferenceSymbolImport(prog, ref.TypeName, name)
 		}
 		if ref.TypeArguments != nil && len(ref.TypeArguments.Nodes) != 0 {
-			if nestiaSDKIsAsyncReturnWrapper(name) && len(ref.TypeArguments.Nodes) == 1 {
+			if nestiaSDKIsAsyncReturnWrapper(prog, ref.TypeName, name) && len(ref.TypeArguments.Nodes) == 1 {
 				return nestiaSDKReflectTypeNode(prog, imports, ref.TypeArguments.Nodes[0])
 			}
 			args := make([]any, 0, len(ref.TypeArguments.Nodes))
@@ -1589,28 +1589,32 @@ func nestiaSDKParameterTypeNode(node *shimast.Node) *shimast.Node {
 	return nil
 }
 
-func nestiaSDKMethodReturnTypeName(prog *driver.Program, method *shimast.Node, typ *shimchecker.Type) string {
+func nestiaSDKMethodReturnTypeName(
+	prog *driver.Program,
+	method *shimast.Node,
+	typ *shimchecker.Type,
+) string {
 	if method != nil && method.FunctionLikeData() != nil {
 		if typeNode := method.FunctionLikeData().Type; typeNode != nil {
-			return nestiaSDKReturnTypeNodeText(typeNode)
+			return nestiaSDKReturnTypeNodeText(prog, typeNode)
 		}
 	}
 	return nestiaSDKTypeNameFromChecker(prog, typ)
 }
 
-func nestiaSDKMethodReturnTypeNode(method *shimast.Node) *shimast.Node {
+func nestiaSDKMethodReturnTypeNode(prog *driver.Program, method *shimast.Node) *shimast.Node {
 	if method != nil && method.FunctionLikeData() != nil {
 		if typeNode := method.FunctionLikeData().Type; typeNode != nil {
-			return nestiaSDKReturnTypeNode(typeNode)
+			return nestiaSDKReturnTypeNode(prog, typeNode)
 		}
 	}
 	return nil
 }
 
-func nestiaSDKReturnTypeNode(node *shimast.Node) *shimast.Node {
+func nestiaSDKReturnTypeNode(prog *driver.Program, node *shimast.Node) *shimast.Node {
 	if node != nil && node.Kind == shimast.KindTypeReference {
 		ref := node.AsTypeReferenceNode()
-		if ref != nil && ref.TypeArguments != nil && len(ref.TypeArguments.Nodes) == 1 && nestiaSDKIsAsyncReturnWrapper(nestiaSDKEntityNameText(ref.TypeName)) {
+		if ref != nil && ref.TypeArguments != nil && len(ref.TypeArguments.Nodes) == 1 && nestiaSDKIsAsyncReturnWrapper(prog, ref.TypeName, nestiaSDKEntityNameText(ref.TypeName)) {
 			return ref.TypeArguments.Nodes[0]
 		}
 	}
@@ -1621,20 +1625,86 @@ func nestiaSDKEntityNameText(node *shimast.Node) string {
 	return nestiaSDKTypeNodeText(node)
 }
 
-func nestiaSDKReturnTypeNodeText(node *shimast.Node) string {
+func nestiaSDKReturnTypeNodeText(prog *driver.Program, node *shimast.Node) string {
 	text := nestiaSDKTypeNodeText(node)
 	if node != nil && node.Kind == shimast.KindTypeReference {
 		ref := node.AsTypeReferenceNode()
-		if ref != nil && ref.TypeArguments != nil && len(ref.TypeArguments.Nodes) == 1 && nestiaSDKIsAsyncReturnWrapper(nestiaSDKEntityNameText(ref.TypeName)) {
+		if ref != nil && ref.TypeArguments != nil && len(ref.TypeArguments.Nodes) == 1 && nestiaSDKIsAsyncReturnWrapper(prog, ref.TypeName, nestiaSDKEntityNameText(ref.TypeName)) {
 			return nestiaSDKTypeNodeText(ref.TypeArguments.Nodes[0])
 		}
 	}
 	return text
 }
 
-func nestiaSDKIsAsyncReturnWrapper(name string) bool {
-	return name == "Promise" || name == "Observable"
+func nestiaSDKIsAsyncReturnWrapper(
+	prog *driver.Program,
+	node *shimast.Node,
+	name string,
+) bool {
+	if name == "Promise" {
+		return true
+	}
+	if name != "Observable" || prog == nil || prog.Checker == nil {
+		return false
+	}
+	symbol := prog.Checker.GetSymbolAtLocation(node)
+	return nestiaSDKIsRxjsObservableImport(node) ||
+		(symbol != nil && nestiaSDKIsRxjsDeclarations(symbol.Declarations))
 }
+
+func nestiaSDKIsRxjsDeclarations(declarations []*shimast.Node) bool {
+	for _, decl := range declarations {
+		sourceFile := shimast.GetSourceFileOfNode(decl)
+		if sourceFile == nil {
+			continue
+		}
+		file := filepath.ToSlash(sourceFile.FileName())
+		if strings.Contains(file, "/node_modules/rxjs/") {
+			return true
+		}
+	}
+	return false
+}
+
+func nestiaSDKIsRxjsObservableImport(node *shimast.Node) bool {
+	source, ok := transform.SourceFileText(shimast.GetSourceFileOfNode(node))
+	return ok && nestiaSDKHasNamedImport(source, "rxjs", "Observable", "Observable")
+}
+
+func nestiaSDKHasNamedImport(
+	source string,
+	module string,
+	imported string,
+	local string,
+) bool {
+	for _, match := range nestiaSDKImportFromPattern.FindAllStringSubmatch(source, -1) {
+		if len(match) < 3 || match[2] != module {
+			continue
+		}
+		open := strings.Index(match[1], "{")
+		close := strings.LastIndex(match[1], "}")
+		if open < 0 || close <= open {
+			continue
+		}
+		for _, part := range strings.Split(match[1][open+1:close], ",") {
+			fields := strings.Fields(strings.TrimPrefix(strings.TrimSpace(part), "type "))
+			if len(fields) == 1 && fields[0] == local && imported == local {
+				return true
+			}
+			if len(fields) == 3 &&
+				fields[0] == imported &&
+				fields[1] == "as" &&
+				fields[2] == local {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+var nestiaSDKImportFromPattern = regexp.MustCompile(
+	`(?s)import\s+(?:type\s+)?(.+?)\s+from\s+["']([^"']+)["']`,
+)
 
 func nestiaSDKTypeNodeText(node *shimast.Node) string {
 	if node == nil {

--- a/packages/sdk/src/analyses/ReflectMcpOperationAnalyzer.ts
+++ b/packages/sdk/src/analyses/ReflectMcpOperationAnalyzer.ts
@@ -1,3 +1,5 @@
+import { METHOD_METADATA, PATH_METADATA } from "@nestjs/common/constants";
+
 import { INestiaProject } from "../structures/INestiaProject";
 import { IOperationMetadata } from "../structures/IOperationMetadata";
 import { IReflectController } from "../structures/IReflectController";
@@ -29,6 +31,16 @@ export namespace ReflectMcpOperationAnalyzer {
     if (route === undefined) return null;
 
     const errors: string[] = [];
+    const hasHttpRoute: boolean =
+      Reflect.getMetadata(PATH_METADATA, ctx.function) !== undefined ||
+      Reflect.getMetadata(METHOD_METADATA, ctx.function) !== undefined;
+    const hasWebSocketRoute: boolean =
+      Reflect.getMetadata("nestia/WebSocketRoute", ctx.function) !== undefined;
+
+    if (hasHttpRoute || hasWebSocketRoute)
+      errors.push(
+        "@McpRoute must not be combined with HTTP or WebSocket route decorators on the same method.",
+      );
 
     const preconfigured: IReflectMcpOperationParameter.IPreconfigured[] = (
       (Reflect.getMetadata(

--- a/packages/sdk/src/generates/internal/SdkHttpCloneReferencer.ts
+++ b/packages/sdk/src/generates/internal/SdkHttpCloneReferencer.ts
@@ -72,7 +72,9 @@ export namespace SdkHttpCloneReferencer {
     const unique: Set<string> = new Set();
     const keep: ITypedWebSocketRoute["imports"] = [];
     for (const imp of props.route.imports) {
-      const cloned: string[] = imp.file.includes("node_modules")
+      const cloned: string[] = SdkWebSocketCloneProgrammer.isNodeModulesPath(
+        imp.file,
+      )
         ? []
         : imp.elements.filter((elem) =>
             props.cloned.has(

--- a/packages/sdk/src/generates/internal/SdkMcpRouteProgrammer.ts
+++ b/packages/sdk/src/generates/internal/SdkMcpRouteProgrammer.ts
@@ -1,4 +1,5 @@
 import {
+  IdentifierFactory,
   Node,
   NodeFlags,
   SyntaxKind,
@@ -227,10 +228,19 @@ export namespace SdkMcpRouteProgrammer {
                             TypeScriptFactory.createArrowFunction(
                               undefined,
                               undefined,
-                              [],
+                              [IdentifierFactory.parameter("entry")],
                               undefined,
                               undefined,
-                              TypeScriptFactory.createTrue(),
+                              TypeScriptFactory.createBinaryExpression(
+                                TypeScriptFactory.createPropertyAccessExpression(
+                                  TypeScriptFactory.createIdentifier("entry"),
+                                  "type",
+                                ),
+                                TypeScriptFactory.createToken(
+                                  SyntaxKind.EqualsEqualsEqualsToken,
+                                ),
+                                TypeScriptFactory.createStringLiteral("text"),
+                              ),
                             ),
                           ],
                         ),

--- a/packages/sdk/src/generates/internal/SdkWebSocketCloneProgrammer.ts
+++ b/packages/sdk/src/generates/internal/SdkWebSocketCloneProgrammer.ts
@@ -25,7 +25,7 @@ export namespace SdkWebSocketCloneProgrammer {
     (ctx: IContext) =>
     async (file: string, name: string): Promise<boolean> => {
       const location: string | null = await resolveSourceFile(file);
-      if (location === null || location.includes("node_modules")) return false;
+      if (location === null || isNodeModulesPath(location)) return false;
 
       const key: string = `${location}#${name}`;
       const status: CloneStatus | undefined = ctx.visited.get(key);
@@ -289,6 +289,12 @@ export namespace SdkWebSocketCloneProgrammer {
 
   export const importKey = (file: string, name: string): string =>
     `${file}#${name}`;
+
+  export const isNodeModulesPath = (file: string): boolean =>
+    path
+      .resolve(file)
+      .split(/[\\/]+/)
+      .includes("node_modules");
 }
 
 interface IContext {

--- a/tests/test-sdk/features/mcp-error-mixed-http/nestia.config.ts
+++ b/tests/test-sdk/features/mcp-error-mixed-http/nestia.config.ts
@@ -1,0 +1,7 @@
+import { INestiaConfig } from "@nestia/sdk";
+
+export const NESTIA_CONFIG: INestiaConfig = {
+  input: ["src/controllers"],
+  output: "src/api",
+};
+export default NESTIA_CONFIG;

--- a/tests/test-sdk/features/mcp-error-mixed-http/src/controllers/McpErrorController.ts
+++ b/tests/test-sdk/features/mcp-error-mixed-http/src/controllers/McpErrorController.ts
@@ -1,0 +1,20 @@
+import core from "@nestia/core";
+import { Controller } from "@nestjs/common";
+
+/**
+ * Compile-fail fixture: an MCP tool and HTTP route must be separate methods so
+ * SDK analysis cannot silently drop one protocol surface.
+ *
+ * @author wildduck - https://github.com/wildduck2
+ */
+@Controller()
+export class McpErrorController {
+  @core.McpRoute("mixed_http")
+  @core.TypedRoute.Get("mixed-http")
+  public async run(
+    @core.McpRoute.Params() params: { value: string },
+  ): Promise<{ ok: boolean }> {
+    void params;
+    return { ok: true };
+  }
+}

--- a/tests/test-sdk/features/mcp-error-mixed-http/tsconfig.json
+++ b/tests/test-sdk/features/mcp-error-mixed-http/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../config/tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      "@api": ["./src/api"],
+      "@api/lib/*": ["./src/api/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/tests/test-sdk/features/swagger-hidden/src/test/features/test_sdk.ts
+++ b/tests/test-sdk/features/swagger-hidden/src/test/features/test_sdk.ts
@@ -2,6 +2,17 @@ import { TestValidator } from "@nestia/e2e";
 
 import api from "@api";
 
+/**
+ * Verifies Swagger exclusion decorators do not remove SDK functions.
+ *
+ * Locks the distinction between SDK generation and Swagger document emission.
+ * `@ApiExcludeController()` and `@ApiExcludeEndpoint()` are Swagger-only
+ * decorators; generated typed SDK clients must still expose callable routes.
+ *
+ * 1. Read the generated SDK functional namespace.
+ * 2. Assert excluded and visible controllers are all present.
+ * 3. Keep the assertion sorted so namespace churn is explicit.
+ */
 export async function test_sdk(): Promise<void> {
   TestValidator.equals("functions", Object.keys(api.functional).sort(), [
     "internal",

--- a/tests/test-sdk/features/swagger-hidden/src/test/features/test_swagger.ts
+++ b/tests/test-sdk/features/swagger-hidden/src/test/features/test_swagger.ts
@@ -1,6 +1,18 @@
 import { TestValidator } from "@nestia/e2e";
 import fs from "fs";
 
+/**
+ * Verifies Swagger exclusion decorators remove only hidden Swagger paths.
+ *
+ * Locks `SwaggerGenerator`'s handling of `@ApiExcludeController()` and
+ * `@ApiExcludeEndpoint()`. The fixture intentionally leaves one visible route
+ * beside excluded routes so the test fails if the generator either ignores
+ * exclusions or drops the whole controller namespace.
+ *
+ * 1. Read the generated Swagger document.
+ * 2. List all emitted paths.
+ * 3. Assert only the visible endpoint remains.
+ */
 export async function test_swagger(): Promise<void> {
   const swagger = JSON.parse(
     await fs.promises.readFile(__dirname + "/../../../swagger.json", "utf8"),

--- a/website/src/content/docs/core/McpRoute.mdx
+++ b/website/src/content/docs/core/McpRoute.mdx
@@ -144,6 +144,11 @@ and `@title` can provide a UI title.
 `McpAdaptor.upgrade()` must run before `app.listen()`. Without the adaptor,
 decorated methods are only metadata and no MCP HTTP endpoint is mounted.
 
+Keep MCP tools on their own controller methods. A method decorated with
+`@McpRoute()` must not also carry an HTTP route decorator such as
+`@TypedRoute.Get()` or a `@WebSocketRoute()` decorator; generate a separate
+method when the same business operation needs multiple protocol surfaces.
+
 ---
 
 ## Installation


### PR DESCRIPTION
## Summary
- Narrow native `Observable` return unwrapping to RxJS-backed `Observable` symbols so unrelated user types are not treated as async wrappers.
- Reject mixed `@McpRoute` and HTTP/WebSocket route decorators, and document the separation requirement.
- Harden generated MCP SDK response selection and WebSocket clone path detection.
- Add/repair focused SDK fixtures for MCP route errors and swagger-hidden coverage docs.

## Verification
- `pnpm --filter @nestia/core build`
- `pnpm --filter @nestia/sdk build`
- `pnpm --filter nestia build`
- `TEST_SDK_SKIP_BUILD=1 node tests/test-sdk/start.js --only mcp --concurrency 1`
- `TEST_SDK_SKIP_BUILD=1 node tests/test-sdk/start.js --only swagger-hidden --concurrency 1`
- `git diff --cached --check`

## Known local gaps
- Direct `go` / `gofmt` commands are unavailable in the local PowerShell PATH.
- The broader `route` SDK slice still fails locally on the existing Windows tsgo temp-path normalization issue (`fileName should be normalized and absolute`).
