### PR TITLE
feat(cli): scaffold pnpm monorepo templates in nestia start/template

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,7 @@ jobs:
           - { name: transform-options, run: "pnpm --filter ./tests/test-transform-options start" }
           - { name: e2e, run: "pnpm --filter ./tests/test-e2e start" }
           - { name: benchmark, run: "pnpm --filter ./tests/test-benchmark start" }
+          - { name: cli, run: "pnpm --filter ./tests/test-cli start" }
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/packages/cli/src/NestiaProjectTemplate.ts
+++ b/packages/cli/src/NestiaProjectTemplate.ts
@@ -1,0 +1,137 @@
+import cp from "child_process";
+import fs from "fs";
+
+export namespace NestiaProjectTemplate {
+  /**
+   * Side effects performed while scaffolding a template project.
+   *
+   * Injected so that the scaffolding flow can be unit tested without touching
+   * the network, the file system, or a real package manager.
+   */
+  export interface IContext {
+    /** Runs a command, inheriting stdio. Throws on non-zero exit. */
+    execute: (command: string) => void;
+    /** Silently checks whether a command succeeds. */
+    probe: (command: string) => boolean;
+    /** Changes the working directory. */
+    chdir: (directory: string) => void;
+    /** Checks whether a path exists. */
+    exists: (path: string) => boolean;
+    /** Removes a path recursively, ignoring missing entries. */
+    remove: (path: string) => void;
+  }
+
+  export interface IProps {
+    /** Banner title printed before cloning. */
+    title: string;
+    /** Default repository URL, overridable through `--repository <url>`. */
+    repository: string;
+    /** Whether to run the test suite after building. */
+    test: boolean;
+  }
+
+  export const clone =
+    (props: IProps) =>
+    (halter: (msg?: string) => never, context: IContext = CONTEXT) =>
+    async (argv: string[]): Promise<void> => {
+      // VALIDATION
+      const { dest, repository } = parse(argv, halter);
+      if (dest === undefined) halter();
+      else if (context.exists(dest) === true)
+        halter("The target directory already exists.");
+
+      console.log("-----------------------------------------");
+      console.log(` ${props.title}`);
+      console.log("-----------------------------------------");
+
+      // COPY PROJECTS
+      context.execute(
+        `git clone "${repository ?? props.repository}" "${dest}"`,
+      );
+      console.log(`cd "${dest}"`);
+      context.chdir(dest);
+
+      // TEMPLATE REPOSITORIES ARE PNPM MONOREPOS.
+      //
+      // Their workspace manifests use the `catalog:` dependency protocol,
+      // which npm cannot resolve. Only pnpm (directly installed, or served
+      // through corepack) can set them up.
+      const pm: string = getPackageManager(halter, context);
+
+      // INSTALL DEPENDENCIES
+      context.execute(`${pm} install`);
+
+      // BUILD TYPESCRIPT
+      context.execute(`${pm} run build`);
+
+      // DO TEST
+      if (props.test === true) context.execute(`${pm} run test`);
+
+      // REMOVE REPOSITORY ONLY FILES
+      context.remove(".git");
+      context.remove(".github/dependabot.yml");
+    };
+
+  interface IArguments {
+    dest?: string;
+    repository?: string;
+  }
+
+  function parse(argv: string[], halter: (msg?: string) => never): IArguments {
+    const output: IArguments = {};
+    for (let i: number = 0; i < argv.length; ++i) {
+      const value: string = argv[i]!;
+      if (value === "--repository") {
+        const url: string | undefined = argv[i + 1];
+        if (url === undefined)
+          halter("The --repository option requires a URL value.");
+        output.repository = url;
+        ++i;
+      } else if (value.startsWith("--") === false && output.dest === undefined)
+        output.dest = value;
+    }
+    return output;
+  }
+
+  function getPackageManager(
+    halter: (msg?: string) => never,
+    context: IContext,
+  ): string {
+    if (context.probe("pnpm --version") === true) return "pnpm";
+    else if (context.probe("corepack --version") === true) {
+      process.env.COREPACK_ENABLE_DOWNLOAD_PROMPT = "0";
+      return "corepack pnpm";
+    }
+    return halter(
+      [
+        "The template project is a pnpm monorepo, but neither pnpm nor",
+        "corepack could be found. Install pnpm and try again:",
+        "",
+        "  npm install --global pnpm",
+        "",
+        "or activate it through corepack (bundled with Node.js):",
+        "",
+        "  corepack enable",
+      ].join("\n"),
+    );
+  }
+
+  const CONTEXT: IContext = {
+    execute: (command: string): void => {
+      console.log(`\n$ ${command}`);
+      cp.execSync(command, { stdio: "inherit" });
+    },
+    probe: (command: string): boolean => {
+      try {
+        cp.execSync(command, { stdio: "ignore" });
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    chdir: (directory: string): void => process.chdir(directory),
+    exists: (path: string): boolean => fs.existsSync(path),
+    remove: (path: string): void =>
+      fs.rmSync(path, { recursive: true, force: true }),
+  };
+}

--- a/packages/cli/src/NestiaStarter.ts
+++ b/packages/cli/src/NestiaStarter.ts
@@ -1,41 +1,9 @@
-import cp from "child_process";
-import fs from "fs";
+import { NestiaProjectTemplate } from "./NestiaProjectTemplate.js";
 
 export namespace NestiaStarter {
-  export const clone =
-    (halter: (msg?: string) => never) =>
-    async (argv: string[]): Promise<void> => {
-      // VALIDATION
-      const dest: string | undefined = argv[0];
-      if (dest === undefined) halter();
-      else if (fs.existsSync(dest) === true)
-        halter("The target directory already exists.");
-
-      console.log("-----------------------------------------");
-      console.log(" Nestia Starter Kit");
-      console.log("-----------------------------------------");
-
-      // COPY PROJECTS
-      execute(`git clone https://github.com/samchon/nestia-template ${dest}`);
-      console.log(`cd "${dest}"`);
-      process.chdir(dest);
-
-      // INSTALL DEPENDENCIES
-      execute("npm install");
-
-      // BUILD TYPESCRIPT
-      execute("npm run build");
-
-      // DO TEST
-      execute("npm run test");
-
-      // REMOVE .GIT DIRECTORY
-      cp.execSync("npx rimraf .git");
-      cp.execSync("npx rimraf .github/dependabot.yml");
-    };
-
-  function execute(command: string): void {
-    console.log(`\n$ ${command}`);
-    cp.execSync(command, { stdio: "inherit" });
-  }
+  export const clone = NestiaProjectTemplate.clone({
+    title: "Nestia Starter Kit",
+    repository: "https://github.com/samchon/nestia-start",
+    test: true,
+  });
 }

--- a/packages/cli/src/NestiaTemplate.ts
+++ b/packages/cli/src/NestiaTemplate.ts
@@ -1,37 +1,9 @@
-import cp from "child_process";
-import fs from "fs";
+import { NestiaProjectTemplate } from "./NestiaProjectTemplate.js";
 
 export namespace NestiaTemplate {
-  export const clone =
-    (halter: (msg?: string) => never) =>
-    async (argv: string[]): Promise<void> => {
-      // VALIDATION
-      const dest: string | undefined = argv[0];
-      if (dest === undefined) halter();
-      else if (fs.existsSync(dest) === true)
-        halter("The target directory already exists.");
-
-      console.log("-----------------------------------------");
-      console.log(" Nestia Template Kit");
-      console.log("-----------------------------------------");
-
-      // COPY PROJECTS
-      execute(`git clone https://github.com/samchon/backend ${dest}`);
-      console.log(`cd "${dest}"`);
-      process.chdir(dest);
-
-      // INSTALL DEPENDENCIES
-      execute("npm install");
-
-      // BUILD TYPESCRIPT
-      execute("npm run build");
-
-      // REMOVE .GIT DIRECTORY
-      cp.execSync("npx rimraf .git");
-    };
-
-  function execute(command: string): void {
-    console.log(`\n$ ${command}`);
-    cp.execSync(command, { stdio: "inherit" });
-  }
+  export const clone = NestiaProjectTemplate.clone({
+    title: "Nestia Template Kit",
+    repository: "https://github.com/samchon/backend",
+    test: false,
+  });
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,8 +3,8 @@ const USAGE = `Wrong command has been detected. Use like below:
 
 npx nestia [command] [options?]
 
-  1. npx nestia start <directory>
-  2. npx nestia template <directory>
+  1. npx nestia start <directory> [--repository <url>]
+  2. npx nestia template <directory> [--repository <url>]
   3. npx nestia dependencies
   4. npx nestia init
   5. npx nestia sdk

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -649,6 +649,25 @@ importers:
         specifier: catalog:typescript
         version: 0.18.1
 
+  tests/test-cli:
+    dependencies:
+      '@nestia/e2e':
+        specifier: workspace:^
+        version: link:../../packages/e2e
+    devDependencies:
+      '@types/node':
+        specifier: catalog:utils
+        version: 25.9.0
+      cross-env:
+        specifier: catalog:utils
+        version: 10.1.0
+      nestia:
+        specifier: workspace:^
+        version: link:../../packages/cli
+      ttsc:
+        specifier: catalog:typescript
+        version: 0.18.1
+
   tests/test-e2e:
     dependencies:
       '@nestia/e2e':

--- a/tests/test-cli/package.json
+++ b/tests/test-cli/package.json
@@ -1,0 +1,19 @@
+{
+  "private": true,
+  "name": "@nestia/test-cli",
+  "version": "12.0.0-rc.3",
+  "scripts": {
+    "dev": "ttsc --watch",
+    "start": "pnpm --filter nestia build && cross-env NODE_OPTIONS=\"--no-experimental-strip-types --no-experimental-detect-module\" ttsx src/index.ts"
+  },
+  "dependencies": {
+    "@nestia/e2e": "workspace:^"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:utils",
+    "cross-env": "catalog:utils",
+    "nestia": "workspace:^",
+    "ttsc": "catalog:typescript"
+  },
+  "packageManager": "pnpm@10.6.4"
+}

--- a/tests/test-cli/src/features/test_cli_existing_directory_halt.ts
+++ b/tests/test-cli/src/features/test_cli_existing_directory_halt.ts
@@ -1,0 +1,32 @@
+import { TestValidator } from "@nestia/e2e";
+
+import { CliTestHarness } from "../internal/CliTestHarness";
+
+/**
+ * Verifies the scaffolder halts when the destination directory already exists.
+ *
+ * Cloning into an existing directory would either fail halfway through git or
+ * mix template files into user data; the guard must fire before the clone, with
+ * the exact message users have relied on since the npm-era CLI.
+ *
+ * 1. Run `nestia start` with a fake context whose `exists` reports true.
+ * 2. Assert it halts with "The target directory already exists.".
+ * 3. Assert no command was executed at all.
+ */
+export const test_cli_existing_directory_halt = async (): Promise<void> => {
+  const fake: CliTestHarness.IFakeContext = CliTestHarness.createFakeContext({
+    exists: () => true,
+  });
+  const reason: string | undefined = await CliTestHarness.expectHalt(() =>
+    CliTestHarness.getStarter()(CliTestHarness.halter, fake.context)([
+      "my-project",
+    ]),
+  );
+
+  TestValidator.equals(
+    "reason",
+    reason,
+    "The target directory already exists.",
+  );
+  TestValidator.equals("commands", fake.commands, []);
+};

--- a/tests/test-cli/src/features/test_cli_missing_directory_argument_halt.ts
+++ b/tests/test-cli/src/features/test_cli_missing_directory_argument_halt.ts
@@ -1,0 +1,36 @@
+import { TestValidator } from "@nestia/e2e";
+
+import { CliTestHarness } from "../internal/CliTestHarness";
+
+/**
+ * Verifies both scaffolding commands halt with the usage message when no
+ * destination directory is given.
+ *
+ * A missing directory argument must halt with `undefined` (the dispatcher
+ * substitutes the usage text for it) before anything is cloned; note that a
+ * lone `--repository <url>` pair must not be mistaken for the destination.
+ *
+ * 1. Run `nestia start` and `nestia template` with an empty argv.
+ * 2. Run `nestia start` with only `--repository <url>`.
+ * 3. Assert every case halts with an `undefined` reason and executes nothing.
+ */
+export const test_cli_missing_directory_argument_halt =
+  async (): Promise<void> => {
+    for (const argv of [
+      [],
+      ["--repository", "https://github.com/someone/fork"],
+    ]) {
+      for (const cloner of [
+        CliTestHarness.getStarter(),
+        CliTestHarness.getTemplate(),
+      ]) {
+        const fake: CliTestHarness.IFakeContext =
+          CliTestHarness.createFakeContext();
+        const reason: string | undefined = await CliTestHarness.expectHalt(() =>
+          cloner(CliTestHarness.halter, fake.context)(argv),
+        );
+        TestValidator.equals("reason", reason, undefined);
+        TestValidator.equals("commands", fake.commands, []);
+      }
+    }
+  };

--- a/tests/test-cli/src/features/test_cli_package_manager_corepack_fallback.ts
+++ b/tests/test-cli/src/features/test_cli_package_manager_corepack_fallback.ts
@@ -1,0 +1,53 @@
+import { TestValidator } from "@nestia/e2e";
+
+import { CliTestHarness } from "../internal/CliTestHarness";
+
+/**
+ * Verifies the scaffolder falls back to `corepack pnpm` when pnpm is not
+ * directly installed.
+ *
+ * Node.js bundles corepack, so most machines without a global pnpm can still
+ * resolve the `catalog:` protocol through it — but only if the CLI both
+ * prefixes every lifecycle command with `corepack pnpm` and suppresses the
+ * interactive download prompt that would otherwise hang a non-interactive
+ * scaffold.
+ *
+ * 1. Run `nestia start` with a fake context where only `corepack --version` probes
+ *    successfully.
+ * 2. Assert install/build/test commands are prefixed with `corepack pnpm`.
+ * 3. Assert `COREPACK_ENABLE_DOWNLOAD_PROMPT` is set to `"0"`.
+ */
+export const test_cli_package_manager_corepack_fallback =
+  async (): Promise<void> => {
+    const original: string | undefined =
+      process.env.COREPACK_ENABLE_DOWNLOAD_PROMPT;
+    delete process.env.COREPACK_ENABLE_DOWNLOAD_PROMPT;
+    try {
+      const fake: CliTestHarness.IFakeContext =
+        CliTestHarness.createFakeContext({
+          probe: (command) => command.startsWith("corepack"),
+        });
+      await CliTestHarness.getStarter()(CliTestHarness.halter, fake.context)([
+        "my-project",
+      ]);
+
+      TestValidator.equals("probes", fake.probes, [
+        "pnpm --version",
+        "corepack --version",
+      ]);
+      TestValidator.equals("commands", fake.commands.slice(1), [
+        "corepack pnpm install",
+        "corepack pnpm run build",
+        "corepack pnpm run test",
+      ]);
+      TestValidator.equals<string | undefined>(
+        "prompt",
+        "0",
+        process.env.COREPACK_ENABLE_DOWNLOAD_PROMPT,
+      );
+    } finally {
+      if (original === undefined)
+        delete process.env.COREPACK_ENABLE_DOWNLOAD_PROMPT;
+      else process.env.COREPACK_ENABLE_DOWNLOAD_PROMPT = original;
+    }
+  };

--- a/tests/test-cli/src/features/test_cli_package_manager_missing_halt.ts
+++ b/tests/test-cli/src/features/test_cli_package_manager_missing_halt.ts
@@ -1,0 +1,38 @@
+import { TestValidator } from "@nestia/e2e";
+
+import { CliTestHarness } from "../internal/CliTestHarness";
+
+/**
+ * Verifies the scaffolder halts with installation guidance when neither pnpm
+ * nor corepack is available.
+ *
+ * Falling through to npm — the old behavior — would hard-fail deep inside `npm
+ * install` with a cryptic `catalog:` protocol error. Halting before any install
+ * attempt, with a message telling the user how to get pnpm, is the contract
+ * this test pins down.
+ *
+ * 1. Run `nestia start` with a fake context where every probe fails.
+ * 2. Assert the command halts and the message names pnpm and corepack.
+ * 3. Assert no package manager command was ever executed.
+ */
+export const test_cli_package_manager_missing_halt =
+  async (): Promise<void> => {
+    const fake: CliTestHarness.IFakeContext = CliTestHarness.createFakeContext({
+      probe: () => false,
+    });
+    const reason: string | undefined = await CliTestHarness.expectHalt(() =>
+      CliTestHarness.getStarter()(CliTestHarness.halter, fake.context)([
+        "my-project",
+      ]),
+    );
+
+    TestValidator.predicate(
+      "guidance",
+      reason !== undefined &&
+        reason.includes("pnpm") &&
+        reason.includes("corepack"),
+    );
+    TestValidator.equals("commands", fake.commands, [
+      `git clone "https://github.com/samchon/nestia-start" "my-project"`,
+    ]);
+  };

--- a/tests/test-cli/src/features/test_cli_repository_option_override.ts
+++ b/tests/test-cli/src/features/test_cli_repository_option_override.ts
@@ -1,0 +1,45 @@
+import { TestValidator } from "@nestia/e2e";
+
+import { CliTestHarness } from "../internal/CliTestHarness";
+
+/**
+ * Verifies the `--repository <url>` option replaces the default template
+ * repository URL.
+ *
+ * The override exists for forks and for network-free end-to-end testing of the
+ * CLI itself; if argument parsing regressed, the flag (or its value) could be
+ * mistaken for the destination directory, or the default URL could be cloned
+ * regardless of the user's choice.
+ *
+ * 1. Run `nestia start` with `--repository` pointing at a fork URL.
+ * 2. Assert the clone command uses the fork URL instead of the default.
+ * 3. Assert the destination directory is still parsed correctly.
+ * 4. Assert a `--repository` flag without a value halts with guidance.
+ */
+export const test_cli_repository_option_override = async (): Promise<void> => {
+  const url: string = "https://github.com/someone/nestia-start-fork";
+  const fake: CliTestHarness.IFakeContext = CliTestHarness.createFakeContext();
+  await CliTestHarness.getStarter()(CliTestHarness.halter, fake.context)([
+    "my-project",
+    "--repository",
+    url,
+  ]);
+
+  TestValidator.equals(
+    "clone",
+    fake.commands[0],
+    `git clone "${url}" "my-project"`,
+  );
+  TestValidator.equals("chdir", fake.chdirs, ["my-project"]);
+
+  const reason: string | undefined = await CliTestHarness.expectHalt(() =>
+    CliTestHarness.getStarter()(
+      CliTestHarness.halter,
+      CliTestHarness.createFakeContext().context,
+    )(["my-project", "--repository"]),
+  );
+  TestValidator.predicate(
+    "missing value",
+    reason !== undefined && reason.includes("--repository"),
+  );
+};

--- a/tests/test-cli/src/features/test_cli_scaffold_start_end_to_end.ts
+++ b/tests/test-cli/src/features/test_cli_scaffold_start_end_to_end.ts
@@ -1,0 +1,48 @@
+import { TestValidator } from "@nestia/e2e";
+import fs from "fs";
+import path from "path";
+
+import { CliTestHarness } from "../internal/CliTestHarness";
+
+/**
+ * Verifies the real `nestia start` executable scaffolds a pnpm monorepo
+ * end-to-end.
+ *
+ * Unit tests fake every side effect, so only this test proves the built
+ * `bin/index.js` wires the engine correctly: a real `git clone`, a real `pnpm
+ * install` against a `pnpm-workspace.yaml` project (npm would reject the
+ * workspace protocol family outright), real build/test script execution, and
+ * real removal of the repository-only files. The `--repository` override keeps
+ * it network-free.
+ *
+ * 1. Create a local fixture git repository shaped like a tiny pnpm monorepo whose
+ *    build/test scripts drop `.built` / `.tested` marker files.
+ * 2. Run `node packages/cli/bin/index.js start <dest> --repository <fixture>`.
+ * 3. Assert the destination exists with both markers present.
+ * 4. Assert `.git` and `.github/dependabot.yml` were removed.
+ */
+export const test_cli_scaffold_start_end_to_end = async (): Promise<void> => {
+  const fixture: CliTestHarness.IFixture = CliTestHarness.prepareFixture();
+  try {
+    CliTestHarness.runCli([
+      "start",
+      fixture.dest,
+      "--repository",
+      fixture.repository,
+    ]);
+
+    const exists = (...segments: string[]): boolean =>
+      fs.existsSync(path.join(fixture.dest, ...segments));
+    TestValidator.predicate("dest", fs.existsSync(fixture.dest));
+    TestValidator.predicate("workspace", exists("pnpm-workspace.yaml"));
+    TestValidator.predicate("build marker", exists(".built"));
+    TestValidator.predicate("test marker", exists(".tested"));
+    TestValidator.predicate("no .git", exists(".git") === false);
+    TestValidator.predicate(
+      "no dependabot",
+      exists(".github", "dependabot.yml") === false,
+    );
+  } finally {
+    fixture.clean();
+  }
+};

--- a/tests/test-cli/src/features/test_cli_scaffold_template_end_to_end.ts
+++ b/tests/test-cli/src/features/test_cli_scaffold_template_end_to_end.ts
@@ -1,0 +1,46 @@
+import { TestValidator } from "@nestia/e2e";
+import fs from "fs";
+import path from "path";
+
+import { CliTestHarness } from "../internal/CliTestHarness";
+
+/**
+ * Verifies the real `nestia template` executable scaffolds a pnpm monorepo
+ * without running its test suite.
+ *
+ * The template command shares the starter's engine but must stop after the
+ * build step — the backend template's test suite expects databases and other
+ * infrastructure a fresh clone does not have. Only a real CLI run proves the
+ * dispatcher maps `template` onto the no-test configuration.
+ *
+ * 1. Create a local fixture git repository whose build/test scripts drop `.built`
+ *    / `.tested` marker files.
+ * 2. Run `node packages/cli/bin/index.js template <dest> --repository <fixture>`.
+ * 3. Assert the build marker exists but the test marker does not.
+ * 4. Assert `.git` and `.github/dependabot.yml` were removed.
+ */
+export const test_cli_scaffold_template_end_to_end =
+  async (): Promise<void> => {
+    const fixture: CliTestHarness.IFixture = CliTestHarness.prepareFixture();
+    try {
+      CliTestHarness.runCli([
+        "template",
+        fixture.dest,
+        "--repository",
+        fixture.repository,
+      ]);
+
+      const exists = (...segments: string[]): boolean =>
+        fs.existsSync(path.join(fixture.dest, ...segments));
+      TestValidator.predicate("dest", fs.existsSync(fixture.dest));
+      TestValidator.predicate("build marker", exists(".built"));
+      TestValidator.predicate("no test marker", exists(".tested") === false);
+      TestValidator.predicate("no .git", exists(".git") === false);
+      TestValidator.predicate(
+        "no dependabot",
+        exists(".github", "dependabot.yml") === false,
+      );
+    } finally {
+      fixture.clean();
+    }
+  };

--- a/tests/test-cli/src/features/test_cli_start_command_sequence.ts
+++ b/tests/test-cli/src/features/test_cli_start_command_sequence.ts
@@ -1,0 +1,36 @@
+import { TestValidator } from "@nestia/e2e";
+
+import { CliTestHarness } from "../internal/CliTestHarness";
+
+/**
+ * Verifies `nestia start` clones `nestia-start` and drives the full pnpm
+ * lifecycle in order.
+ *
+ * The new template repository is a pnpm monorepo whose manifests use the
+ * `catalog:` dependency protocol, which npm cannot resolve — the previous `npm
+ * install` flow hard-failed on it. This locks the exact command sequence (pnpm,
+ * not npm; canonical `nestia-start` URL, not the renamed `nestia-template`
+ * redirect) plus the trailing repository-file cleanup.
+ *
+ * 1. Run the starter's `clone` against a fake context with pnpm available.
+ * 2. Assert the executed commands are exactly clone → install → build → test.
+ * 3. Assert `.git` and `.github/dependabot.yml` are removed afterwards.
+ */
+export const test_cli_start_command_sequence = async (): Promise<void> => {
+  const fake: CliTestHarness.IFakeContext = CliTestHarness.createFakeContext();
+  await CliTestHarness.getStarter()(CliTestHarness.halter, fake.context)([
+    "my-project",
+  ]);
+
+  TestValidator.equals("commands", fake.commands, [
+    `git clone "https://github.com/samchon/nestia-start" "my-project"`,
+    "pnpm install",
+    "pnpm run build",
+    "pnpm run test",
+  ]);
+  TestValidator.equals("chdir", fake.chdirs, ["my-project"]);
+  TestValidator.equals("removed", fake.removed, [
+    ".git",
+    ".github/dependabot.yml",
+  ]);
+};

--- a/tests/test-cli/src/features/test_cli_template_command_sequence.ts
+++ b/tests/test-cli/src/features/test_cli_template_command_sequence.ts
@@ -1,0 +1,32 @@
+import { TestValidator } from "@nestia/e2e";
+
+import { CliTestHarness } from "../internal/CliTestHarness";
+
+/**
+ * Verifies `nestia template` clones `samchon/backend` and skips the test suite.
+ *
+ * Both scaffolding commands share one engine, so a regression in the
+ * per-command props would silently make `template` inherit the starter's
+ * behavior: wrong repository URL, or a `pnpm run test` step the heavier backend
+ * template deliberately omits during scaffolding.
+ *
+ * 1. Run the template's `clone` against a fake context with pnpm available.
+ * 2. Assert the clone targets `https://github.com/samchon/backend`.
+ * 3. Assert no `pnpm run test` command is executed.
+ */
+export const test_cli_template_command_sequence = async (): Promise<void> => {
+  const fake: CliTestHarness.IFakeContext = CliTestHarness.createFakeContext();
+  await CliTestHarness.getTemplate()(CliTestHarness.halter, fake.context)([
+    "my-backend",
+  ]);
+
+  TestValidator.equals("commands", fake.commands, [
+    `git clone "https://github.com/samchon/backend" "my-backend"`,
+    "pnpm install",
+    "pnpm run build",
+  ]);
+  TestValidator.equals("removed", fake.removed, [
+    ".git",
+    ".github/dependabot.yml",
+  ]);
+};

--- a/tests/test-cli/src/index.ts
+++ b/tests/test-cli/src/index.ts
@@ -1,0 +1,22 @@
+import { DynamicExecutor } from "@nestia/e2e";
+
+async function main(): Promise<void> {
+  const report: DynamicExecutor.IReport = await DynamicExecutor.assert({
+    parameters: () => [],
+    location: __dirname + "/features",
+    prefix: "test",
+    onComplete: (exec) => {
+      const elapsed: number =
+        new Date(exec.completed_at).getTime() -
+        new Date(exec.started_at).getTime();
+      console.log(` - ${exec.name}: ${elapsed.toLocaleString()} ms`);
+    },
+    simultaneous: 1,
+    extension: "ts",
+  });
+  console.log(`Elapsed time: ${report.time.toLocaleString()} ms`);
+}
+main().catch((exp) => {
+  console.log(exp);
+  process.exit(-1);
+});

--- a/tests/test-cli/src/internal/CliTestHarness.ts
+++ b/tests/test-cli/src/internal/CliTestHarness.ts
@@ -1,0 +1,204 @@
+import cp from "child_process";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+/**
+ * Local helpers for the `nestia start` / `nestia template` test suite.
+ *
+ * The suite exercises the built CLI artifacts under `packages/cli/bin`, not the
+ * TypeScript sources: unit tests load the scaffolding engine through an
+ * absolute-path `require()` (the package's exports map blocks deep subpath
+ * imports), and end-to-end tests spawn the real `bin/index.js` executable
+ * against a local fixture git repository so no network access is needed.
+ */
+export namespace CliTestHarness {
+  /* -----------------------------------------------------------
+    LOCATIONS
+  ----------------------------------------------------------- */
+  /** Ttsx relocates compiled sources, so anchor on the workspace cwd. */
+  export const ROOT: string = path.resolve(process.cwd(), "..", "..");
+  export const CLI_BIN: string = path.join(ROOT, "packages", "cli", "bin");
+  export const CLI_MAIN: string = path.join(CLI_BIN, "index.js");
+
+  /* -----------------------------------------------------------
+    BUILT ENGINE ACCESSORS
+  ----------------------------------------------------------- */
+  /** Mirrors `NestiaProjectTemplate.IContext` of `packages/cli`. */
+  export interface IContext {
+    execute: (command: string) => void;
+    probe: (command: string) => boolean;
+    chdir: (directory: string) => void;
+    exists: (path: string) => boolean;
+    remove: (path: string) => void;
+  }
+  export type Cloner = (
+    halter: (msg?: string) => never,
+    context?: IContext,
+  ) => (argv: string[]) => Promise<void>;
+
+  export const getStarter = (): Cloner =>
+    load("NestiaStarter.js").NestiaStarter.clone;
+  export const getTemplate = (): Cloner =>
+    load("NestiaTemplate.js").NestiaTemplate.clone;
+
+  const load = (file: string): any => require(path.join(CLI_BIN, file));
+
+  /* -----------------------------------------------------------
+    UNIT TEST FAKES
+  ----------------------------------------------------------- */
+  export interface IFakeContext {
+    context: IContext;
+    commands: string[];
+    probes: string[];
+    chdirs: string[];
+    removed: string[];
+  }
+  export const createFakeContext = (props?: {
+    exists?: (path: string) => boolean;
+    probe?: (command: string) => boolean;
+  }): IFakeContext => {
+    const commands: string[] = [];
+    const probes: string[] = [];
+    const chdirs: string[] = [];
+    const removed: string[] = [];
+    const context: IContext = {
+      execute: (command) => void commands.push(command),
+      probe: (command) => {
+        probes.push(command);
+        return props?.probe !== undefined
+          ? props.probe(command)
+          : command.startsWith("pnpm");
+      },
+      chdir: (directory) => void chdirs.push(directory),
+      exists: (location) =>
+        props?.exists !== undefined ? props.exists(location) : false,
+      remove: (location) => void removed.push(location),
+    };
+    return { context, commands, probes, chdirs, removed };
+  };
+
+  /** Thrown by {@link halter} so tests can observe the halt reason. */
+  export class HaltError extends Error {
+    public constructor(public readonly reason: string | undefined) {
+      super(reason ?? "(usage)");
+    }
+  }
+  export const halter = (msg?: string): never => {
+    throw new HaltError(msg);
+  };
+  export const expectHalt = async (
+    task: () => Promise<void>,
+  ): Promise<string | undefined> => {
+    try {
+      await task();
+    } catch (error) {
+      if (error instanceof HaltError) return error.reason;
+      throw error;
+    }
+    throw new Error("Expected the command to halt, but it completed.");
+  };
+
+  /* -----------------------------------------------------------
+    END TO END FIXTURES
+  ----------------------------------------------------------- */
+  export interface IFixture {
+    /** Local git repository standing in for the template repository. */
+    repository: string;
+    /** Scaffold destination; does not exist until the CLI creates it. */
+    dest: string;
+    /** Best-effort removal of every temporary directory. */
+    clean: () => void;
+  }
+
+  /**
+   * Creates a local git repository shaped like a tiny pnpm monorepo whose root
+   * `build` / `test` scripts drop `.built` / `.tested` marker files, so tests
+   * can prove which lifecycle steps the CLI actually ran.
+   */
+  export const prepareFixture = (): IFixture => {
+    const repository: string = fs.mkdtempSync(
+      path.join(os.tmpdir(), "nestia-cli-fixture-"),
+    );
+    const workspace: string = fs.mkdtempSync(
+      path.join(os.tmpdir(), "nestia-cli-scaffold-"),
+    );
+    write(
+      repository,
+      "package.json",
+      JSON.stringify(
+        {
+          name: "nestia-cli-fixture",
+          version: "0.0.1",
+          private: true,
+          scripts: {
+            build: `node -e "require('fs').writeFileSync('.built','1')"`,
+            test: `node -e "require('fs').writeFileSync('.tested','1')"`,
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    write(repository, "pnpm-workspace.yaml", `packages:\n  - "packages/*"\n`);
+    write(
+      repository,
+      path.join("packages", "api", "package.json"),
+      JSON.stringify(
+        { name: "nestia-cli-fixture-api", version: "0.0.1", private: true },
+        null,
+        2,
+      ),
+    );
+    write(
+      repository,
+      path.join(".github", "dependabot.yml"),
+      "version: 2\nupdates: []\n",
+    );
+
+    const git = (...args: string[]): void =>
+      void cp.execFileSync("git", args, { cwd: repository, stdio: "ignore" });
+    git("init");
+    git("add", ".");
+    git(
+      "-c",
+      "user.name=nestia",
+      "-c",
+      "user.email=nestia@test",
+      "-c",
+      "commit.gpgsign=false",
+      "commit",
+      "-m",
+      "fixture",
+    );
+
+    return {
+      repository,
+      dest: path.join(workspace, "project"),
+      clean: () => {
+        for (const directory of [repository, workspace])
+          try {
+            fs.rmSync(directory, {
+              recursive: true,
+              force: true,
+              maxRetries: 4,
+            });
+          } catch {
+            // temporary directories; leftovers are harmless
+          }
+      },
+    };
+  };
+
+  /** Runs the real CLI executable (`packages/cli/bin/index.js`). */
+  export const runCli = (args: string[]): void =>
+    void cp.execFileSync(process.execPath, [CLI_MAIN, ...args], {
+      stdio: "inherit",
+    });
+
+  const write = (root: string, file: string, content: string): void => {
+    const location: string = path.join(root, file);
+    fs.mkdirSync(path.dirname(location), { recursive: true });
+    fs.writeFileSync(location, content, "utf8");
+  };
+}

--- a/tests/test-cli/tsconfig.json
+++ b/tests/test-cli/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../config/tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+  },
+  "include": ["src"],
+}


### PR DESCRIPTION
## Summary

The template repositories (`samchon/nestia-start`, `samchon/backend`) are now pnpm monorepos whose manifests use the `catalog:` dependency protocol — npm hard-fails on it, so `npx nestia start` / `npx nestia template` were broken. This PR reworks both commands around a single shared engine, `packages/cli/src/NestiaProjectTemplate.ts`, with an injectable side-effect context (`execute` / `probe` / `chdir` / `exists` / `remove`) so every branch is unit-testable without network access.

- Package manager resolution: probe `pnpm --version` → use `pnpm`; else probe `corepack --version` → use `corepack pnpm` with `COREPACK_ENABLE_DOWNLOAD_PROMPT=0`; else halt with clear "install pnpm / corepack enable" guidance. npm is never invoked.
- `start` clones the canonical `https://github.com/samchon/nestia-start` URL instead of the renamed `nestia-template` redirect; `template` keeps `https://github.com/samchon/backend` and still skips the test step.
- New `--repository <url>` override (shown in USAGE) for forks and offline e2e testing.
- `.git` and `.github/dependabot.yml` are removed with `fs.rmSync` instead of spawning `npx rimraf` (which pointlessly invoked npm).
- `NestiaStarter` / `NestiaTemplate` are now thin wrappers; the `clone(halter)(argv)` calling shape is unchanged, so the dispatcher only got a USAGE text update.

New `tests/test-cli` workspace (function-per-file, DynamicExecutor):

- Unit (fake context): start command sequence, template command sequence (no test step), `--repository` override + missing-value halt, pnpm→corepack fallback + prompt env var, no-package-manager halt, missing directory argument halt, existing directory halt.
- End-to-end (no network): a local fixture git repository shaped like a tiny pnpm monorepo (root `build`/`test` scripts drop `.built`/`.tested` markers, `pnpm-workspace.yaml`, `.github/dependabot.yml`) is scaffolded by the real `packages/cli/bin/index.js` for both commands; asserts markers, `.git` removal, and dependabot removal (and marker absence for `template`).

CI: added `- { name: cli, run: "pnpm --filter ./tests/test-cli start" }` to the test matrix.

## Verification

All run locally on Windows 11 (Node 22, pnpm 10.6.4, git 2.51):

- `pnpm install` — pass (lockfile picks up the new `tests/test-cli` importer only)
- `pnpm --filter nestia build` — pass
- `pnpm --filter ./tests/test-cli start` — pass, 9/9 tests green (e2e legs really clone + `pnpm install` + build/test + cleanup against the local fixture)
- `node packages/cli/bin/index.js` (no args) — USAGE prints with the new `[--repository <url>]` lines
- `node packages/cli/bin/index.js start` / `start .` — usage halt and "The target directory already exists." halt
- Changed TS files formatted with the repo prettier

## Known gaps

- No test performs a real network clone of `nestia-start`/`backend` with a full install+build+test pass (deliberate: CI must stay offline-safe); the canonical URLs are locked by unit tests only.
- The corepack fallback is covered by a unit test with a fake probe; it was not exercised on a machine that truly lacks pnpm.
- Docs under `website/` intentionally untouched (out of scope for this PR per instruction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYUZ95W7jUpsnTgxBmamAH
