### PR TITLE
fix(sdk): stop forcing npm into user projects from distribute and dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,7 @@ jobs:
           - { name: transform-options, run: "pnpm --filter ./tests/test-transform-options start" }
           - { name: e2e, run: "pnpm --filter ./tests/test-e2e start" }
           - { name: benchmark, run: "pnpm --filter ./tests/test-benchmark start" }
+          - { name: distribute, run: "pnpm --filter ./tests/test-distribute start" }
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/packages/sdk/src/executable/internal/DependenciesInstaller.ts
+++ b/packages/sdk/src/executable/internal/DependenciesInstaller.ts
@@ -1,0 +1,54 @@
+import cp from "child_process";
+
+import { PackageManagerDetector } from "../../utils/PackageManagerDetector";
+import { SdkManifest } from "../../utils/SdkManifest";
+
+/** Composes and runs the `nestia dependencies` installation. */
+export namespace DependenciesInstaller {
+  /**
+   * Composes the exact install command for the given package manager.
+   *
+   * `@nestia/e2e` and `@nestia/fetcher` are pinned to the running SDK's own
+   * version line, and `typia` to the range `@nestia/sdk` itself declares, so a
+   * fresh `npx @nestia/sdk dependencies` cannot pull an incompatible major from
+   * the registry. Workspace-relative ranges (`catalog:`, `workspace:`) are not
+   * installable from the registry, so `typia` falls back to unpinned in that
+   * case — it only occurs inside this monorepo itself.
+   *
+   * Kept pure (inputs -> string[]) so unit tests can assert the command strings
+   * without executing any install.
+   */
+  export const compose = (props: {
+    manager: PackageManagerDetector.Manager;
+    version: string;
+    typia: string | undefined;
+  }): string[] => {
+    const specs: string[] = [
+      `@nestia/e2e@^${props.version}`,
+      `@nestia/fetcher@^${props.version}`,
+      props.typia !== undefined && installable(props.typia)
+        ? `typia@${props.typia}`
+        : "typia",
+    ];
+    const prefix: string =
+      props.manager === "npm" ? "npm install" : `${props.manager} add`;
+    return [`${prefix} ${specs.join(" ")}`];
+  };
+
+  export const install = (props: {
+    manager: PackageManagerDetector.Manager;
+  }): void => {
+    const manifest: SdkManifest.IManifest = SdkManifest.read();
+    for (const command of compose({
+      manager: props.manager,
+      version: manifest.version,
+      typia: manifest.dependencies.typia,
+    })) {
+      console.log(`\n$ ${command}`);
+      cp.execSync(command, { stdio: "inherit" });
+    }
+  };
+
+  const installable = (range: string): boolean =>
+    !range.startsWith("catalog:") && !range.startsWith("workspace:");
+}

--- a/packages/sdk/src/executable/sdk.ts
+++ b/packages/sdk/src/executable/sdk.ts
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
-import cp from "child_process";
 import fs from "fs";
 import process from "process";
 
+import { PackageManagerDetector } from "../utils/PackageManagerDetector";
 import { CommandParser } from "./internal/CommandParser";
+import { DependenciesInstaller } from "./internal/DependenciesInstaller";
 import type { NestiaSdkCommand } from "./internal/NestiaSdkCommand";
 
 const USAGE = `Wrong command has been detected. Use like below:
@@ -28,14 +29,19 @@ function halt(desc: string): never {
 function dependencies(argv: string[]): void {
   // INSTALL DEPENDENCIES
   const options = CommandParser.parse(argv);
-  const module = options.manager ?? options.module ?? "npm";
-  const prefix: string = module === "yarn" ? "yarn add" : `${module} install`;
-
-  for (const lib of ["@nestia/e2e", "@nestia/fetcher", "typia"]) {
-    const command: string = `${prefix} ${lib}`;
-    console.log(`\n$ ${command}`);
-    cp.execSync(command, { stdio: "inherit" });
-  }
+  const manual: string | undefined = options.manager ?? options.module;
+  if (
+    manual !== undefined &&
+    !(PackageManagerDetector.MANAGERS as readonly string[]).includes(manual)
+  )
+    halt(
+      `Unsupported package manager "${manual}". Choose one of (npm|pnpm|yarn).`,
+    );
+  DependenciesInstaller.install({
+    manager:
+      (manual as PackageManagerDetector.Manager | undefined) ??
+      PackageManagerDetector.detect({ directory: process.cwd() }),
+  });
 }
 
 async function initialize(): Promise<void> {

--- a/packages/sdk/src/generates/internal/SdkDistributionComposer.ts
+++ b/packages/sdk/src/generates/internal/SdkDistributionComposer.ts
@@ -3,8 +3,17 @@ import fs from "fs";
 import path from "path";
 
 import { INestiaConfig } from "../../INestiaConfig";
+import { PackageManagerDetector } from "../../utils/PackageManagerDetector";
+import { SdkManifest } from "../../utils/SdkManifest";
 
 export namespace SdkDistributionComposer {
+  export interface IDependencies {
+    version: string;
+    typia: string;
+    tgrid: string | undefined;
+    mcp: string | undefined;
+  }
+
   export const compose = async (props: {
     config: INestiaConfig;
     mcp: boolean;
@@ -15,6 +24,10 @@ export namespace SdkDistributionComposer {
 
     const root: string = process.cwd();
     const output: string = path.resolve(props.config.output!);
+    const manager: PackageManagerDetector.Manager =
+      PackageManagerDetector.detect({
+        directory: path.resolve(props.config.distribute!),
+      });
     process.chdir(props.config.distribute!);
 
     const exit = () => process.chdir(root);
@@ -22,25 +35,82 @@ export namespace SdkDistributionComposer {
 
     // COPY FILES
     console.log("Composing SDK distribution environments...");
-    for (const file of await fs.promises.readdir(BUNDLE))
-      await fs.promises.copyFile(`${BUNDLE}/${file}`, file);
+    const copied: string[] = await copyBundle({
+      from: BUNDLE,
+      into: process.cwd(),
+    });
 
-    // CONFIGURE PATHS
+    // CONFIGURE PATHS (only in files this run created)
     for (const file of ["package.json", "tsconfig.json"])
-      await replace({ root, output })(file);
+      if (copied.includes(file)) await replace({ root, output })(file);
 
     // INSTALL PACKAGES
-    const v: IDependencies = await dependencies({ websocket: props.websocket });
-    execute("npm install --save-dev rimraf");
-    execute(`npm install --save @nestia/fetcher@${v.version}`);
-    execute(`npm install --save typia@${v.typia}`);
-    if (props.mcp && v.mcp !== undefined)
-      execute(`npm install --save @modelcontextprotocol/sdk@${v.mcp}`);
-    if (props.websocket && v.tgrid !== undefined)
-      execute(`npm install --save tgrid@${v.tgrid}`);
-    execute("npx typia setup --manager npm");
+    //
+    // `typia setup` is not invoked anymore: typia v13 dropped that CLI
+    // command (only `generate` remains, everything else exits non-zero),
+    // and the @next line wires the transform through the ttsc plugin
+    // pipeline instead of ts-patch.
+    for (const command of commands({
+      manager,
+      dependencies: dependencies({ websocket: props.websocket }),
+      mcp: props.mcp,
+      websocket: props.websocket,
+    }))
+      execute(command);
 
     exit();
+  };
+
+  /**
+   * Copies each bundled file into the distribution directory only when the
+   * target does not exist yet, and returns the names of the files it created.
+   *
+   * A user-authored README.md / tsconfig.json / package.json in the
+   * distribution directory must never be clobbered by a rerun, following the
+   * same write-if-missing contract as the SDK output bundling.
+   */
+  export const copyBundle = async (props: {
+    from: string;
+    into: string;
+  }): Promise<string[]> => {
+    const copied: string[] = [];
+    for (const file of await fs.promises.readdir(props.from)) {
+      const target: string = path.join(props.into, file);
+      if (fs.existsSync(target)) continue;
+      await fs.promises.copyFile(path.join(props.from, file), target);
+      copied.push(file);
+    }
+    return copied;
+  };
+
+  /**
+   * Composes the exact install commands for the detected package manager.
+   *
+   * Kept pure (inputs -> string[]) so unit tests can assert the command strings
+   * without executing any install.
+   */
+  export const commands = (props: {
+    manager: PackageManagerDetector.Manager;
+    dependencies: IDependencies;
+    mcp: boolean;
+    websocket: boolean;
+  }): string[] => {
+    const add = (dev: boolean, spec: string): string =>
+      props.manager === "npm"
+        ? `npm install ${dev ? "--save-dev" : "--save"} ${spec}`
+        : `${props.manager} add ${dev ? "-D " : ""}${spec}`;
+    const output: string[] = [
+      add(true, "rimraf"),
+      add(false, `@nestia/fetcher@${props.dependencies.version}`),
+      add(false, `typia@${props.dependencies.typia}`),
+    ];
+    if (props.mcp && props.dependencies.mcp !== undefined)
+      output.push(
+        add(false, `@modelcontextprotocol/sdk@${props.dependencies.mcp}`),
+      );
+    if (props.websocket && props.dependencies.tgrid !== undefined)
+      output.push(add(false, `tgrid@${props.dependencies.tgrid}`));
+    return output;
   };
 
   const configured = async (): Promise<boolean> =>
@@ -80,25 +150,11 @@ export namespace SdkDistributionComposer {
       );
     };
 
-  const dependencies = async (opts: {
-    websocket: boolean;
-  }): Promise<IDependencies> => {
-    const content: string = await fs.promises.readFile(
-      __dirname + "/../../../package.json",
-      "utf8",
-    );
-    const json: {
-      version: string;
-      dependencies: Record<string, string>;
-      devDependencies: Record<string, string>;
-    } = JSON.parse(content);
-    const dependencies: Record<string, string> = {
-      ...json.devDependencies,
-      ...json.dependencies,
-    };
+  const dependencies = (opts: { websocket: boolean }): IDependencies => {
+    const manifest: SdkManifest.IManifest = SdkManifest.read();
     const required = (key: "version" | "typia"): string => {
       const value: string | undefined =
-        key === "version" ? json.version : dependencies[key];
+        key === "version" ? manifest.version : manifest.dependencies[key];
       if (typeof value !== "string" || value.length === 0)
         throw new Error(
           `Unable to resolve ${key} version for SDK distribution.`,
@@ -108,16 +164,10 @@ export namespace SdkDistributionComposer {
     return {
       version: required("version"),
       typia: required("typia"),
-      tgrid: opts.websocket ? dependencies.tgrid : undefined,
-      mcp: dependencies["@modelcontextprotocol/sdk"],
+      tgrid: opts.websocket ? manifest.dependencies.tgrid : undefined,
+      mcp: manifest.dependencies["@modelcontextprotocol/sdk"],
     };
   };
 }
 
-interface IDependencies {
-  version: string;
-  typia: string;
-  tgrid: string | undefined;
-  mcp: string | undefined;
-}
 const BUNDLE = __dirname + "/../../../assets/bundle/distribute";

--- a/packages/sdk/src/utils/PackageManagerDetector.ts
+++ b/packages/sdk/src/utils/PackageManagerDetector.ts
@@ -1,0 +1,77 @@
+import fs from "fs";
+import path from "path";
+
+/**
+ * Detects which package manager owns a directory.
+ *
+ * Walks up from the given directory to the file-system root and returns the
+ * manager of the first marker found on the way. An explicit `packageManager`
+ * declaration in `package.json` wins over lockfiles at the same level, so a
+ * project pinning e.g. `yarn@4` is respected even when a stray lockfile of
+ * another manager remains. A nested project carrying its own
+ * `package-lock.json` resolves to npm even inside an outer pnpm monorepo,
+ * because installs must target the nearest project boundary. Without any marker
+ * anywhere, npm is the fallback.
+ */
+export namespace PackageManagerDetector {
+  export const MANAGERS = ["npm", "pnpm", "yarn"] as const;
+  export type Manager = (typeof MANAGERS)[number];
+
+  /**
+   * Injectable file-system view, so unit tests can simulate marker layouts
+   * without touching the real disk.
+   */
+  export interface IFileSystem {
+    exists(location: string): boolean;
+    read(location: string): string;
+  }
+
+  export const detect = (props: {
+    directory: string;
+    fs?: IFileSystem;
+  }): Manager => {
+    const view: IFileSystem = props.fs ?? REAL;
+    let current: string = path.resolve(props.directory);
+    while (true) {
+      const found: Manager | undefined = at(view, current);
+      if (found !== undefined) return found;
+      const parent: string = path.dirname(current);
+      if (parent === current) return "npm";
+      current = parent;
+    }
+  };
+
+  const at = (view: IFileSystem, directory: string): Manager | undefined => {
+    const declared: Manager | undefined = declaration(view, directory);
+    if (declared !== undefined) return declared;
+    if (
+      view.exists(path.join(directory, "pnpm-lock.yaml")) ||
+      view.exists(path.join(directory, "pnpm-workspace.yaml"))
+    )
+      return "pnpm";
+    if (view.exists(path.join(directory, "yarn.lock"))) return "yarn";
+    if (view.exists(path.join(directory, "package-lock.json"))) return "npm";
+    return undefined;
+  };
+
+  const declaration = (
+    view: IFileSystem,
+    directory: string,
+  ): Manager | undefined => {
+    const manifest: string = path.join(directory, "package.json");
+    if (!view.exists(manifest)) return undefined;
+    try {
+      const value: unknown = JSON.parse(view.read(manifest)).packageManager;
+      if (typeof value !== "string") return undefined;
+      for (const manager of MANAGERS)
+        if (value === manager || value.startsWith(`${manager}@`))
+          return manager;
+    } catch {}
+    return undefined;
+  };
+
+  const REAL: IFileSystem = {
+    exists: (location) => fs.existsSync(location),
+    read: (location) => fs.readFileSync(location, "utf8"),
+  };
+}

--- a/packages/sdk/src/utils/SdkManifest.ts
+++ b/packages/sdk/src/utils/SdkManifest.ts
@@ -1,0 +1,34 @@
+import fs from "fs";
+import path from "path";
+
+/**
+ * Reads the running `@nestia/sdk`'s own `package.json` at runtime, so that
+ * installer commands can pin companion packages (`@nestia/fetcher`,
+ * `@nestia/e2e`, `typia`, ...) to the exact version line this SDK was released
+ * with, instead of pulling whatever the registry currently tags as latest.
+ */
+export namespace SdkManifest {
+  export interface IManifest {
+    version: string;
+    dependencies: Record<string, string>;
+  }
+
+  export const read = (): IManifest => {
+    const json: {
+      version?: string;
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    } = JSON.parse(
+      fs.readFileSync(path.join(__dirname, "..", "..", "package.json"), "utf8"),
+    );
+    if (typeof json.version !== "string" || json.version.length === 0)
+      throw new Error("Unable to resolve @nestia/sdk's own version.");
+    return {
+      version: json.version,
+      dependencies: {
+        ...(json.devDependencies ?? {}),
+        ...(json.dependencies ?? {}),
+      },
+    };
+  };
+}

--- a/packages/sdk/src/utils/TtscExecutor.ts
+++ b/packages/sdk/src/utils/TtscExecutor.ts
@@ -52,7 +52,7 @@ export namespace TtscExecutor {
       throw new Error(
         `Unable to find "ttsc" binary from package metadata. ` +
           `Available bin entries: ${keys}. ` +
-          `Reinstall with: npm install --save-dev ttsc`,
+          `Reinstall "ttsc" as a devDependency (e.g. pnpm add -D ttsc).`,
       );
     }
 
@@ -60,7 +60,7 @@ export namespace TtscExecutor {
     if (!fs.existsSync(resolved))
       throw new Error(
         `"ttsc" binary not found at "${resolved}". ` +
-          `Reinstall with: npm install --save-dev ttsc`,
+          `Reinstall "ttsc" as a devDependency (e.g. pnpm add -D ttsc).`,
       );
     bin_.set(cwd, resolved);
     return resolved;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -649,6 +649,12 @@ importers:
         specifier: catalog:typescript
         version: 0.18.1
 
+  tests/test-distribute:
+    devDependencies:
+      '@nestia/sdk':
+        specifier: workspace:^
+        version: link:../../packages/sdk
+
   tests/test-e2e:
     dependencies:
       '@nestia/e2e':

--- a/tests/test-distribute/features/test_dependencies_commands_npm.js
+++ b/tests/test-distribute/features/test_dependencies_commands_npm.js
@@ -1,0 +1,28 @@
+const assert = require("assert/strict");
+
+const { DependenciesInstaller } = require("../internal/sdk");
+
+/**
+ * Verifies the npm command composed by `nestia dependencies`, with every
+ * package pinned.
+ *
+ * The command used to install `@nestia/e2e`, `@nestia/fetcher`, and `typia`
+ * unpinned, so the registry's latest could introduce an incompatible major next
+ * to an older SDK. The companions must be pinned to the running SDK's own
+ * version line and typia to the range @nestia/sdk declares.
+ *
+ * 1. Compose the install command for npm with a known SDK version and typia range.
+ * 2. Assert the exact command string with all three pinned specs.
+ */
+exports.test_dependencies_commands_npm = () => {
+  assert.deepEqual(
+    DependenciesInstaller.compose({
+      manager: "npm",
+      version: "12.0.0-rc.3",
+      typia: "^13.0.0",
+    }),
+    [
+      "npm install @nestia/e2e@^12.0.0-rc.3 @nestia/fetcher@^12.0.0-rc.3 typia@^13.0.0",
+    ],
+  );
+};

--- a/tests/test-distribute/features/test_dependencies_commands_pnpm.js
+++ b/tests/test-distribute/features/test_dependencies_commands_pnpm.js
@@ -1,0 +1,28 @@
+const assert = require("assert/strict");
+
+const { DependenciesInstaller } = require("../internal/sdk");
+
+/**
+ * Verifies the pnpm command composed by `nestia dependencies`.
+ *
+ * Pnpm's install-a-package verb is `add`, not `install`; the old `${manager}
+ * install <lib>` template produced `pnpm install <lib>`, which only works by
+ * accident of pnpm's npm compatibility. The pnpm path must emit the canonical
+ * syntax with the same pinned specs as npm.
+ *
+ * 1. Compose the install command for pnpm with a known SDK version and typia
+ *    range.
+ * 2. Assert the exact `pnpm add` command string with pinned specs.
+ */
+exports.test_dependencies_commands_pnpm = () => {
+  assert.deepEqual(
+    DependenciesInstaller.compose({
+      manager: "pnpm",
+      version: "12.0.0-rc.3",
+      typia: "^13.0.0",
+    }),
+    [
+      "pnpm add @nestia/e2e@^12.0.0-rc.3 @nestia/fetcher@^12.0.0-rc.3 typia@^13.0.0",
+    ],
+  );
+};

--- a/tests/test-distribute/features/test_dependencies_commands_yarn.js
+++ b/tests/test-distribute/features/test_dependencies_commands_yarn.js
@@ -1,0 +1,27 @@
+const assert = require("assert/strict");
+
+const { DependenciesInstaller } = require("../internal/sdk");
+
+/**
+ * Verifies the yarn command composed by `nestia dependencies`.
+ *
+ * The explicit `--manager yarn` override predates the detection logic and must
+ * keep producing `yarn add` while gaining the same pinned specs as the other
+ * managers.
+ *
+ * 1. Compose the install command for yarn with a known SDK version and typia
+ *    range.
+ * 2. Assert the exact `yarn add` command string with pinned specs.
+ */
+exports.test_dependencies_commands_yarn = () => {
+  assert.deepEqual(
+    DependenciesInstaller.compose({
+      manager: "yarn",
+      version: "12.0.0-rc.3",
+      typia: "^13.0.0",
+    }),
+    [
+      "yarn add @nestia/e2e@^12.0.0-rc.3 @nestia/fetcher@^12.0.0-rc.3 typia@^13.0.0",
+    ],
+  );
+};

--- a/tests/test-distribute/features/test_dependencies_typia_catalog_fallback.js
+++ b/tests/test-distribute/features/test_dependencies_typia_catalog_fallback.js
@@ -1,0 +1,30 @@
+const assert = require("assert/strict");
+
+const { DependenciesInstaller } = require("../internal/sdk");
+
+/**
+ * Verifies the unpinned typia fallback when @nestia/sdk declares a
+ * workspace-relative range.
+ *
+ * Inside this monorepo, @nestia/sdk's manifest declares typia as
+ * `catalog:samchon` (rewritten to a real range only at publish time). Emitting
+ * `typia@catalog:samchon` toward the public registry would make the install
+ * fail, so such ranges must fall back to an unpinned `typia` spec. The pinned
+ * companions are unaffected because the SDK's own version is always concrete.
+ *
+ * 1. Compose the install command with typia declared as `catalog:samchon`.
+ * 2. Assert typia is unpinned while both companions stay pinned.
+ * 3. Repeat with a `workspace:^` range and an undefined range.
+ */
+exports.test_dependencies_typia_catalog_fallback = () => {
+  for (const typia of ["catalog:samchon", "workspace:^", undefined])
+    assert.deepEqual(
+      DependenciesInstaller.compose({
+        manager: "pnpm",
+        version: "12.0.0-rc.3",
+        typia,
+      }),
+      ["pnpm add @nestia/e2e@^12.0.0-rc.3 @nestia/fetcher@^12.0.0-rc.3 typia"],
+      `typia range: ${String(typia)}`,
+    );
+};

--- a/tests/test-distribute/features/test_detect_nested_package_lock_wins_over_ancestor_pnpm.js
+++ b/tests/test-distribute/features/test_detect_nested_package_lock_wins_over_ancestor_pnpm.js
@@ -1,0 +1,48 @@
+const assert = require("assert/strict");
+const fs = require("fs");
+const path = require("path");
+
+const { withTemporaryDirectory } = require("../internal/directory");
+const { PackageManagerDetector } = require("../internal/sdk");
+
+/**
+ * Verifies that a nested npm project stops the walk before an ancestor pnpm
+ * workspace is reached.
+ *
+ * A standalone npm project checked out inside a larger pnpm monorepo (a
+ * vendored app, a test fixture, ...) owns its own package-lock.json. Installs
+ * must stay inside that boundary; walking past it to the outer pnpm markers
+ * would run pnpm against a project npm manages and mutate the outer workspace's
+ * lockfile.
+ *
+ * 1. Create `<root>` with a pnpm-workspace.yaml and pnpm-lock.yaml, plus a nested
+ *    `<root>/vendor/app` holding package.json + package-lock.json.
+ * 2. Detect from `<root>/vendor/app`.
+ * 3. Assert the result is "npm".
+ */
+exports.test_detect_nested_package_lock_wins_over_ancestor_pnpm = () =>
+  withTemporaryDirectory(async (directory) => {
+    const nested = path.join(directory, "vendor", "app");
+    await fs.promises.mkdir(nested, { recursive: true });
+    await fs.promises.writeFile(
+      path.join(directory, "pnpm-workspace.yaml"),
+      "packages:\n  - 'vendor/*'\n",
+      "utf8",
+    );
+    await fs.promises.writeFile(
+      path.join(directory, "pnpm-lock.yaml"),
+      "lockfileVersion: '9.0'\n",
+      "utf8",
+    );
+    await fs.promises.writeFile(
+      path.join(nested, "package.json"),
+      JSON.stringify({ name: "app" }),
+      "utf8",
+    );
+    await fs.promises.writeFile(
+      path.join(nested, "package-lock.json"),
+      JSON.stringify({ lockfileVersion: 3 }),
+      "utf8",
+    );
+    assert.equal(PackageManagerDetector.detect({ directory: nested }), "npm");
+  });

--- a/tests/test-distribute/features/test_detect_npm_by_package_lock.js
+++ b/tests/test-distribute/features/test_detect_npm_by_package_lock.js
@@ -1,0 +1,27 @@
+const assert = require("assert/strict");
+const fs = require("fs");
+const path = require("path");
+
+const { withTemporaryDirectory } = require("../internal/directory");
+const { PackageManagerDetector } = require("../internal/sdk");
+
+/**
+ * Verifies npm detection through a `package-lock.json` marker.
+ *
+ * Package-lock.json must act as a positive stop marker, not merely fall through
+ * to the default: the walk-up has to end at the nearest project boundary
+ * instead of continuing into ancestors that may belong to another manager.
+ *
+ * 1. Create a temporary directory containing only a package-lock.json file.
+ * 2. Detect from that directory.
+ * 3. Assert the result is "npm".
+ */
+exports.test_detect_npm_by_package_lock = () =>
+  withTemporaryDirectory(async (directory) => {
+    await fs.promises.writeFile(
+      path.join(directory, "package-lock.json"),
+      JSON.stringify({ lockfileVersion: 3 }),
+      "utf8",
+    );
+    assert.equal(PackageManagerDetector.detect({ directory }), "npm");
+  });

--- a/tests/test-distribute/features/test_detect_npm_fallback_without_markers.js
+++ b/tests/test-distribute/features/test_detect_npm_fallback_without_markers.js
@@ -1,0 +1,30 @@
+const assert = require("assert/strict");
+const path = require("path");
+
+const { PackageManagerDetector } = require("../internal/sdk");
+
+/**
+ * Verifies the npm fallback when no marker exists anywhere up to the
+ * file-system root.
+ *
+ * The walk-up must terminate at the root instead of looping forever, and a
+ * project without any manager marker keeps the historical npm behavior. An
+ * injected file-system view guarantees a marker-free world regardless of what
+ * actually exists on the machine running the suite.
+ *
+ * 1. Build a fake file system where no file exists.
+ * 2. Detect from a deeply nested directory through that view.
+ * 3. Assert the result is "npm".
+ */
+exports.test_detect_npm_fallback_without_markers = () => {
+  const manager = PackageManagerDetector.detect({
+    directory: path.join("some", "deeply", "nested", "project"),
+    fs: {
+      exists: () => false,
+      read: () => {
+        throw new Error("Nothing should be read from an empty file system.");
+      },
+    },
+  });
+  assert.equal(manager, "npm");
+};

--- a/tests/test-distribute/features/test_detect_package_manager_field_wins_over_lockfiles.js
+++ b/tests/test-distribute/features/test_detect_package_manager_field_wins_over_lockfiles.js
@@ -1,0 +1,35 @@
+const assert = require("assert/strict");
+const fs = require("fs");
+const path = require("path");
+
+const { withTemporaryDirectory } = require("../internal/directory");
+const { PackageManagerDetector } = require("../internal/sdk");
+
+/**
+ * Verifies that an explicit `packageManager` declaration wins over lockfiles
+ * found in the same directory.
+ *
+ * Projects migrating between managers often keep a stale lockfile around for a
+ * while. The `packageManager` field is the deliberate declaration, so it must
+ * take precedence within a directory level; otherwise a stray pnpm-lock.yaml
+ * would hijack a project that pinned yarn.
+ *
+ * 1. Create a temporary directory holding both a pnpm-lock.yaml and a package.json
+ *    declaring `"packageManager": "yarn@4.5.0"`.
+ * 2. Detect from that directory.
+ * 3. Assert the result is "yarn".
+ */
+exports.test_detect_package_manager_field_wins_over_lockfiles = () =>
+  withTemporaryDirectory(async (directory) => {
+    await fs.promises.writeFile(
+      path.join(directory, "pnpm-lock.yaml"),
+      "lockfileVersion: '9.0'\n",
+      "utf8",
+    );
+    await fs.promises.writeFile(
+      path.join(directory, "package.json"),
+      JSON.stringify({ name: "project", packageManager: "yarn@4.5.0" }),
+      "utf8",
+    );
+    assert.equal(PackageManagerDetector.detect({ directory }), "yarn");
+  });

--- a/tests/test-distribute/features/test_detect_pnpm_by_package_manager_field.js
+++ b/tests/test-distribute/features/test_detect_pnpm_by_package_manager_field.js
@@ -1,0 +1,29 @@
+const assert = require("assert/strict");
+const fs = require("fs");
+const path = require("path");
+
+const { withTemporaryDirectory } = require("../internal/directory");
+const { PackageManagerDetector } = require("../internal/sdk");
+
+/**
+ * Verifies pnpm detection through the `packageManager` field of `package.json`.
+ *
+ * `nestia sdk --distribute` and `nestia dependencies` used to hard-code npm,
+ * which corrupted pnpm monorepos with stray package-lock.json files. The
+ * `packageManager` field is the most explicit ownership declaration a project
+ * can make, so it must be honored even without any lockfile around.
+ *
+ * 1. Create a temporary directory whose package.json declares `"packageManager":
+ *    "pnpm@10.6.4"` and no lockfile.
+ * 2. Detect from that directory.
+ * 3. Assert the result is "pnpm".
+ */
+exports.test_detect_pnpm_by_package_manager_field = () =>
+  withTemporaryDirectory(async (directory) => {
+    await fs.promises.writeFile(
+      path.join(directory, "package.json"),
+      JSON.stringify({ name: "project", packageManager: "pnpm@10.6.4" }),
+      "utf8",
+    );
+    assert.equal(PackageManagerDetector.detect({ directory }), "pnpm");
+  });

--- a/tests/test-distribute/features/test_detect_pnpm_by_pnpm_lock.js
+++ b/tests/test-distribute/features/test_detect_pnpm_by_pnpm_lock.js
@@ -1,0 +1,27 @@
+const assert = require("assert/strict");
+const fs = require("fs");
+const path = require("path");
+
+const { withTemporaryDirectory } = require("../internal/directory");
+const { PackageManagerDetector } = require("../internal/sdk");
+
+/**
+ * Verifies pnpm detection through a `pnpm-lock.yaml` marker.
+ *
+ * Most pnpm projects carry only the lockfile, not a `packageManager` field. If
+ * the lockfile branch regressed, those projects would silently fall back to npm
+ * and get a rogue package-lock.json next to their pnpm-lock.yaml.
+ *
+ * 1. Create a temporary directory containing only a pnpm-lock.yaml file.
+ * 2. Detect from that directory.
+ * 3. Assert the result is "pnpm".
+ */
+exports.test_detect_pnpm_by_pnpm_lock = () =>
+  withTemporaryDirectory(async (directory) => {
+    await fs.promises.writeFile(
+      path.join(directory, "pnpm-lock.yaml"),
+      "lockfileVersion: '9.0'\n",
+      "utf8",
+    );
+    assert.equal(PackageManagerDetector.detect({ directory }), "pnpm");
+  });

--- a/tests/test-distribute/features/test_detect_pnpm_by_pnpm_workspace.js
+++ b/tests/test-distribute/features/test_detect_pnpm_by_pnpm_workspace.js
@@ -1,0 +1,27 @@
+const assert = require("assert/strict");
+const fs = require("fs");
+const path = require("path");
+
+const { withTemporaryDirectory } = require("../internal/directory");
+const { PackageManagerDetector } = require("../internal/sdk");
+
+/**
+ * Verifies pnpm detection through a `pnpm-workspace.yaml` marker.
+ *
+ * A freshly scaffolded pnpm monorepo (like the nestia ecosystem templates) may
+ * declare its workspace before any install has produced a lockfile. The
+ * workspace manifest alone must therefore be enough to pick pnpm.
+ *
+ * 1. Create a temporary directory containing only a pnpm-workspace.yaml file.
+ * 2. Detect from that directory.
+ * 3. Assert the result is "pnpm".
+ */
+exports.test_detect_pnpm_by_pnpm_workspace = () =>
+  withTemporaryDirectory(async (directory) => {
+    await fs.promises.writeFile(
+      path.join(directory, "pnpm-workspace.yaml"),
+      "packages:\n  - 'packages/*'\n",
+      "utf8",
+    );
+    assert.equal(PackageManagerDetector.detect({ directory }), "pnpm");
+  });

--- a/tests/test-distribute/features/test_detect_walk_up_from_nested_directory.js
+++ b/tests/test-distribute/features/test_detect_walk_up_from_nested_directory.js
@@ -1,0 +1,37 @@
+const assert = require("assert/strict");
+const fs = require("fs");
+const path = require("path");
+
+const { withTemporaryDirectory } = require("../internal/directory");
+const { PackageManagerDetector } = require("../internal/sdk");
+
+/**
+ * Verifies the walk-up from a nested directory to an ancestor marker.
+ *
+ * The distribute directory (e.g. `packages/api`) usually sits levels below the
+ * project root that owns the lockfile, and the composer detects from the
+ * distribute directory itself. Intermediate package.json files without a
+ * `packageManager` field must not stop the walk, or every monorepo sub-package
+ * would fall back to npm.
+ *
+ * 1. Create `<root>/packages/api` where only `<root>` holds a pnpm-workspace.yaml,
+ *    and `packages/api` holds a package.json without a `packageManager` field.
+ * 2. Detect from `<root>/packages/api`.
+ * 3. Assert the result is "pnpm".
+ */
+exports.test_detect_walk_up_from_nested_directory = () =>
+  withTemporaryDirectory(async (directory) => {
+    const nested = path.join(directory, "packages", "api");
+    await fs.promises.mkdir(nested, { recursive: true });
+    await fs.promises.writeFile(
+      path.join(directory, "pnpm-workspace.yaml"),
+      "packages:\n  - 'packages/*'\n",
+      "utf8",
+    );
+    await fs.promises.writeFile(
+      path.join(nested, "package.json"),
+      JSON.stringify({ name: "api" }),
+      "utf8",
+    );
+    assert.equal(PackageManagerDetector.detect({ directory: nested }), "pnpm");
+  });

--- a/tests/test-distribute/features/test_detect_yarn_by_yarn_lock.js
+++ b/tests/test-distribute/features/test_detect_yarn_by_yarn_lock.js
@@ -1,0 +1,28 @@
+const assert = require("assert/strict");
+const fs = require("fs");
+const path = require("path");
+
+const { withTemporaryDirectory } = require("../internal/directory");
+const { PackageManagerDetector } = require("../internal/sdk");
+
+/**
+ * Verifies yarn detection through a `yarn.lock` marker.
+ *
+ * Yarn projects would previously get npm installs forced into them by the
+ * distribute composer, producing a package-lock.json that fights the yarn.lock.
+ * The yarn branch must stay distinct from both the pnpm markers and the npm
+ * fallback.
+ *
+ * 1. Create a temporary directory containing only a yarn.lock file.
+ * 2. Detect from that directory.
+ * 3. Assert the result is "yarn".
+ */
+exports.test_detect_yarn_by_yarn_lock = () =>
+  withTemporaryDirectory(async (directory) => {
+    await fs.promises.writeFile(
+      path.join(directory, "yarn.lock"),
+      "# yarn lockfile v1\n",
+      "utf8",
+    );
+    assert.equal(PackageManagerDetector.detect({ directory }), "yarn");
+  });

--- a/tests/test-distribute/features/test_distribute_bundle_copy_preserves_existing_files.js
+++ b/tests/test-distribute/features/test_distribute_bundle_copy_preserves_existing_files.js
@@ -1,0 +1,52 @@
+const assert = require("assert/strict");
+const fs = require("fs");
+const path = require("path");
+
+const { withTemporaryDirectory } = require("../internal/directory");
+const { BUNDLE, SdkDistributionComposer } = require("../internal/sdk");
+
+/**
+ * Verifies the write-if-missing contract of the distribute bundle copy.
+ *
+ * The composer used to `copyFile` every bundled file unconditionally on first
+ * setup, so a user-authored README.md or tsconfig.json in the distribute
+ * directory was silently clobbered. Each file must now be copied only when
+ * missing, and the returned list must name exactly the files created — the
+ * composer relies on it to patch path placeholders only in files it created
+ * itself.
+ *
+ * 1. Pre-place a README.md with sentinel content in a temporary directory.
+ * 2. Copy the real distribute bundle assets into it.
+ * 3. Assert the README.md content is untouched, the remaining bundle files were
+ *    created, and the returned list excludes README.md.
+ */
+exports.test_distribute_bundle_copy_preserves_existing_files = () =>
+  withTemporaryDirectory(async (directory) => {
+    const sentinel = "# user authored readme\n";
+    await fs.promises.writeFile(
+      path.join(directory, "README.md"),
+      sentinel,
+      "utf8",
+    );
+
+    const copied = await SdkDistributionComposer.copyBundle({
+      from: BUNDLE,
+      into: directory,
+    });
+
+    const bundled = (await fs.promises.readdir(BUNDLE)).sort();
+    assert.deepEqual(
+      copied.sort(),
+      bundled.filter((file) => file !== "README.md"),
+    );
+    assert.equal(
+      await fs.promises.readFile(path.join(directory, "README.md"), "utf8"),
+      sentinel,
+    );
+    for (const file of bundled)
+      assert.equal(
+        fs.existsSync(path.join(directory, file)),
+        true,
+        `${file} must exist after the copy.`,
+      );
+  });

--- a/tests/test-distribute/features/test_distribute_commands_npm.js
+++ b/tests/test-distribute/features/test_distribute_commands_npm.js
@@ -1,0 +1,37 @@
+const assert = require("assert/strict");
+
+const { SdkDistributionComposer } = require("../internal/sdk");
+
+/**
+ * Verifies the npm command set composed for the distribute installation.
+ *
+ * Npm projects keep the historical `npm install --save(-dev)` syntax; this pins
+ * the base command set (rimraf as devDependency, pinned `@nestia/fetcher` and
+ * `typia` as dependencies) with the optional MCP and WebSocket packages omitted
+ * when their protocols are unused. It also locks the removal of `npx typia
+ * setup`, which typia v13 no longer ships and whose invocation would abort the
+ * composer.
+ *
+ * 1. Compose commands for npm with mcp/websocket disabled.
+ * 2. Assert the exact command strings.
+ */
+exports.test_distribute_commands_npm = () => {
+  assert.deepEqual(
+    SdkDistributionComposer.commands({
+      manager: "npm",
+      dependencies: {
+        version: "12.0.0-rc.3",
+        typia: "^13.0.0",
+        tgrid: undefined,
+        mcp: "^1.0.0",
+      },
+      mcp: false,
+      websocket: false,
+    }),
+    [
+      "npm install --save-dev rimraf",
+      "npm install --save @nestia/fetcher@12.0.0-rc.3",
+      "npm install --save typia@^13.0.0",
+    ],
+  );
+};

--- a/tests/test-distribute/features/test_distribute_commands_pnpm.js
+++ b/tests/test-distribute/features/test_distribute_commands_pnpm.js
@@ -1,0 +1,39 @@
+const assert = require("assert/strict");
+
+const { SdkDistributionComposer } = require("../internal/sdk");
+
+/**
+ * Verifies the pnpm command set composed for the distribute installation,
+ * including the optional MCP and WebSocket packages.
+ *
+ * The composer used to force `npm install` into every project, corrupting pnpm
+ * monorepos with a rogue package-lock.json. pnpm must get its own `pnpm add` /
+ * `pnpm add -D` syntax, and the protocol-conditional packages must appear when
+ * their protocol is used and a version is known.
+ *
+ * 1. Compose commands for pnpm with mcp/websocket enabled and versions for both
+ *    optional packages.
+ * 2. Assert the exact command strings, including the two optional installs.
+ */
+exports.test_distribute_commands_pnpm = () => {
+  assert.deepEqual(
+    SdkDistributionComposer.commands({
+      manager: "pnpm",
+      dependencies: {
+        version: "12.0.0-rc.3",
+        typia: "^13.0.0",
+        tgrid: "^1.2.1",
+        mcp: "^1.0.0",
+      },
+      mcp: true,
+      websocket: true,
+    }),
+    [
+      "pnpm add -D rimraf",
+      "pnpm add @nestia/fetcher@12.0.0-rc.3",
+      "pnpm add typia@^13.0.0",
+      "pnpm add @modelcontextprotocol/sdk@^1.0.0",
+      "pnpm add tgrid@^1.2.1",
+    ],
+  );
+};

--- a/tests/test-distribute/features/test_distribute_commands_yarn.js
+++ b/tests/test-distribute/features/test_distribute_commands_yarn.js
@@ -1,0 +1,37 @@
+const assert = require("assert/strict");
+
+const { SdkDistributionComposer } = require("../internal/sdk");
+
+/**
+ * Verifies the yarn command set composed for the distribute installation, and
+ * that protocol packages without a known version are omitted.
+ *
+ * Yarn needs `yarn add` / `yarn add -D` instead of `npm install`. This case
+ * also locks the guard for protocols that are used but whose package version
+ * could not be resolved from @nestia/sdk's manifest: emitting an unpinned or
+ * `undefined`-versioned install would be worse than skipping.
+ *
+ * 1. Compose commands for yarn with mcp/websocket enabled but both optional
+ *    package versions undefined.
+ * 2. Assert the exact command strings, without any optional install.
+ */
+exports.test_distribute_commands_yarn = () => {
+  assert.deepEqual(
+    SdkDistributionComposer.commands({
+      manager: "yarn",
+      dependencies: {
+        version: "12.0.0-rc.3",
+        typia: "^13.0.0",
+        tgrid: undefined,
+        mcp: undefined,
+      },
+      mcp: true,
+      websocket: true,
+    }),
+    [
+      "yarn add -D rimraf",
+      "yarn add @nestia/fetcher@12.0.0-rc.3",
+      "yarn add typia@^13.0.0",
+    ],
+  );
+};

--- a/tests/test-distribute/internal/directory.js
+++ b/tests/test-distribute/internal/directory.js
@@ -1,0 +1,18 @@
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+/**
+ * Runs a closure inside a fresh temporary directory and removes the directory
+ * afterwards, even when the closure throws.
+ */
+exports.withTemporaryDirectory = async (closure) => {
+  const directory = await fs.promises.mkdtemp(
+    path.join(os.tmpdir(), "nestia-test-distribute-"),
+  );
+  try {
+    return await closure(directory);
+  } finally {
+    await fs.promises.rm(directory, { force: true, recursive: true });
+  }
+};

--- a/tests/test-distribute/internal/sdk.js
+++ b/tests/test-distribute/internal/sdk.js
@@ -1,0 +1,26 @@
+const path = require("path");
+
+// @nestia/sdk's exports map blocks deep subpath imports, so this suite
+// requires the built files by absolute path instead.
+const LIB = path.join(__dirname, "..", "..", "..", "packages", "sdk", "lib");
+
+exports.PackageManagerDetector = require(
+  path.join(LIB, "utils", "PackageManagerDetector.js"),
+).PackageManagerDetector;
+exports.SdkDistributionComposer = require(
+  path.join(LIB, "generates", "internal", "SdkDistributionComposer.js"),
+).SdkDistributionComposer;
+exports.DependenciesInstaller = require(
+  path.join(LIB, "executable", "internal", "DependenciesInstaller.js"),
+).DependenciesInstaller;
+exports.BUNDLE = path.join(
+  __dirname,
+  "..",
+  "..",
+  "..",
+  "packages",
+  "sdk",
+  "assets",
+  "bundle",
+  "distribute",
+);

--- a/tests/test-distribute/package.json
+++ b/tests/test-distribute/package.json
@@ -1,0 +1,12 @@
+{
+  "private": true,
+  "name": "@nestia/test-distribute",
+  "version": "12.0.0-rc.3",
+  "scripts": {
+    "start": "node start.js"
+  },
+  "devDependencies": {
+    "@nestia/sdk": "workspace:^"
+  },
+  "packageManager": "pnpm@10.6.4"
+}

--- a/tests/test-distribute/start.js
+++ b/tests/test-distribute/start.js
@@ -1,0 +1,74 @@
+const cp = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const ROOT = path.join(__dirname, "..", "..");
+const FEATURES = path.join(__dirname, "features");
+const PNPM = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+
+const build = () =>
+  new Promise((resolve, reject) => {
+    const child = cp.spawn(PNPM, ["--filter", "@nestia/sdk", "run", "build"], {
+      cwd: ROOT,
+      env: {
+        ...process.env,
+        NODE_OPTIONS: "",
+        TTSC_GO_BINARY: process.env.TTSC_GO_BINARY || "go",
+        TTSC_CACHE_DIR:
+          process.env.TTSC_CACHE_DIR ||
+          path.join(ROOT, "node_modules", ".cache", "ttsc"),
+      },
+      stdio: "inherit",
+      shell: process.platform === "win32",
+    });
+    child.on("error", reject);
+    child.on("exit", (code, signal) =>
+      code === 0
+        ? resolve()
+        : reject(
+            new Error(
+              `@nestia/sdk build failed with ${signal ?? `exit code ${code}`}.`,
+            ),
+          ),
+    );
+  });
+
+const main = async () => {
+  if (process.env.TEST_DISTRIBUTE_SKIP_BUILD !== "1") await build();
+
+  const files = (await fs.promises.readdir(FEATURES))
+    .filter((file) => file.endsWith(".js"))
+    .sort();
+  const failures = [];
+  for (const file of files) {
+    const name = path.basename(file, ".js");
+    const exported = require(path.join(FEATURES, file));
+    const functions = Object.keys(exported).filter((key) =>
+      key.startsWith("test_"),
+    );
+    if (functions.length !== 1 || functions[0] !== name)
+      throw new Error(
+        `Each feature file must export exactly one test function matching ` +
+          `its file name; ${file} exports [${functions.join(", ")}].`,
+      );
+    const started = Date.now();
+    try {
+      await exported[name]();
+      console.log(`  - ${name}: ${(Date.now() - started).toLocaleString()} ms`);
+    } catch (error) {
+      failures.push(name);
+      console.error(`  - ${name}: failed`);
+      console.error(error);
+    }
+  }
+  console.log(
+    `Total: ${files.length - failures.length} of ${files.length} passed.`,
+  );
+  if (failures.length !== 0)
+    throw new Error(`Failed test-distribute features: ${failures.join(", ")}`);
+};
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(-1);
+});


### PR DESCRIPTION
## Summary

`@nestia/sdk` has two surfaces that execute package-manager commands inside the **user's** project, and both hard-coded npm while the ecosystem templates are now pnpm monorepos with `catalog:` deps:

1. **`SdkDistributionComposer`** (runs when `distribute` is configured) executed `npm install ...` in the distribute directory — planting a rogue `package-lock.json` inside pnpm/yarn projects — and unconditionally `copyFile`'d the bundle assets over whatever the user had there.
2. **`nestia dependencies`** defaulted to npm and installed `@nestia/e2e`, `@nestia/fetcher`, and `typia` **unpinned**, so registry latest could pull an incompatible major next to an older SDK.
3. **`TtscExecutor`** error guidance suggested `npm install --save-dev ttsc` regardless of the project's manager.

### Changes

- **New `PackageManagerDetector`** (`packages/sdk/src/utils/PackageManagerDetector.ts`): walks up from the target directory to the fs root. Per level: `package.json` `packageManager` field first (explicit declaration beats lockfiles, so a project pinning `yarn@4` isn't hijacked by a stray `pnpm-lock.yaml`), then `pnpm-lock.yaml`/`pnpm-workspace.yaml` → pnpm, `yarn.lock` → yarn, `package-lock.json` → npm (a positive stop marker, so a nested npm project inside an outer pnpm monorepo keeps its own boundary). npm fallback at the root. Takes an injectable fs view for tests.
- **Distribute compose** detects from the distribute directory, composes manager-appropriate commands via a pure exported builder (`SdkDistributionComposer.commands`: `npm install --save(-dev)` / `pnpm add (-D)` / `yarn add (-D)`), and copies bundle files **write-if-missing** (`copyBundle` returns what it created; `${root}`/`${output}` placeholders are only patched in files that run created). User-authored `README.md`/`tsconfig.json`/`package.json` are never clobbered — same contract as the SDK output bundling after #1530.
- **`nestia dependencies`** keeps the explicit `--manager` override (now validated against `npm|pnpm|yarn`), defaults via detection from cwd, and pins: `@nestia/e2e@^<sdk version>` `@nestia/fetcher@^<sdk version>` `typia@<range @nestia/sdk declares>`, read at runtime from the SDK's own manifest (shared `SdkManifest` reader, also used by the composer). `catalog:`/`workspace:` ranges fall back to unpinned typia — those only exist inside this monorepo, never in the published package.
- **Removed `npx typia setup --manager npm`** instead of parameterizing it: **typia v13 deleted the `setup` subcommand** (verified in the installed CLI — only `generate` remains; anything else prints usage and exits −1), so any invocation would abort compose with an exception. The @next line wires the transform through the ttsc plugin pipeline, not ts-patch, so nothing replaces it.
- **`TtscExecutor`** messages are now manager-neutral: `Reinstall "ttsc" as a devDependency (e.g. pnpm add -D ttsc).`

### Tests

New `tests/test-distribute` workspace (plain-node, function-per-file `test_<snake_case>` suite; requires the **built** sdk lib by absolute path since the exports map blocks deep imports), registered in the CI matrix as `distribute`. 17 cases cover: every detection branch (packageManager field, pnpm-lock, pnpm-workspace, yarn.lock, package-lock stop marker, npm fallback via injected fs, walk-up past marker-less package.json, field-beats-lockfile, nested-npm-beats-ancestor-pnpm), the three managers' exact command strings for both distribute (incl. conditional MCP/tgrid lines and their omission when versions are unknown) and dependencies (pinned specs), the typia catalog fallback, and the write-if-missing copy against the real bundle assets (pre-placed README preserved, missing files created, returned list exact).

## Verification

- `pnpm --filter ./tests/test-distribute start` — 17/17 passed (Windows 11, local).
- `pnpm --filter ./tests/test-sdk start --only distribute` — 4/4 green. **Note:** these features are trivially green — `tests/test-sdk/start.js` short-circuits every feature whose name contains "distribute" before any generation (`if (name.includes("distribute")) return;`, present since the file's creation on this line), so compose has never executed in CI here.
- Compose exercised end-to-end in a scratch project with `child_process.execSync` stubbed: npm detected from `package-lock.json` two levels up, pre-placed README preserved, placeholders patched only in copied files, command order `rimraf → fetcher → typia → (tgrid)` with no `typia setup`.
- `nestia dependencies --manager bogus` halts with `Unsupported package manager "bogus". Choose one of (npm|pnpm|yarn).`
- Changed files formatted with the repo prettier config.

## The CI distribute-feature package-manager question

Asked to reason about whether pnpm detection would corrupt the repo workspace when the test-sdk distribute features run compose in CI. Findings:

1. **Compose does not run in CI at all**: `distribute:` configs exist only in the 4 `tests/test-sdk/features/distribute*` fixtures, and `start.js` returns before generation for all of them. So this PR cannot mutate the root lockfile during tests.
2. The hazard is real if that ever changes: an empirical check (pnpm 10) showed `pnpm add` in a nested directory whose `package.json` is **not** a workspace member still resolves the enclosing `pnpm-workspace.yaml` and **registers the directory as a new importer in the ROOT `pnpm-lock.yaml`**, also creating root `node_modules` churn. The feature dirs carry no manager marker of their own, so detection from `features/distribute/packages/api` would walk to the repo root and pick pnpm.
3. Chosen design: keep detection pure (nearest explicit marker wins; nested `package-lock.json` stops the walk) — correct for user projects — and leave the fixtures untouched since they never execute compose (also per the scope constraints on this PR). If the distribute features are ever re-enabled to run compose for real, the fixture dirs must first get their own boundary marker (a local `pnpm-workspace.yaml`, or `package.json` + `package-lock.json` to pin npm as before); the old npm behavior only left gitignored `package-lock.json`/`node_modules` strays, which is why this was never noticed.

## Known gaps

- Real installs against a live registry were not executed (command composition is stub-verified and unit-tested instead).
- Inside this monorepo the composer would still emit `typia@catalog:samchon` (pre-existing: the manifest is read at runtime and `catalog:` is only rewritten at publish); harmless because compose never runs here, and published installs get the real range.
- `--manager` values outside `npm|pnpm|yarn` (e.g. `bun`) now halt with guidance instead of blindly running `<value> install`; bun users previously "worked" by accident and now need one of the supported managers.
- Yarn berry is only covered at command-syntax level (`yarn add -D` is valid for both classic and berry); a lockfile-less PnP project without a `packageManager` field falls back to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYUZ95W7jUpsnTgxBmamAH
