### PR TITLE
fix(e2e): error handling in promise resolution (port of #1516)

### DIFF
--- a/packages/e2e/src/TestValidator.ts
+++ b/packages/e2e/src/TestValidator.ts
@@ -232,7 +232,9 @@ export namespace TestValidator {
       const output: T = task();
       if (is_promise(output))
         return new Promise<void>((resolve, reject) =>
-          output.catch(() => resolve()).then(() => reject(message())),
+          output
+            .catch(() => resolve())
+            .then(() => reject(new Error(message()))),
         ) as any;
       else throw new Error(message());
     } catch {


### PR DESCRIPTION
# Why

Port of #1516 (merged into `master`) to the `@next` branch.

In general, people expect the value caught from a rejected promise to be an
`Error`. The asynchronous branch of `TestValidator.error()` rejected with the
raw `message()` **string**, so a `catch` handler received a `string` instead of
an `Error` — inconsistent with the synchronous branch right below it, which
already does `throw new Error(message())`.

# What Changed

`packages/e2e/src/TestValidator.ts`: wrap the rejection value in `new Error(...)`
so both the sync and async branches reject/throw an `Error`.

```diff
-          output.catch(() => resolve()).then(() => reject(message())),
+          output
+            .catch(() => resolve())
+            .then(() => reject(new Error(message()))),
```

(The multi-line shape is just Prettier's formatting of the one-line change in #1516.)

# Verification

- `pnpm --filter ./packages/e2e build` — passes
- `npx prettier --check src/TestValidator.ts` — formatted

Original author: @sunrabbit123 (credited as co-author on the commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
