### PR TITLE
fix(e2e): error handling in promise resolution

### DIFF
--- a/packages/e2e/src/TestValidator.ts
+++ b/packages/e2e/src/TestValidator.ts
@@ -232,7 +232,7 @@ export namespace TestValidator {
       const output: T = task();
       if (is_promise(output))
         return new Promise<void>((resolve, reject) =>
-          output.catch(() => resolve()).then(() => reject(message())),
+          output.catch(() => resolve()).then(() => reject(new Error(message()))),
         ) as any;
       else throw new Error(message());
     } catch {


### PR DESCRIPTION
# Why

In general, people expect 'Error' to come from the 'catch' statement.
but, current code does throw the `string`

# What Changed

just add `new Error` statement
just one line modefied

