### PR TITLE
fix(test): e2e suite silently ran zero tests under ttsx

### DIFF
--- a/tests/test-e2e/src/index.ts
+++ b/tests/test-e2e/src/index.ts
@@ -12,8 +12,13 @@ async function main(): Promise<void> {
       console.log(` - ${exec.name}: ${elapsed.toLocaleString()} ms`);
     },
     simultaneous: 1,
-    extension: "js",
+    // ttsx executes the .ts sources directly, so the discovered files carry
+    // the extension of THIS file, not a compiled "js". A hardcoded "js" made
+    // discovery return zero tests and the suite pass vacuously.
+    extension: __filename.substring(__filename.length - 2),
   });
+  if (report.executions.length === 0)
+    throw new Error("No e2e test function has been discovered.");
   console.log(`Elapsed time: ${report.time.toLocaleString()} ms`);
 }
 main().catch((exp) => {


### PR DESCRIPTION
## Summary

The CI `e2e` leg has been green while executing **zero** test functions. `tests/test-e2e/src/index.ts` passed `extension: "js"` to `DynamicExecutor.assert`, but the suite runs its `.ts` sources directly via ttsx — so file discovery never matched anything and the empty report passed vacuously (CI log of run 29044232765 shows `Elapsed time: 3 ms` with no executed functions).

Fix: derive the extension from `__filename` (the pattern the generated test-sdk feature suites already use), and throw when discovery returns an empty execution list so the suite can never pass vacuously again.

## Verification

- Before: CI log shows 0 ` - test_*` lines, `Elapsed time: 3 ms`.
- After (local, Windows): `pnpm --filter ./tests/test-e2e start` → 11/11 functions execute and pass, `Elapsed time: 626 ms`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYUZ95W7jUpsnTgxBmamAH