### PR TITLE
fix(build): emit CommonJS (require) output & port #1511 specifier to e2e

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/build.yml'
+      - 'config/**'
       - 'packages/*/native/**'
       - 'packages/*/src/**'
       - 'packages/*/package.json'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/test.yml'
+      - 'config/**'
       - 'packages/*/native/**'
       - 'packages/*/src/**'
       - 'packages/*/test/**'

--- a/config/tsconfig.json
+++ b/config/tsconfig.json
@@ -29,8 +29,8 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "nodenext" /* Specify what module code is generated. */,
-    "moduleResolution": "nodenext",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+    "module": "commonjs" /* Specify what module code is generated. */,
+    "moduleResolution": "bundler",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */

--- a/packages/e2e/src/DynamicExecutor.ts
+++ b/packages/e2e/src/DynamicExecutor.ts
@@ -1,6 +1,5 @@
 import fs from "fs";
 import NodePath from "path";
-import { pathToFileURL } from "url";
 
 /**
  * Dynamic Executor running prefixed functions.
@@ -211,6 +210,16 @@ export namespace DynamicExecutor {
       return report;
     };
 
+  const specifier = (location: string): string => {
+    const relative: string = NodePath.relative(
+      __dirname,
+      NodePath.resolve(location),
+    )
+      .split(NodePath.sep)
+      .join("/");
+    return `./${relative}`;
+  };
+
   const iterate = async <Arguments extends any[]>(props: {
     location: string;
     extension: string;
@@ -234,9 +243,13 @@ export namespace DynamicExecutor {
         else if (file.startsWith(props.prefix) === false) continue;
         else if (props.filter && props.filter(file) === false) continue;
 
-        const modulo: Module<Arguments> = await import(
-          pathToFileURL(location).href
-        );
+        // Convert the absolute path to a POSIX relative specifier. It works
+        // both as a native ESM dynamic import (module: nodenext, which keeps
+        // `import()` as is) and as a `require()` call (module: commonjs, which
+        // downlevels `import()` to `require()`). A raw absolute path would
+        // break the native import on Windows (file URL scheme), and a `file://`
+        // URL would break the downleveled `require()`.
+        const modulo: Module<Arguments> = await import(specifier(location));
         container.push(() => props.executor(location, modulo));
       }
     };


### PR DESCRIPTION
## Why

On the `@next` line the shared config used `module: nodenext`, so TypeScript kept dynamic `import()` as native ESM. `packages/e2e/lib/DynamicExecutor.js` (and other generated output) emitted `yield import(...)` instead of the `require()`-based dynamic load used before TS 7.

This switches the build back to CommonJS so dynamic `import()` downlevels to `require()` again, and ports the only remaining piece of master's #1511 that next was missing — the POSIX relative `specifier()` helper.

## What changed

- **`config/tsconfig.json`** — `module: nodenext → commonjs`, `moduleResolution: nodenext → bundler`. `node10` resolution was removed in TS 7, so `commonjs` must pair with `bundler`. This flips every package to CJS/`require` output.
- **`packages/e2e/src/DynamicExecutor.ts`** — replace `await import(pathToFileURL(location).href)` with `await import(specifier(location))`, where `specifier()` returns a `./…` POSIX relative path computed from `__dirname` (verbatim from #1511). A relative specifier resolves correctly both as native ESM `import()` and as a downleveled `require()`, on any OS — a `file://` URL would break `require()`, a raw absolute path would break native import on Windows.
- **`.github/workflows/{build,test}.yml`** — also trigger on `config/**` changes.

## Scope of #1511 on next

#1511 = specifier + (gate-by-file-name / JSDoc / `IBenchmarkMaster`) + (migrate `x-` JSDoc). The latter two groups were already ported to next via **#1512** and **#1513**; this PR adds only the remaining **specifier** half, scoped to e2e. The core/sdk loaders (`load_controller`, `ConfigAnalyzer`, `NestiaConfigLoader`) were intentionally left alone — next re-architected them (ttsx fallback, `RuntimeCompiler`, materialized-module `.mjs` split) and #1511's plain-`import` rewrite does not apply.

## Verification

- `pnpm build` across the full workspace: green (benchmark, core, editor, sdk, cli).
- e2e now emits `yield Promise.resolve(`${specifier(location)}`).then(s => __importStar(require(s)))`.
- **Not tested:** `pnpm test` (known Windows go-test temp-path issue) and runtime behavior of ESM-only dynamic imports (e.g. `McpAdaptor`), which now downlevel to `require()` under commonjs — worth a runtime check before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)