### PR TITLE
fix(e2e, benchmark): file-name based dynamic loader filter (port of #1511, part 1/2)

### DIFF
--- a/packages/benchmark/src/DynamicBenchmarker.ts
+++ b/packages/benchmark/src/DynamicBenchmarker.ts
@@ -74,13 +74,15 @@ export namespace DynamicBenchmarker {
     /**
      * Filter function.
      *
-     * The filter function to determine whether to execute the function in the
-     * servant or not.
+     * The filter function is called with the file name (basename) of each
+     * benchmark function module, not with the function name. When it returns
+     * `false`, the file would never be imported in the servant, so that every
+     * function defined in the file would never be executed either.
      *
-     * @param name Function name
+     * @param file File name (basename) of the benchmark functions
      * @returns Whether to execute the function or not.
      */
-    filter?: (name: string) => boolean;
+    filter?: (file: string) => boolean;
 
     /**
      * Progress callback function.
@@ -124,10 +126,10 @@ export namespace DynamicBenchmarker {
      * Extension of the benchmark function files to load, without the leading
      * dot.
      *
-     * The servant reads {@link location} and imports every file ending with
-     * this extension. Set it to match how the feature files are actually run:
-     * `"js"` when they are built JavaScript, or `"ts"` when they are executed
-     * from TypeScript source (for example under `ttsx`).
+     * The servant reads {@link location} and imports every file ending with this
+     * extension. Set it to match how the feature files are actually run: `"js"`
+     * when they are built JavaScript, or `"ts"` when they are executed from
+     * TypeScript source (for example under `ttsx`).
      *
      * @default "js"
      */
@@ -139,7 +141,9 @@ export namespace DynamicBenchmarker {
      * Every prefixed function will be executed in the servant.
      *
      * In other words, if a function name doesn't start with the prefix, then it
-     * would never be executed.
+     * would never be executed. Also, when a file name (basename) does not start
+     * with the prefix, the file would never be imported either, so that every
+     * function defined in the file would never be executed.
      */
     prefix: string;
 
@@ -401,11 +405,14 @@ const iterate =
         file.endsWith(`.${ctx.props.extension ?? "js"}`) &&
         file.endsWith(".d.ts") === false
       ) {
+        // GATE BY FILE NAME (PREFIX & FILTER), SO THAT EXCLUDED FILES ARE
+        // NEVER IMPORTED.
+        if (file.startsWith(ctx.props.prefix) === false) continue;
+        if ((await ctx.driver.filter(file)) === false) continue;
         const modulo = await import(location);
         for (const [key, value] of Object.entries(modulo)) {
           if (typeof value !== "function") continue;
           else if (key.startsWith(ctx.props.prefix) === false) continue;
-          else if ((await ctx.driver.filter(key)) === false) continue;
           ctx.collection.push({
             key,
             value: value as (...args: Parameters) => Promise<any>,

--- a/packages/benchmark/src/internal/IBenchmarkMaster.ts
+++ b/packages/benchmark/src/internal/IBenchmarkMaster.ts
@@ -1,4 +1,4 @@
 export interface IBenchmarkMaster {
-  filter: (name: string) => boolean;
+  filter: (file: string) => boolean;
   progress: (current: number) => void;
 }

--- a/packages/e2e/src/DynamicExecutor.ts
+++ b/packages/e2e/src/DynamicExecutor.ts
@@ -42,7 +42,9 @@ export namespace DynamicExecutor {
      * Every prefixed function will be executed.
      *
      * In other words, if a function name doesn't start with the prefix, then it
-     * would never be executed.
+     * would never be executed. Also, when a file name (basename) does not start
+     * with the prefix, the file would never be imported either, so that every
+     * function defined in the file would never be executed.
      */
     prefix: string;
 
@@ -69,10 +71,15 @@ export namespace DynamicExecutor {
     /**
      * Filter function whether to run or not.
      *
-     * @param name Function name
+     * The filter function is called with the file name (basename) of each
+     * dynamic function module, not with the function name. When it returns
+     * `false`, the file would never be imported, so that every function defined
+     * in the file would never be executed either.
+     *
+     * @param file File name (basename) of the dynamic functions
      * @returns Whether to run or not
      */
-    filter?: (name: string) => boolean;
+    filter?: (file: string) => boolean;
 
     /**
      * Wrapper of test function.
@@ -188,6 +195,8 @@ export namespace DynamicExecutor {
       const processes: Array<() => Promise<void>> = await iterate({
         extension: props.extension ?? "js",
         location: props.location,
+        prefix: props.prefix,
+        filter: props.filter,
         executor,
       });
       await Promise.all(
@@ -205,6 +214,8 @@ export namespace DynamicExecutor {
   const iterate = async <Arguments extends any[]>(props: {
     location: string;
     extension: string;
+    prefix: string;
+    filter?: (file: string) => boolean;
     executor: (path: string, modulo: Module<Arguments>) => Promise<void>;
   }): Promise<Array<() => Promise<void>>> => {
     const container: Array<() => Promise<void>> = [];
@@ -218,6 +229,10 @@ export namespace DynamicExecutor {
           await visitor(location);
           continue;
         } else if (file.substr(-3) !== `.${props.extension}`) continue;
+        // GATE BY FILE NAME (PREFIX & FILTER), SO THAT EXCLUDED FILES ARE
+        // NEVER IMPORTED.
+        else if (file.startsWith(props.prefix) === false) continue;
+        else if (props.filter && props.filter(file) === false) continue;
 
         const modulo: Module<Arguments> = await import(
           pathToFileURL(location).href
@@ -237,8 +252,7 @@ export namespace DynamicExecutor {
       for (const [key, closure] of Object.entries(modulo)) {
         if (
           key.substring(0, props.prefix.length) !== props.prefix ||
-          typeof closure !== "function" ||
-          (props.filter && props.filter(key) === false)
+          typeof closure !== "function"
         )
           continue;
 


### PR DESCRIPTION
## 배경

master 에 머지된 #1511 (`fix: file URL for await import & file-name based dynamic loader filter`) 의 내용을 `next` 브랜치로 가져온다. 단, #1511 은 한 PR 에 두 가지 독립된 변경이 섞여 있어 **두 개의 PR 로 분할**한다.

- **(1/2) — 본 PR**: dynamic loader 의 **파일명 기준 필터링**
- (2/2): migrate `NestiaMigrateDtoProgrammer` 의 `x-` plugin property → JSDoc 태그 (별도 PR)

## 변경 사항

`DynamicExecutor` (`@nestia/e2e`) 와 `DynamicBenchmarker` (`@nestia/benchmark`) 가 **파일을 import 하기 전에 파일명(basename)으로 먼저 게이팅**한다.

- 파일명(basename)이 `prefix` 로 시작하지 않으면 그 파일은 **아예 import 되지 않는다** (따라서 side effect 도 실행되지 않음).
- `filter` 콜백이 `false` 를 반환하면 그 파일은 import 되지 않는다.
- `filter` 의 인자가 **함수명 → 파일명(basename)** 으로 바뀐다.
- import 이후의 per-key `filter(key)` 호출은 제거하고, 함수명 prefix 체크만 유지한다.

### ⚠️ #1511 의 `await import()` ESM 변경은 의도적으로 포팅하지 않음

`next` 는 native ESM 동적 import 문제를 패키지별로 이미 (그리고 더 정교하게) 해결해 두었다:

| 패키지 | 현재 next 의 방식 | module |
|---|---|---|
| `e2e` / `benchmark` | `pathToFileURL(...).href` (native import) | `nodenext` |
| `core` (`load_controller`) | `Function`-wrapped native import + `pathToFileURL` (ttsx 런타임 대응) | `commonjs` |
| `sdk` (`ConfigAnalyzer`, `NestiaConfigLoader`) | `RuntimeCompiler` 가 emit 한 산출물 import | `commonjs` |

#1511 이 최종 채택한 POSIX-relative `specifier()` 헬퍼는 **downlevel 된 `require()`** 를 전제로 하므로, next 의 commonjs+ttsx 패키지에 그대로 적용하면 오히려 **회귀(regression)** 가 발생한다. 따라서 본 PR 은 next 의 기존 import 호출을 **건드리지 않고**, 필터/프리픽스 게이팅과 문서만 변경한다.

## Breaking change

`DynamicExecutor.IProps.filter` 와 `DynamicBenchmarker.IMasterProps.filter` 의 인자가 **함수명이 아니라 파일명(basename)** 이 된다. master #1511 과 동일한 동작이며, v12 (major) 라인이므로 허용 가능.

## 검증

- `@nestia/e2e` / `@nestia/benchmark` 빌드 통과.
- 독립 하니스로 `DynamicExecutor` 동작 확인:
  - prefix 로 시작하지 않는 파일(`helper.js`)은 import 되지 않음 → 그 안의 `test_gamma` 미실행 ✓
  - 디렉토리 재귀 탐색은 영향 없음 (`nested/test_delta.js` 실행) ✓
  - `filter` 콜백이 받은 인자가 파일명(`test_alpha.js`, ...)임을 확인 ✓
  - 함수명 prefix 체크는 유지 (`test_beta.js` 내 `notPrefixed` 미실행) ✓
- 기존 fixture(`tests/test-*`, prefix `test`/`test_api_`)는 모든 feature 파일이 prefix 로 시작하므로 영향 없음. 유일한 `DynamicExecutor` `filter` 사용처(`tests/test-sdk/features/beautify`)는 substring 매칭이라 파일명 기준으로도 동일하게 동작.

> 참고: `tests/test-benchmark` 의 로컬 e2e 실행은 본 변경과 무관한 ttsx/Windows 의 `@nestia/core` 컨트롤러 트랜스폼 오류(`fileName should be normalized and absolute`, Temp 경로)로 막혀 확인하지 못했다. CI(ubuntu)에서 커버된다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)