### PR TITLE
fix(sdk, migrate): emit type-only imports for generated DTO references

### DIFF
--- a/packages/migrate/src/programmers/NestiaMigrateImportProgrammer.ts
+++ b/packages/migrate/src/programmers/NestiaMigrateImportProgrammer.ts
@@ -89,8 +89,11 @@ export class NestiaMigrateImportProgrammer {
         .map((i) =>
           factory.createImportDeclaration(
             undefined,
+            // DTO files declare pure types, and generated code references them
+            // only in type positions — keep the clause type-only so emitted
+            // JS never loads the DTO module at runtime.
             factory.createImportClause(
-              false,
+              true,
               undefined,
               factory.createNamedImports([
                 factory.createImportSpecifier(

--- a/packages/sdk/src/generates/internal/ImportDictionary.ts
+++ b/packages/sdk/src/generates/internal/ImportDictionary.ts
@@ -127,12 +127,12 @@ export class ImportDictionary {
   }
 
   private toImportClaude(c: ICompositeValue): ImportClause {
-    // A namespace import cannot carry a per-binding `type` modifier, so the
-    // type-only flag stays off here (a value namespace import resolves type
-    // members fine), matching the legacy printer output `import * as X`.
+    // A namespace binding cannot carry a per-binding `type` modifier, so the
+    // type-only flag goes on the clause itself (`import type * as X`) —
+    // generated SDK code references DTO namespaces only in type positions.
     if (c.asterisk !== null)
       return factory.createImportClause(
-        false,
+        c.declaration,
         undefined,
         factory.createNamespaceImport(factory.createIdentifier(c.asterisk)),
       );

--- a/tests/test-migrate/src/features/test_migrate_dto_import_type.ts
+++ b/tests/test-migrate/src/features/test_migrate_dto_import_type.ts
@@ -1,0 +1,163 @@
+import {
+  INestiaMigrateConfig,
+  NestiaMigrateApplication,
+} from "@nestia/migrate";
+import { OpenApiV3_1 } from "@typia/interface";
+
+/**
+ * Verifies migrated projects import DTO types with `import type`.
+ *
+ * Migrated DTO files declare pure types, and every generated module — SDK
+ * functions, NestJS controllers, e2e suites, and the DTO files themselves —
+ * references them only in type positions. The import programmer therefore must
+ * print type-only clauses; a plain value import would make bundlers and Node.js
+ * load pure type modules at runtime and breaks `verbatimModuleSyntax`
+ * consumers.
+ *
+ * 1. Build a synthetic OpenAPI document whose operations reference DTO schemas,
+ *    including a DTO that references another DTO.
+ * 2. Generate both the SDK and the NestJS projects from it.
+ * 3. Assert every DTO import in every generated module is type-only, while runtime
+ *    library imports such as `typia` stay value imports.
+ */
+export const test_migrate_dto_import_type = (): void => {
+  const app: NestiaMigrateApplication =
+    NestiaMigrateApplication.assert(DOCUMENT);
+  const config: INestiaMigrateConfig = {
+    keyword: true,
+    simulate: true,
+    e2e: true,
+    package: "fixture",
+  };
+  assertProject("sdk", app.sdk(config));
+  assertProject("nest", app.nest(config));
+};
+
+function assertProject(title: string, files: Record<string, string>): void {
+  const violations: string[] = [];
+  let count: number = 0;
+  let runtime: boolean = false;
+  for (const [key, content] of Object.entries(files)) {
+    if (key.endsWith(".ts") === false) continue;
+    const insideStructures: boolean = key.includes("structures/");
+    for (const match of content.matchAll(/^import[^;]*from "[^"]+";/gm)) {
+      const statement: string = match[0];
+      const specifier: string = statement.match(/from "([^"]+)";$/)![1]!;
+      if (specifier === "typia" && statement.startsWith("import typia")) {
+        // typia.assert/random calls survive to runtime — the value import
+        // must not be swept up by the type-only DTO clause.
+        runtime = true;
+        continue;
+      }
+      const dto: boolean =
+        specifier.includes("structures/") ||
+        (insideStructures && specifier.startsWith("./"));
+      if (dto === false) continue;
+      ++count;
+      if (statement.startsWith("import type ") === false)
+        violations.push(`${title}/${key}: ${statement.split("\n")[0]}`);
+    }
+  }
+  if (violations.length !== 0)
+    throw new Error(
+      ["Migrated DTO imports must be type-only:", ...violations].join("\n"),
+    );
+  if (count === 0)
+    throw new Error(`The ${title} fixture must contain DTO imports.`);
+  if (runtime === false)
+    throw new Error(`The ${title} fixture must keep the typia value import.`);
+}
+
+const DOCUMENT = {
+  openapi: "3.1.0",
+  info: {
+    title: "DTO import type fixture",
+    version: "1.0.0",
+  },
+  paths: {
+    "/bbs/articles": {
+      post: {
+        operationId: "bbs.articles.store",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                $ref: "#/components/schemas/IBbsArticle.IStore",
+              },
+            },
+          },
+        },
+        responses: {
+          "201": {
+            description: "Newly archived article",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/IBbsArticle",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {
+      IBbsArticle: {
+        type: "object",
+        properties: {
+          id: {
+            type: "string",
+            format: "uuid",
+          },
+          title: {
+            type: "string",
+          },
+          body: {
+            type: "string",
+          },
+          files: {
+            type: "array",
+            items: {
+              $ref: "#/components/schemas/IAttachmentFile",
+            },
+          },
+        },
+        required: ["id", "title", "body", "files"],
+      },
+      "IBbsArticle.IStore": {
+        type: "object",
+        properties: {
+          title: {
+            type: "string",
+          },
+          body: {
+            type: "string",
+          },
+          files: {
+            type: "array",
+            items: {
+              $ref: "#/components/schemas/IAttachmentFile",
+            },
+          },
+        },
+        required: ["title", "body", "files"],
+      },
+      IAttachmentFile: {
+        type: "object",
+        properties: {
+          name: {
+            type: "string",
+          },
+          url: {
+            type: "string",
+            format: "uri",
+          },
+        },
+        required: ["name", "url"],
+      },
+    },
+  },
+} satisfies OpenApiV3_1.IDocument;

--- a/tests/test-migrate/src/index.ts
+++ b/tests/test-migrate/src/index.ts
@@ -16,6 +16,7 @@ import type { IValidation } from "typia";
 
 import { test_migrate_api_accessor_collision } from "./features/test_migrate_api_accessor_collision";
 import { test_migrate_api_response_header_tags } from "./features/test_migrate_api_response_header_tags";
+import { test_migrate_dto_import_type } from "./features/test_migrate_dto_import_type";
 
 const TEST_ROOT: string = process.cwd();
 const ROOT: string = path.resolve(TEST_ROOT, "../..");
@@ -207,6 +208,7 @@ const main = async (): Promise<void> => {
     assertFixtureSwagger(document);
     test_migrate_api_accessor_collision(document);
     test_migrate_api_response_header_tags();
+    test_migrate_dto_import_type();
     for (const [mode, keyword] of [
       ["nest", true],
       ["nest", false],

--- a/tests/test-sdk/features/import-type/nestia.config.ts
+++ b/tests/test-sdk/features/import-type/nestia.config.ts
@@ -1,0 +1,16 @@
+import { INestiaConfig } from "@nestia/sdk";
+
+export const NESTIA_CONFIG: INestiaConfig = {
+  input: ["src/controllers"],
+  output: "src/api",
+  e2e: "src/test",
+  swagger: {
+    output: "swagger.json",
+    security: {
+      bearer: {
+        type: "apiKey",
+      },
+    },
+  },
+};
+export default NESTIA_CONFIG;

--- a/tests/test-sdk/features/import-type/src/Backend.ts
+++ b/tests/test-sdk/features/import-type/src/Backend.ts
@@ -1,0 +1,27 @@
+import core from "@nestia/core";
+import { INestApplication } from "@nestjs/common";
+import { NestFactory } from "@nestjs/core";
+
+export class Backend {
+  private application_?: INestApplication;
+
+  public async open(): Promise<void> {
+    this.application_ = await NestFactory.create(
+      await core.EncryptedModule.dynamic(__dirname + "/controllers", {
+        key: "A".repeat(32),
+        iv: "B".repeat(16),
+      }),
+      { logger: false },
+    );
+    await this.application_.listen(Number(process.env.TEST_SDK_PORT ?? 37_000));
+  }
+
+  public async close(): Promise<void> {
+    if (this.application_ === undefined) return;
+
+    const app = this.application_;
+    await app.close();
+
+    delete this.application_;
+  }
+}

--- a/tests/test-sdk/features/import-type/src/api/structures/IBbsArticle.ts
+++ b/tests/test-sdk/features/import-type/src/api/structures/IBbsArticle.ts
@@ -1,0 +1,37 @@
+export interface IBbsArticle extends IBbsArticle.IStore {
+  /** @format uuid */
+  id: string;
+
+  /** @format date-time */
+  created_at: string;
+}
+export namespace IBbsArticle {
+  export interface IStore {
+    /**
+     * @minLength 3
+     * @maxLength 50
+     */
+    title: string;
+    body: string;
+    files: IAttachmentFile[];
+  }
+
+  export type IUpdate = Partial<IStore>;
+}
+
+export interface IAttachmentFile {
+  /**
+   * @minLength 1
+   * @maxLength 255
+   */
+  name: string | null;
+
+  /**
+   * @minLength 1
+   * @maxLength 8
+   */
+  extension: string | null;
+
+  /** @format uri */
+  url: string;
+}

--- a/tests/test-sdk/features/import-type/src/api/structures/IMemo.ts
+++ b/tests/test-sdk/features/import-type/src/api/structures/IMemo.ts
@@ -1,0 +1,6 @@
+export default interface IMemo {
+  /** @format uuid */
+  id: string;
+
+  content: string;
+}

--- a/tests/test-sdk/features/import-type/src/api/structures/IPage.ts
+++ b/tests/test-sdk/features/import-type/src/api/structures/IPage.ts
@@ -1,0 +1,12 @@
+export interface IPage<T> {
+  data: T[];
+  pagination: IPage.IPagination;
+}
+export namespace IPage {
+  export interface IPagination {
+    current: number;
+    limit: number;
+    records: number;
+    pages: number;
+  }
+}

--- a/tests/test-sdk/features/import-type/src/controllers/BbsArticleController.ts
+++ b/tests/test-sdk/features/import-type/src/controllers/BbsArticleController.ts
@@ -1,0 +1,30 @@
+import core from "@nestia/core";
+import { Controller } from "@nestjs/common";
+import typia from "typia";
+
+import { IBbsArticle } from "../api/structures/IBbsArticle";
+import IMemo from "../api/structures/IMemo";
+import * as pagination from "../api/structures/IPage";
+
+@Controller("bbs/articles")
+export class BbsArticleController {
+  @core.TypedRoute.Patch()
+  public async index(): Promise<pagination.IPage<IBbsArticle>> {
+    return typia.random<pagination.IPage<IBbsArticle>>();
+  }
+
+  @core.TypedRoute.Get("memo")
+  public async memo(): Promise<IMemo> {
+    return typia.random<IMemo>();
+  }
+
+  @core.TypedRoute.Post()
+  public async store(
+    @core.TypedBody() input: IBbsArticle.IStore,
+  ): Promise<IBbsArticle> {
+    return {
+      ...typia.random<IBbsArticle>(),
+      ...input,
+    };
+  }
+}

--- a/tests/test-sdk/features/import-type/src/test/features/test_sdk_dto_import_type.ts
+++ b/tests/test-sdk/features/import-type/src/test/features/test_sdk_dto_import_type.ts
@@ -1,0 +1,83 @@
+import fs from "fs";
+import path from "path";
+
+/**
+ * Verifies generated SDK modules import DTO types with `import type`.
+ *
+ * Generated SDK code only ever references DTO modules in type positions, so
+ * every DTO import must carry the type-only clause. A plain value import would
+ * make bundlers and Node.js load pure type modules at runtime and breaks
+ * `verbatimModuleSyntax` consumers. The printer has three separate binding
+ * branches — named elements, a default binding, and a namespace binding
+ * (`import type * as X`) — and each needs its own regression lock, while
+ * runtime imports such as the fetcher must stay value imports.
+ *
+ * 1. Generate the SDK from a controller importing DTOs with a named binding, a
+ *    default binding, and a namespace (`import * as`) binding.
+ * 2. Scan every generated module under `src/api/functional` and the generated e2e
+ *    suite under `src/test/features/api/automated`.
+ * 3. Assert every import from the `structures` directory is type-only, all three
+ *    type-only binding forms actually appear, and the runtime fetcher import
+ *    remains a value import.
+ */
+export const test_sdk_dto_import_type = (): void => {
+  const roots: string[] = [
+    path.resolve(__dirname, "..", "..", "api", "functional"),
+    path.resolve(__dirname, "api", "automated"),
+  ];
+  const violations: string[] = [];
+  let named: boolean = false;
+  let dflt: boolean = false;
+  let namespace: boolean = false;
+  let fetcher: boolean = false;
+
+  for (const root of roots) {
+    if (fs.existsSync(root) === false)
+      throw new Error(`Missing generated directory: ${root}`);
+    for (const file of collect(root)) {
+      const content: string = fs.readFileSync(file, "utf8");
+      for (const match of content.matchAll(/^import[^;]*from "[^"]+";/gm)) {
+        const statement: string = match[0];
+        if (/^import (type )?\{ (Plain|Encrypted)Fetcher \}/.test(statement)) {
+          if (statement.startsWith("import type"))
+            violations.push(
+              `${path.relative(__dirname, file)}: the fetcher is called at runtime and must stay a value import — ${statement.split("\n")[0]}`,
+            );
+          fetcher = true;
+          continue;
+        }
+        if (/from "[^"]*structures\/[^"]*";$/.test(statement) === false)
+          continue;
+        if (statement.startsWith("import type ") === false) {
+          violations.push(
+            `${path.relative(__dirname, file)}: ${statement.split("\n")[0]}`,
+          );
+          continue;
+        }
+        if (statement.startsWith("import type * as ")) namespace = true;
+        else if (statement.startsWith("import type {")) named = true;
+        else dflt = true;
+      }
+    }
+  }
+
+  if (violations.length !== 0)
+    throw new Error(
+      ["Generated DTO imports must be type-only:", ...violations].join("\n"),
+    );
+  if (named === false)
+    throw new Error("Fixture must produce a named type-only DTO import.");
+  if (dflt === false)
+    throw new Error("Fixture must produce a default type-only DTO import.");
+  if (namespace === false)
+    throw new Error("Fixture must produce a namespace type-only DTO import.");
+  if (fetcher === false)
+    throw new Error("Fixture must produce a runtime fetcher import.");
+};
+
+const collect = (location: string): string[] =>
+  fs.readdirSync(location).flatMap((name) => {
+    const next: string = path.join(location, name);
+    if (fs.statSync(next).isDirectory()) return collect(next);
+    return name.endsWith(".ts") ? [next] : [];
+  });

--- a/tests/test-sdk/features/import-type/src/test/index.ts
+++ b/tests/test-sdk/features/import-type/src/test/index.ts
@@ -1,0 +1,47 @@
+import { DynamicExecutor } from "@nestia/e2e";
+
+import { Backend } from "../Backend";
+
+async function main(): Promise<void> {
+  const server: Backend = new Backend();
+  await server.open();
+
+  const report: DynamicExecutor.IReport = await DynamicExecutor.validate({
+    extension: __filename.substring(__filename.length - 2),
+    prefix: "test",
+    parameters: () => [
+      {
+        host: `http://127.0.0.1:${process.env.TEST_SDK_PORT ?? 37_000}`,
+        encryption: {
+          key: "A".repeat(32),
+          iv: "B".repeat(16),
+        },
+      },
+    ],
+    location: `${__dirname}/features`,
+    onComplete: (exec) => {
+      const elapsed: number =
+        new Date(exec.completed_at).getTime() -
+        new Date(exec.started_at).getTime();
+      console.log(`  - ${exec.name}: ${elapsed.toLocaleString()} ms`);
+    },
+  });
+  await server.close();
+
+  const exceptions: Error[] = report.executions
+    .filter((exec) => exec.error !== null)
+    .map((exec) => exec.error!);
+  if (exceptions.length === 0) {
+    console.log("Success");
+    console.log("Elapsed time", report.time.toLocaleString(), `ms`);
+  } else {
+    for (const exp of exceptions) console.log(exp);
+    console.log("Failed");
+    console.log("Elapsed time", report.time.toLocaleString(), `ms`);
+    process.exit(-1);
+  }
+}
+main().catch((exp) => {
+  console.log(exp);
+  process.exit(-1);
+});

--- a/tests/test-sdk/features/import-type/tsconfig.json
+++ b/tests/test-sdk/features/import-type/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../config/tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      "@api": ["./src/api"],
+      "@api/lib/*": ["./src/api/*"],
+    },
+  },
+  "include": ["src"],
+}


### PR DESCRIPTION
## Why

Generated SDK and migrated projects reference DTO modules exclusively in type positions, yet two printer paths emitted plain value imports:

- **packages/sdk** — named/default DTO imports were already type-only, but the namespace binding (`import * as X from "<dto>"`) kept the type-only flag off for legacy printer parity. It now honors the flag and prints `import type * as X` (the per-binding `type` modifier is not allowed on namespace bindings, so the flag goes on the clause).
- **packages/migrate** — `NestiaMigrateImportProgrammer.toStatements` hard-coded `isTypeOnly: false` for every DTO clause, so SDK functions, NestJS controllers, e2e suites, and DTO cross-imports all loaded pure type modules at runtime. Now type-only.

Value imports would force bundlers and Node.js to load pure type modules at runtime and break `verbatimModuleSyntax` consumers.

## Safety

- migrate: DTO identifiers only ever come from `NestiaMigrateImportProgrammer.dto()`, which returns a `TypeReferenceNode` — never a value position.
- sdk: the asterisk import path only flows through `ImportDictionary.declarations()` (route DTO imports, always type-only intent). Runtime imports (fetcher, typia) carry their own `declaration: false` flags and are unchanged.

## Tests

- `tests/test-sdk/features/import-type` — new fixture whose controller imports DTOs via named, default, and namespace bindings; its test scans every generated `src/api/functional/**` and automated e2e module, asserts all DTO imports are type-only across all three binding forms, and asserts the fetcher import stays a value import.
- `tests/test-migrate/src/features/test_migrate_dto_import_type.ts` — generates both sdk and nest projects from a synthetic OpenAPI document (including DTO→DTO references) and asserts every DTO import is type-only while the `typia` value import survives. The existing test-migrate scenario compiles of generated projects also cover the emitted output.

## Verification

Not run locally by request — CI is the verification gate for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JjfmhonWb4ZKAniYipc9e