### PR TITLE
[codex] Fix SDK accessor escaping for route segments

### DIFF
--- a/packages/sdk/src/analyses/AccessorAnalyzer.ts
+++ b/packages/sdk/src/analyses/AccessorAnalyzer.ts
@@ -25,25 +25,54 @@ export namespace AccessorAnalyzer {
   };
 
   const variable = (routeList: Array<AnyRoute>) => {
-    const dict: Map<string, number> = prepare(routeList);
+    const reserved: Set<string> = reserve(routeList);
+    const assigned: Map<string, string> = new Map();
+    const used: Set<string> = new Set();
     for (const route of routeList) {
-      const emended: string[] = route.accessor.slice();
+      const emended: string[] = [];
       route.accessor.forEach((accessor, i) => {
-        if (NamingConvention.variable(accessor)) return;
-        while (true) {
+        const source: string = route.accessor.slice(0, i + 1).join(".");
+        const registered: string | undefined = assigned.get(source);
+        if (registered !== undefined) {
+          emended.push(registered.split(".").at(-1)!);
+          return;
+        }
+
+        accessor = normalize(accessor);
+        while (NamingConvention.variable(accessor) === false)
           accessor = "_" + accessor;
-          const partial: string = [
-            ...route.accessor.slice(0, i),
-            accessor,
-          ].join(".");
-          if (dict.has(partial) === false) {
-            emended[i] = accessor;
+        while (true) {
+          const partial: string = [...emended, accessor].join(".");
+          if (
+            used.has(partial) === false &&
+            (reserved.has(partial) === false || partial === source)
+          ) {
+            assigned.set(source, partial);
+            used.add(partial);
+            emended.push(accessor);
             break;
           }
+          accessor = "_" + accessor;
         }
       });
       route.accessor.splice(0, route.accessor.length, ...emended);
     }
+  };
+
+  const reserve = (routeList: Array<AnyRoute>): Set<string> => {
+    const output: Set<string> = new Set();
+    for (const route of routeList)
+      route.accessor.forEach((_a, i) => {
+        const partial: string[] = route.accessor.slice(0, i + 1);
+        if (partial.every(NamingConvention.variable))
+          output.add(partial.join("."));
+      });
+    return output;
+  };
+
+  const normalize = (accessor: string): string => {
+    const output: string = accessor.replace(/[^A-Za-z0-9_$]/g, "_");
+    return output.length ? output : "_";
   };
 
   const shrink = (routeList: Array<AnyRoute>) => {

--- a/tests/test-sdk/features/escape/src/controllers/UserController.ts
+++ b/tests/test-sdk/features/escape/src/controllers/UserController.ts
@@ -1,0 +1,10 @@
+import core from "@nestia/core";
+import { Controller } from "@nestjs/common";
+
+@Controller("users")
+export class UserController {
+  @core.TypedRoute.Get("@me/permissions")
+  public async permissions(): Promise<string[]> {
+    return [];
+  }
+}

--- a/tests/test-sdk/features/escape/src/test/features/test_accessor_escape.ts
+++ b/tests/test-sdk/features/escape/src/test/features/test_accessor_escape.ts
@@ -1,5 +1,22 @@
 import api from "@api";
 
+/**
+ * Verifies SDK accessors escape reserved words and non-identifier route
+ * segments without changing endpoint URLs.
+ *
+ * Locks the accessor normalization branch shared by the SDK file tree and
+ * namespace exports. Reserved route names already need a leading underscore;
+ * route segments such as `@me` additionally need illegal identifier characters
+ * converted before TypeScript export declarations are printed.
+ *
+ * 1. Touch the generated accessor for the reserved `delete` route segment.
+ * 2. Touch the generated accessor for the `@me` route segment.
+ * 3. Assert the escaped accessor still returns the original endpoint path.
+ */
 export const test_accessor_escape = (): void => {
   api.functional._delete.erase.METADATA;
+  api.functional.users._me.permissions.METADATA;
+
+  if (api.functional.users._me.permissions.path() !== "/users/@me/permissions")
+    throw new Error("Escaped SDK accessor must keep the original route path.");
 };

--- a/website/src/content/docs/setup/legacy.mdx
+++ b/website/src/content/docs/setup/legacy.mdx
@@ -505,6 +505,7 @@ If a build emits `Error on nestia.core.<method>(): no transform has been configu
 - `npm run prepare` (or the equivalent) has executed at least once after install, so `ts-patch install` patched the local `typescript`.
 - The TypeScript binary actually being invoked is the project-local one (`node_modules/.bin/tsc`), not a globally installed `tsc` that points at an unpatched compiler.
 - The plugin entries in `tsconfig.json` are spelled exactly as shown above and appear in the `compilerOptions.plugins` array, not at the root.
+- Nx 23 creates Nest workspaces on TypeScript 6 and runs `nx serve` through `@nx/webpack`. The v11 `ts-patch` setup targets TypeScript 5; for Nx 23, migrate to the `@next` / `ttsc` setup, or pin TypeScript 5 before installing the legacy line. If you keep a Webpack target on v11, it must run `ts-loader` with the patched project-local TypeScript compiler.
 
 ## Migrating to TypeScript-Go
 

--- a/website/src/content/docs/setup/tsgo.mdx
+++ b/website/src/content/docs/setup/tsgo.mdx
@@ -233,6 +233,41 @@ bun ttsx src/main.ts
 
 NestJS monorepos created with `nest g app <name>` put each app at `apps/<name>/src/main.ts` with its own `apps/<name>/tsconfig.app.json`. Build each app with `ttsc -p apps/<name>/tsconfig.app.json`, and run the SDK / Swagger / e2e generators per app — `nestia.config.ts` is project-scoped.
 
+### Nx 23
+
+Fresh Nx 23 Nest workspaces use `@nx/webpack` and an `NxAppWebpackPlugin` build target. `nx serve <app>` runs that Webpack target before starting Node, so `compilerOptions.plugins` alone is not enough; the build must either call `ttsc` directly or load `@ttsc/unplugin/webpack` in the generated Webpack config.
+
+If you keep Nx's Webpack build, install `@ttsc/unplugin` and add the plugin next to `NxAppWebpackPlugin`. In the default Nx 23 layout the command runs from the app directory, so `project: "./tsconfig.app.json"` points at the app config:
+
+```js filename="apps/api/webpack.config.js" showLineNumbers copy
+const { NxAppWebpackPlugin } = require("@nx/webpack/app-plugin");
+const ttsc = require("@ttsc/unplugin/webpack").default;
+const { join } = require("path");
+
+module.exports = {
+  output: {
+    path: join(__dirname, "../../dist/apps/api"),
+    clean: true,
+  },
+  plugins: [
+    new NxAppWebpackPlugin({
+      target: "node",
+      compiler: "tsc",
+      main: "./src/main.ts",
+      tsConfig: "./tsconfig.app.json",
+      assets: ["./src/assets"],
+      optimization: false,
+      outputHashing: "none",
+      generatePackageJson: true,
+      sourceMap: true,
+    }),
+    ttsc({ project: "./tsconfig.app.json" }),
+  ],
+};
+```
+
+Without that plugin, `nx serve` can build successfully but the first `@TypedRoute` / `@TypedBody` call fails at runtime with "no transform has been configured" because Nx invoked Webpack's stock TypeScript path instead of `ttsc`.
+
 ## Generate
 
 First time on this project? Run `npx nestia init` once — it writes a starter `nestia.config.ts` next to your `tsconfig.json`. After that, `npx nestia all` emits the SDK, Swagger document, and e2e suite in one pass.


### PR DESCRIPTION
## What changed

- Normalizes generated SDK accessor segments before namespace exports are printed, so paths like `/users/@me/permissions` produce a valid accessor such as `api.functional.users._me.permissions`.
- Adds an SDK escape fixture controller and assertion to pin the `@me` route case while preserving the original endpoint URL.
- Documents the #1518 investigation result: Nx 23 Nest workspaces run `nx serve` through `@nx/webpack`, so `@ttsc/unplugin/webpack` or a direct `ttsc` build target is required; the legacy v11 page now calls out the TypeScript 6 / ts-patch mismatch.

## Why

The previous accessor escape pass only prefixed non-variable segments. A segment containing an illegal identifier character, such as `@me`, became `_@me`, which is still not a valid TypeScript namespace export alias and made generated SDK code fail to compile.

## Validation

- `pnpm --filter ./tests/test-sdk start -- --only escape`
- `git diff --check`
- MDX fenced code block balance check for the edited setup docs

Not run: full website build, because this checkout does not have the website tarball dependencies installed.

Fixes #1519.
Refs #1518.