### PR TITLE
feat(migrate): emit pnpm monorepo template and stamp versions via workspace catalogs

### DIFF
--- a/packages/migrate/src/NestiaMigrateApplication.ts
+++ b/packages/migrate/src/NestiaMigrateApplication.ts
@@ -94,10 +94,10 @@ export class NestiaMigrateApplication {
       ...Object.fromEntries(
         Object.entries(NEST_TEMPLATE).filter(
           ([key]) =>
-            key.startsWith("src/api/structures") === false &&
-            key.startsWith("src/api/functional") === false &&
-            key.startsWith("src/api/controllers") === false &&
-            key.startsWith("test/features") === false,
+            key.startsWith("packages/api/src/structures") === false &&
+            key.startsWith("packages/api/src/functional") === false &&
+            key.startsWith("packages/backend/src/controllers") === false &&
+            key.startsWith("packages/backend/test/features") === false,
         ),
       ),
       ...NestiaMigrateNestProgrammer.write(context),
@@ -105,10 +105,9 @@ export class NestiaMigrateApplication {
       ...(config.e2e ? NestiaMigrateE2eProgrammer.write(context) : {}),
       ...(config.keyword === false
         ? {
-            "nestia.config.ts": NEST_TEMPLATE["nestia.config.ts"]!.replace(
-              "keyword: true",
-              "keyword: false",
-            ),
+            "packages/backend/nestia.config.ts": NEST_TEMPLATE[
+              "packages/backend/nestia.config.ts"
+            ]!.replace("keyword: true", "keyword: false"),
           }
         : {}),
     };

--- a/packages/migrate/src/archivers/NestiaMigrateFileArchiver.ts
+++ b/packages/migrate/src/archivers/NestiaMigrateFileArchiver.ts
@@ -20,6 +20,10 @@ export namespace NestiaMigrateFileArchiver {
         .map((_str, i, entire) => entire.slice(0, i + 1).join("/"));
       for (const s of sequence) await mkdir.get(s);
     };
+    // The file set may lead with a nested path (the monorepo template's
+    // first key is `.github/workflows/build.yml`), so the archive root must
+    // exist before the per-directory mkdir walk below it.
+    await mkdir.get("");
     for (const [key, value] of Object.entries(props.files)) {
       await iterate(key.split("/").slice(0, -1).join("/"));
       await props.writeFile(`${props.root}/${key}`, value);

--- a/packages/migrate/src/executable/bundle.js
+++ b/packages/migrate/src/executable/bundle.js
@@ -4,9 +4,11 @@ const fs = require("fs");
 
 const ROOT = `${__dirname}/../..`;
 const ASSETS = `${ROOT}/assets`;
-const TYPIA = require("js-yaml").load(
+const CATALOGS = require("js-yaml").load(
   fs.readFileSync(`${__dirname}/../../../../pnpm-lock.yaml`, "utf8"),
-).catalogs.samchon;
+).catalogs;
+const TYPIA = CATALOGS.samchon;
+const TYPESCRIPT = CATALOGS.typescript ?? {};
 
 const update = (content, options = {}) => {
   const parsed = JSON.parse(content);
@@ -14,10 +16,19 @@ const update = (content, options = {}) => {
     parsed.dependencies ?? {},
     parsed.devDependencies ?? {},
   ])
-    for (const key of Object.keys(record))
+    for (const key of Object.keys(record)) {
+      const current = record[key];
+      // `catalog:` / `workspace:` specifiers already carry their versions
+      // through pnpm-workspace.yaml, which gets its own stamping pass.
+      if (
+        typeof current === "string" &&
+        (current.startsWith("catalog:") || current.startsWith("workspace:"))
+      )
+        continue;
       if (key.startsWith("@nestia/") || key === "nestia")
         record[key] = `^${version}`;
       else if (TYPIA[key]) record[key] = TYPIA[key].specifier;
+    }
   migratePackageJson(parsed);
   if (options.sdkAggregate) {
     parsed.devDependencies ??= {};
@@ -34,10 +45,41 @@ const migratePackageJson = (parsed) => {
 
   const devDependencies = parsed.devDependencies;
   if (devDependencies) {
-    const usesTypeScript = typeof devDependencies.typescript === "string";
+    const usesTypeScript =
+      typeof devDependencies.typescript === "string" &&
+      devDependencies.typescript.startsWith("catalog:") === false;
     delete devDependencies["typescript-transform-paths"];
-    if (usesTypeScript) devDependencies.ttsc ??= "^0.10.2";
+    // Single-package templates compiling with a direct typescript dependency
+    // need the ttsc compiler this repository currently builds against.
+    if (usesTypeScript && TYPESCRIPT.ttsc)
+      devDependencies.ttsc ??= TYPESCRIPT.ttsc.specifier;
   }
+};
+
+// Stamp the template's pnpm-workspace.yaml catalogs with this repository's
+// current versions. The rewriting is line-targeted on purpose: the samchon
+// catalog relies on YAML anchors (`nestia: &nestia ...` aliased by the
+// `@nestia/*` entries), and a parse/dump round trip would inline and destroy
+// them.
+const updateWorkspaceCatalog = (content) => {
+  const replace = (line, name, specifier) => {
+    if (typeof specifier !== "string") return line;
+    const match = line.match(
+      new RegExp(`^(\\s+${name}: (?:&[A-Za-z0-9_-]+ )?)\\S[^\\r\\n]*(\\r?)$`),
+    );
+    return match === null ? line : `${match[1]}${specifier}${match[2]}`;
+  };
+  return content
+    .split("\n")
+    .map((line) => {
+      line = replace(line, "nestia", `^${version}`);
+      for (const name of ["tgrid", "tstl", "typia"])
+        line = replace(line, name, TYPIA[name]?.specifier);
+      for (const name of ["ttsc", "typescript"])
+        line = replace(line, name, TYPESCRIPT[name]?.specifier);
+      return line;
+    })
+    .join("\n");
 };
 
 const trimTemplateDependencies = (parsed) => {
@@ -168,29 +210,35 @@ export namespace ArgumentParser {
 
 const updateTsConfig = (content) => {
   content = content.replace(
-    /^\s*\{\s*"transform":\s*"typescript-transform-paths"\s*\},\n/gm,
+    /^\s*\{\s*"transform":\s*"typescript-transform-paths"\s*\},\r?\n/gm,
     "",
   );
   content = content.replace(
-    /^\s*\{\s*"transform":\s*"typia\/lib\/transform"(?:,\s*"enabled":\s*false)?\s*\},?\n/gm,
+    /^\s*\{\s*"transform":\s*"typia\/lib\/transform"(?:,\s*"enabled":\s*false)?\s*\},?\r?\n/gm,
     "",
   );
   content = content.replace(
-    /^\s*\{\s*"transform":\s*"@nestia\/core\/lib\/transform"\s*\},?\n/gm,
+    /^\s*\{\s*"transform":\s*"@nestia\/core\/lib\/transform"\s*\},?\r?\n/gm,
     "",
   );
   content = content.replace(
-    /^\s*\{\s*"transform":\s*"@nestia\/core\/native\/transform\.cjs"\s*\},?\n/gm,
+    /^\s*\{\s*"transform":\s*"@nestia\/core\/native\/transform\.cjs"\s*\},?\r?\n/gm,
     "",
   );
   content = content.replace(
-    /^\s*\{\s*"transform":\s*"@nestia\/sdk\/lib\/transform"\s*\},\n/gm,
+    /^\s*\{\s*"transform":\s*"@nestia\/sdk\/lib\/transform"\s*\},\r?\n/gm,
     "",
   );
   return content;
 };
 
-const bundle = async ({ mode, repository, revision, exceptions, transform }) => {
+const bundle = async ({
+  mode,
+  repository,
+  revision,
+  exceptions,
+  transform,
+}) => {
   const root = `${__dirname}/../..`;
   const assets = `${root}/assets`;
   const template = `${assets}/${mode}`;
@@ -204,9 +252,16 @@ const bundle = async ({ mode, repository, revision, exceptions, transform }) => 
         await fs.promises.mkdir(ASSETS);
       } catch {}
 
-    cp.execSync(`git clone https://github.com/samchon/${repository} ${mode}`, {
-      cwd: ASSETS,
-    });
+    // Disable line-ending conversion so the bundled template is byte-identical
+    // on every platform: with core.autocrlf=true (the common Windows default)
+    // the checkout would rewrite LF to CRLF and break the line-targeted
+    // transforms below.
+    cp.execSync(
+      `git clone --config core.autocrlf=false https://github.com/samchon/${repository} ${mode}`,
+      {
+        cwd: ASSETS,
+      },
+    );
     // The template repositories are live projects; an unpinned clone lets any
     // upstream push break this build (samchon/nestia-start#632 did exactly
     // that), so every bundle checks out a reviewed revision.
@@ -275,20 +330,25 @@ const main = async () => {
   await bundle({
     mode: "nest",
     repository: "nestia-start",
-    // nestia-start's master was restructured into a pnpm monorepo
-    // (samchon/nestia-start#632), while the migrate programmers still emit
-    // the single-package layout. Stay pinned to the last compatible commit
-    // until NEST_TEMPLATE and the programmers adopt the monorepo structure.
-    revision: "1057bccd13d75bbe49a73024a0273147999bf818",
+    // The pnpm monorepo restructuring of nestia-start (samchon/nestia-start#632,
+    // #634, #635) is now the layout the migrate programmers emit. This revision
+    // is the first monorepo commit whose config package is consumed through
+    // workspace dependencies, so the archive works with a plain `pnpm install`.
+    revision: "314d77f2e4ef41b18ba1ab7d14ba97f5f74897f3",
     exceptions: [
       ".git",
       ".github/dependabot.yml",
       ".github/workflows/dependabot-automerge.yml",
-      "src/api/functional",
-      "src/controllers",
-      "src/MyModule.ts",
-      "src/providers",
-      "test/features",
+      // The template's lockfile resolves the catalog versions that the
+      // stamping below rewrites; shipping it would only bloat NEST_TEMPLATE
+      // with 160 KB of immediately-stale data.
+      "pnpm-lock.yaml",
+      "packages/api/src/functional",
+      "packages/api/src/structures",
+      "packages/backend/src/MyModule.ts",
+      "packages/backend/src/controllers",
+      "packages/backend/src/providers",
+      "packages/backend/test/features",
     ],
     transform: (key, value) => {
       if (key.endsWith("package.json")) {
@@ -296,9 +356,10 @@ const main = async () => {
         trimTemplateDependencies(parsed);
         return JSON.stringify(parsed, null, 2);
       }
-      if (key === "test/helpers/ArgumentParser.ts") return ARGUMENT_PARSER;
-      if (key.endsWith("tsconfig.json"))
-        return updateTsConfig(value);
+      if (key === "pnpm-workspace.yaml") return updateWorkspaceCatalog(value);
+      if (key === "packages/backend/test/helpers/ArgumentParser.ts")
+        return ARGUMENT_PARSER;
+      if (key.endsWith("tsconfig.json")) return updateTsConfig(value);
       return value;
     },
   });
@@ -324,8 +385,7 @@ const main = async () => {
         return JSON.stringify(parsed, null, 2);
       }
       if (key === "test/utils/ArgumentParser.ts") return ARGUMENT_PARSER;
-      if (key.endsWith("tsconfig.json"))
-        return updateTsConfig(value);
+      if (key.endsWith("tsconfig.json")) return updateTsConfig(value);
       return value;
     },
   });

--- a/packages/migrate/src/programmers/NestiaMigrateApiProgrammer.ts
+++ b/packages/migrate/src/programmers/NestiaMigrateApiProgrammer.ts
@@ -48,7 +48,7 @@ export namespace NestiaMigrateApiProgrammer {
     // DO GENERATE
     const files: Record<string, string> = Object.fromEntries(
       dict.toJSON().map(({ second: value }) => [
-        `src/${ctx.mode === "nest" ? "api/" : ""}functional/${[...value.namespace, "index.ts"].join("/")}`,
+        `${ctx.mode === "nest" ? "packages/api/src" : "src"}/functional/${[...value.namespace, "index.ts"].join("/")}`,
         FilePrinter.write({
           statements: NestiaMigrateApiFileProgrammer.write({
             ...value,

--- a/packages/migrate/src/programmers/NestiaMigrateE2eProgrammer.ts
+++ b/packages/migrate/src/programmers/NestiaMigrateE2eProgrammer.ts
@@ -1,6 +1,6 @@
 import { IHttpMigrateRoute, OpenApi } from "@typia/interface";
-import ts from "../internal/ts";
 
+import ts from "../internal/ts";
 import { INestiaMigrateConfig } from "../structures/INestiaMigrateConfig";
 import { INestiaMigrateContext } from "../structures/INestiaMigrateContext";
 import { INestiaMigrateFile } from "../structures/INestiaMigrateFile";
@@ -13,12 +13,18 @@ export namespace NestiaMigrateE2eProgrammer {
     Object.fromEntries(
       ctx.application.routes
         .map((r) =>
-          writeFile(ctx.config, ctx.application.document().components, r),
+          writeFile(
+            ctx.mode,
+            ctx.config,
+            ctx.application.document().components,
+            r,
+          ),
         )
         .map((r) => [`${r.location}/${r.file}`, r.content]),
     );
 
   const writeFile = (
+    mode: INestiaMigrateContext["mode"],
     config: INestiaMigrateConfig,
     components: OpenApi.IComponents,
     route: IHttpMigrateRoute,
@@ -33,14 +39,22 @@ export namespace NestiaMigrateE2eProgrammer {
         route,
       });
     const statements: ts.Statement[] = [
-      ...importer.toStatements(
-        (name) => `@ORGANIZATION/PROJECT-api/lib/structures/${name}`,
+      // The monorepo template consumes the api workspace package through its
+      // package name, while the single-package sdk template keeps resolving
+      // the built `lib` paths through tsconfig path mappings.
+      ...importer.toStatements((name) =>
+        mode === "nest"
+          ? "@ORGANIZATION/PROJECT-api"
+          : `@ORGANIZATION/PROJECT-api/lib/structures/${name}`,
       ),
       FilePrinter.newLine(),
       func,
     ];
     return {
-      location: `test/features/api`,
+      location:
+        mode === "nest"
+          ? `packages/backend/test/features/api`
+          : `test/features/api`,
       file: `${["test", "api", ...route.accessor].join("_")}.ts`,
       content: FilePrinter.write({ statements }),
     };

--- a/packages/migrate/src/programmers/NestiaMigrateImportProgrammer.ts
+++ b/packages/migrate/src/programmers/NestiaMigrateImportProgrammer.ts
@@ -55,6 +55,13 @@ export class NestiaMigrateImportProgrammer {
     dtoPath: (name: string) => string,
     current?: string,
   ): ts.Statement[] {
+    // Group the DTO references by their resolved module specifier: relative
+    // specifiers stay one-import-per-file, while package specifiers (e.g. the
+    // monorepo's `@ORGANIZATION/PROJECT-api`) merge into a single clause.
+    const modules: Map<string, string[]> = new Map();
+    for (const name of this.dtos_)
+      if (current === undefined || name !== current.split(".")[0])
+        MapUtil.take(modules)(dtoPath(name))(() => []).push(name);
     return [
       ...[...this.external_.entries()].map(([library, props]) =>
         factory.createImportDeclaration(
@@ -82,30 +89,28 @@ export class NestiaMigrateImportProgrammer {
       ...(this.external_.size && this.dtos_.size
         ? [FilePrinter.newLine()]
         : []),
-      ...[...this.dtos_]
-        .filter(
-          current ? (name) => name !== current!.split(".")[0] : () => true,
-        )
-        .map((i) =>
-          factory.createImportDeclaration(
+      ...[...modules.entries()].map(([specifier, names]) =>
+        factory.createImportDeclaration(
+          undefined,
+          // DTO files declare pure types, and generated code references them
+          // only in type positions — keep the clause type-only so emitted
+          // JS never loads the DTO module at runtime.
+          factory.createImportClause(
+            true,
             undefined,
-            // DTO files declare pure types, and generated code references them
-            // only in type positions — keep the clause type-only so emitted
-            // JS never loads the DTO module at runtime.
-            factory.createImportClause(
-              true,
-              undefined,
-              factory.createNamedImports([
+            factory.createNamedImports(
+              names.map((name) =>
                 factory.createImportSpecifier(
                   false,
                   undefined,
-                  factory.createIdentifier(i),
+                  factory.createIdentifier(name),
                 ),
-              ]),
+              ),
             ),
-            factory.createStringLiteral(dtoPath(i)),
           ),
+          factory.createStringLiteral(specifier),
         ),
+      ),
     ];
   }
 }

--- a/packages/migrate/src/programmers/NestiaMigrateNestControllerProgrammer.ts
+++ b/packages/migrate/src/programmers/NestiaMigrateNestControllerProgrammer.ts
@@ -5,7 +5,6 @@ import ts from "../internal/ts";
 import { INestiaMigrateConfig } from "../structures/INestiaMigrateConfig";
 import { INestiaMigrateController } from "../structures/INestiaMigrateController";
 import { FilePrinter } from "../utils/FilePrinter";
-import { StringUtil } from "../utils/StringUtil";
 import { NestiaMigrateImportProgrammer } from "./NestiaMigrateImportProgrammer";
 import { NestiaMigrateNestMethodProgrammer } from "./NestiaMigrateNestMethodProgrammer";
 
@@ -56,13 +55,10 @@ export namespace NestiaMigrateNestControllerProgrammer {
         .flat(),
     );
     return [
-      ...importer.toStatements(
-        (ref) =>
-          `${"../".repeat(
-            StringUtil.splitWithNormalization(props.controller.location)
-              .length - 1,
-          )}api/structures/${ref}`,
-      ),
+      // Controllers live in the backend workspace package while the DTO
+      // structures belong to the api package, so the types must be imported
+      // through the package name instead of a relative path.
+      ...importer.toStatements(() => "@ORGANIZATION/PROJECT-api"),
       ...(importer.empty() ? [] : [FilePrinter.newLine()]),
       $class,
     ];

--- a/packages/migrate/src/programmers/NestiaMigrateNestProgrammer.ts
+++ b/packages/migrate/src/programmers/NestiaMigrateNestProgrammer.ts
@@ -17,11 +17,14 @@ export namespace NestiaMigrateNestProgrammer {
     const controllers: INestiaMigrateController[] =
       NestiaMigrateControllerAnalyzer.analyze(context.application.routes);
     const statements: [string, ts.Statement[]][] = [
-      ["src/MyModule.ts", NestiaMigrateNestModuleProgrammer.write(controllers)],
+      [
+        "packages/backend/src/MyModule.ts",
+        NestiaMigrateNestModuleProgrammer.write(controllers),
+      ],
       ...controllers.map(
         (c) =>
           [
-            `${c.location}/${c.name}.ts`,
+            `packages/backend/${c.location}/${c.name}.ts`,
             NestiaMigrateNestControllerProgrammer.write({
               config: context.config,
               components: context.application.document().components,
@@ -36,18 +39,36 @@ export namespace NestiaMigrateNestProgrammer {
         }).entries(),
       ].map(
         ([key, value]) =>
-          [`src/api/structures/${key}.ts`, writeDtoFile(key, value)] satisfies [
-            string,
-            ts.Statement[],
-          ],
+          [
+            `packages/api/src/structures/${key}.ts`,
+            writeDtoFile(key, value),
+          ] satisfies [string, ts.Statement[]],
       ),
     ];
-    return Object.fromEntries(
+    const files: Record<string, string> = Object.fromEntries(
       statements.map(([key, value]) => [
         key,
         FilePrinter.write({ statements: value }),
       ]),
     );
+    // The template's `packages/api/src/module.ts` re-exports the DTO types
+    // through `export * from "./structures"`, so the generated structure files
+    // need a barrel replacing the one deleted from the bundled template.
+    files["packages/api/src/structures/index.ts"] = writeDtoBarrel(files);
+    return files;
+  };
+
+  const writeDtoBarrel = (files: Record<string, string>): string => {
+    const prefix: string = "packages/api/src/structures/";
+    const names: string[] = Object.entries(files)
+      .filter(
+        ([key, content]) =>
+          key.startsWith(prefix) && key.endsWith(".ts") && content.length !== 0,
+      )
+      .map(([key]) => key.slice(prefix.length, -".ts".length))
+      .sort();
+    if (names.length === 0) return "export {};\n";
+    return names.map((name) => `export * from "./${name}";\n`).join("");
   };
 
   const writeDtoFile = (

--- a/packages/migrate/src/test/index.ts
+++ b/packages/migrate/src/test/index.ts
@@ -75,14 +75,32 @@ const execute = (
       root: directory,
       files,
     });
-    cp.execSync(`npx tsc -p ${directory}/tsconfig.json`, {
-      stdio: "inherit",
-      cwd: directory,
-    });
-    cp.execSync(`npx tsc -p ${directory}/test/tsconfig.json`, {
-      stdio: "inherit",
-      cwd: directory,
-    });
+    const compile = (config: string): void => {
+      cp.execSync(`npx tsc -p ${directory}/${config}`, {
+        stdio: "inherit",
+        cwd: directory,
+      });
+    };
+    if (mode === "nest") {
+      // The monorepo template's backend imports the api workspace package by
+      // its name, so emulate the pnpm workspace link before compiling.
+      await fs.promises.mkdir(`${directory}/node_modules`, {
+        recursive: true,
+      });
+      try {
+        fs.symlinkSync(
+          `${directory}/packages/api`,
+          `${directory}/node_modules/${project}-api`,
+          "junction",
+        );
+      } catch {}
+      compile("packages/api/tsconfig.json");
+      compile("packages/backend/tsconfig.json");
+      compile("packages/backend/test/tsconfig.json");
+    } else {
+      compile("tsconfig.json");
+      compile("test/tsconfig.json");
+    }
   });
 };
 

--- a/tests/test-migrate/src/features/test_migrate_nest_dto_package_import.ts
+++ b/tests/test-migrate/src/features/test_migrate_nest_dto_package_import.ts
@@ -1,0 +1,176 @@
+import {
+  INestiaMigrateConfig,
+  NestiaMigrateApplication,
+} from "@nestia/migrate";
+import { OpenApiV3_1 } from "@typia/interface";
+
+/**
+ * Verifies nest-mode controllers and e2e tests import DTOs by package name.
+ *
+ * In the monorepo template the DTO structures live in the api workspace package
+ * while controllers and test features live in the backend package, so relative
+ * `../api/structures/...` imports no longer resolve. The programmers must
+ * reference the api package by its name (`@ORGANIZATION/PROJECT-api`, which
+ * `renameSlug` rewrites to `<slug>-api`), keeping DTO clauses type-only and
+ * merged into a single import statement per module.
+ *
+ * 1. Generate a nest project with package slug `fixture`.
+ * 2. Assert the controller imports its DTO types through a single type-only
+ *    `fixture-api` clause and keeps no relative structure imports.
+ * 3. Assert the e2e feature imports the api default export and its DTO types from
+ *    `fixture-api` without deep `lib/structures` paths.
+ */
+export const test_migrate_nest_dto_package_import = (): void => {
+  const app: NestiaMigrateApplication =
+    NestiaMigrateApplication.assert(DOCUMENT);
+  const files: Record<string, string> = app.nest({
+    keyword: true,
+    simulate: true,
+    e2e: true,
+    package: "fixture",
+  } satisfies INestiaMigrateConfig);
+
+  const controller: string | undefined =
+    files[
+      "packages/backend/src/controllers/bbs/articles/BbsArticlesController.ts"
+    ];
+  if (controller === undefined)
+    throw new Error("Missing generated controller file.");
+  const controllerImports: string[] = controller
+    .split("\n")
+    .filter((line) => line.includes(`from "fixture-api"`));
+  if (controllerImports.length !== 1)
+    throw new Error(
+      "The controller must import DTOs through a single fixture-api clause.",
+    );
+  if (controllerImports[0]!.startsWith("import type ") === false)
+    throw new Error("The controller's DTO import must be type-only.");
+  for (const name of ["IBbsArticle", "IAttachmentFile"])
+    if (controllerImports[0]!.includes(name) === false)
+      throw new Error(`The controller must import ${name} from fixture-api.`);
+  if (controller.includes("api/structures"))
+    throw new Error("The controller must not import DTOs by relative path.");
+
+  const e2e: string | undefined =
+    files["packages/backend/test/features/api/test_api_bbs_articles_post.ts"];
+  if (e2e === undefined) throw new Error("Missing generated e2e feature.");
+  if (e2e.includes(`import api from "fixture-api";`) === false)
+    throw new Error("The e2e feature must import the api package default.");
+  if (
+    /^import type \{[^}]*IBbsArticle[^}]*\} from "fixture-api";$/m.test(e2e) ===
+    false
+  )
+    throw new Error("The e2e feature must import DTO types from fixture-api.");
+  if (e2e.includes("fixture-api/lib/structures"))
+    throw new Error("The e2e feature must not use deep lib/structures paths.");
+};
+
+const DOCUMENT = {
+  openapi: "3.1.0",
+  info: {
+    title: "DTO package import fixture",
+    version: "1.0.0",
+  },
+  paths: {
+    "/bbs/articles": {
+      post: {
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                $ref: "#/components/schemas/IBbsArticle.IStore",
+              },
+            },
+          },
+        },
+        responses: {
+          "201": {
+            description: "Newly archived article",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/IBbsArticle",
+                },
+              },
+            },
+          },
+        },
+      },
+      get: {
+        responses: {
+          "200": {
+            description: "Attached files of every article",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "array",
+                  items: {
+                    $ref: "#/components/schemas/IAttachmentFile",
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {
+      IBbsArticle: {
+        type: "object",
+        properties: {
+          id: {
+            type: "string",
+            format: "uuid",
+          },
+          title: {
+            type: "string",
+          },
+          body: {
+            type: "string",
+          },
+          files: {
+            type: "array",
+            items: {
+              $ref: "#/components/schemas/IAttachmentFile",
+            },
+          },
+        },
+        required: ["id", "title", "body", "files"],
+      },
+      "IBbsArticle.IStore": {
+        type: "object",
+        properties: {
+          title: {
+            type: "string",
+          },
+          body: {
+            type: "string",
+          },
+          files: {
+            type: "array",
+            items: {
+              $ref: "#/components/schemas/IAttachmentFile",
+            },
+          },
+        },
+        required: ["title", "body", "files"],
+      },
+      IAttachmentFile: {
+        type: "object",
+        properties: {
+          name: {
+            type: "string",
+          },
+          url: {
+            type: "string",
+            format: "uri",
+          },
+        },
+        required: ["name", "url"],
+      },
+    },
+  },
+} satisfies OpenApiV3_1.IDocument;

--- a/tests/test-migrate/src/features/test_migrate_nest_keyword_config_path.ts
+++ b/tests/test-migrate/src/features/test_migrate_nest_keyword_config_path.ts
@@ -1,0 +1,97 @@
+import {
+  INestiaMigrateConfig,
+  NestiaMigrateApplication,
+} from "@nestia/migrate";
+import { OpenApiV3_1 } from "@typia/interface";
+
+/**
+ * Verifies the keyword=false patch targets the backend's nestia.config.ts.
+ *
+ * The monorepo template moved nestia.config.ts from the project root into
+ * `packages/backend`, so the `config.keyword === false` patch has to rewrite
+ * the file at its new key. Patching the old root key would silently add a stray
+ * file whose `keyword: true` stays in effect, generating an SDK whose calling
+ * convention contradicts the migrated controllers.
+ *
+ * 1. Generate a nest project with `keyword: false`.
+ * 2. Assert `packages/backend/nestia.config.ts` carries `keyword: false`.
+ * 3. Assert no root-level nestia.config.ts key exists.
+ * 4. Generate with `keyword: true` and assert the config keeps its default.
+ */
+export const test_migrate_nest_keyword_config_path = (): void => {
+  const app: NestiaMigrateApplication =
+    NestiaMigrateApplication.assert(DOCUMENT);
+  const config = (keyword: boolean): INestiaMigrateConfig => ({
+    keyword,
+    simulate: true,
+    e2e: false,
+    package: "fixture",
+  });
+
+  const positional: Record<string, string> = app.nest(config(false));
+  const patched: string | undefined =
+    positional["packages/backend/nestia.config.ts"];
+  if (patched === undefined)
+    throw new Error("Missing packages/backend/nestia.config.ts.");
+  if (patched.includes("keyword: false") === false)
+    throw new Error("keyword: false must be patched into the backend config.");
+  if (positional["nestia.config.ts"] !== undefined)
+    throw new Error("No root-level nestia.config.ts may be generated.");
+
+  const keyword: Record<string, string> = app.nest(config(true));
+  if (
+    keyword["packages/backend/nestia.config.ts"]?.includes("keyword: true") !==
+    true
+  )
+    throw new Error("keyword: true must keep the template's default config.");
+};
+
+const DOCUMENT = {
+  openapi: "3.1.0",
+  info: {
+    title: "Keyword config path fixture",
+    version: "1.0.0",
+  },
+  paths: {
+    "/bbs/articles": {
+      get: {
+        operationId: "bbs.articles.index",
+        responses: {
+          "200": {
+            description: "Entire articles",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "array",
+                  items: {
+                    $ref: "#/components/schemas/IBbsArticle",
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {
+      IBbsArticle: {
+        type: "object",
+        properties: {
+          id: {
+            type: "string",
+            format: "uuid",
+          },
+          title: {
+            type: "string",
+          },
+          body: {
+            type: "string",
+          },
+        },
+        required: ["id", "title", "body"],
+      },
+    },
+  },
+} satisfies OpenApiV3_1.IDocument;

--- a/tests/test-migrate/src/features/test_migrate_nest_monorepo_layout.ts
+++ b/tests/test-migrate/src/features/test_migrate_nest_monorepo_layout.ts
@@ -1,0 +1,154 @@
+import {
+  INestiaMigrateConfig,
+  NestiaMigrateApplication,
+} from "@nestia/migrate";
+import { OpenApiV3_1 } from "@typia/interface";
+
+/**
+ * Verifies migrated NestJS projects follow the pnpm monorepo template layout.
+ *
+ * The nestia-start template was restructured into a pnpm monorepo whose backend
+ * application (`packages/backend`) and SDK library (`packages/api`) are
+ * separate workspace packages, and every nest-mode programmer emission path
+ * moved with it. A silent regression to the legacy single-package `src/api/...`
+ * layout would scatter generated files outside the workspace packages, where
+ * the bundled template neither compiles nor links them.
+ *
+ * 1. Generate a nest project from a synthetic OpenAPI document.
+ * 2. Assert the module, controller, DTO, barrel, functional, and e2e files land in
+ *    their monorepo locations.
+ * 3. Assert the DTO barrel re-exports every generated structure file.
+ * 4. Assert no generated key uses the legacy single-package `src/` or `test/`
+ *    roots.
+ */
+export const test_migrate_nest_monorepo_layout = (): void => {
+  const app: NestiaMigrateApplication =
+    NestiaMigrateApplication.assert(DOCUMENT);
+  const files: Record<string, string> = app.nest({
+    keyword: true,
+    simulate: true,
+    e2e: true,
+    package: "fixture",
+  } satisfies INestiaMigrateConfig);
+
+  const expected: string[] = [
+    "pnpm-workspace.yaml",
+    "packages/backend/nestia.config.ts",
+    "packages/backend/src/MyModule.ts",
+    "packages/backend/src/controllers/bbs/articles/BbsArticlesController.ts",
+    "packages/backend/test/features/api/test_api_bbs_articles_post.ts",
+    "packages/api/src/structures/IAttachmentFile.ts",
+    "packages/api/src/structures/IBbsArticle.ts",
+    "packages/api/src/structures/index.ts",
+    "packages/api/src/functional/index.ts",
+    "packages/api/src/functional/bbs/articles/index.ts",
+  ];
+  const missing: string[] = expected.filter((key) => files[key] === undefined);
+  if (missing.length !== 0)
+    throw new Error(
+      ["Missing monorepo template files:", ...missing].join("\n"),
+    );
+
+  const barrel: string = files["packages/api/src/structures/index.ts"]!;
+  for (const name of ["IAttachmentFile", "IBbsArticle"])
+    if (barrel.includes(`export * from "./${name}";`) === false)
+      throw new Error(`The DTO barrel must re-export ${name}.`);
+
+  const legacy: string[] = Object.keys(files).filter(
+    (key) => key.startsWith("src/") || key.startsWith("test/"),
+  );
+  if (legacy.length !== 0)
+    throw new Error(
+      ["Legacy single-package paths must not be generated:", ...legacy].join(
+        "\n",
+      ),
+    );
+};
+
+const DOCUMENT = {
+  openapi: "3.1.0",
+  info: {
+    title: "Monorepo layout fixture",
+    version: "1.0.0",
+  },
+  paths: {
+    "/bbs/articles": {
+      post: {
+        operationId: "bbs.articles.store",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                $ref: "#/components/schemas/IBbsArticle.IStore",
+              },
+            },
+          },
+        },
+        responses: {
+          "201": {
+            description: "Newly archived article",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/IBbsArticle",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {
+      IBbsArticle: {
+        type: "object",
+        properties: {
+          id: {
+            type: "string",
+            format: "uuid",
+          },
+          title: {
+            type: "string",
+          },
+          body: {
+            type: "string",
+          },
+          files: {
+            type: "array",
+            items: {
+              $ref: "#/components/schemas/IAttachmentFile",
+            },
+          },
+        },
+        required: ["id", "title", "body", "files"],
+      },
+      "IBbsArticle.IStore": {
+        type: "object",
+        properties: {
+          title: {
+            type: "string",
+          },
+          body: {
+            type: "string",
+          },
+        },
+        required: ["title", "body"],
+      },
+      IAttachmentFile: {
+        type: "object",
+        properties: {
+          name: {
+            type: "string",
+          },
+          url: {
+            type: "string",
+            format: "uri",
+          },
+        },
+        required: ["name", "url"],
+      },
+    },
+  },
+} satisfies OpenApiV3_1.IDocument;

--- a/tests/test-migrate/src/features/test_migrate_nest_workspace_catalog_stamp.ts
+++ b/tests/test-migrate/src/features/test_migrate_nest_workspace_catalog_stamp.ts
@@ -1,0 +1,117 @@
+import {
+  INestiaMigrateConfig,
+  NestiaMigrateApplication,
+} from "@nestia/migrate";
+import { OpenApiV3_1 } from "@typia/interface";
+import { createRequire } from "node:module";
+import path from "path";
+
+/**
+ * Verifies nest projects stamp nestia versions into the workspace catalogs.
+ *
+ * The monorepo template consumes every nestia package through the
+ * `catalog:samchon` indirection of pnpm-workspace.yaml, so version stamping
+ * moved from package.json dependency rewriting to catalog rewriting. The stamp
+ * must track this repository's version while preserving the YAML anchor
+ * (`nestia: &nestia ...`) that the `@nestia/*` alias entries dereference — a
+ * naive YAML round trip would inline and destroy those anchors.
+ *
+ * 1. Generate a nest project from a synthetic OpenAPI document.
+ * 2. Assert pnpm-workspace.yaml pins `nestia: &nestia ^<current version>`.
+ * 3. Assert the `@nestia/*` alias entries and the `ttsc` anchor survive.
+ * 4. Assert package.json dependencies keep their `catalog:` indirections.
+ */
+export const test_migrate_nest_workspace_catalog_stamp = (): void => {
+  const app: NestiaMigrateApplication =
+    NestiaMigrateApplication.assert(DOCUMENT);
+  const files: Record<string, string> = app.nest({
+    keyword: true,
+    simulate: true,
+    e2e: false,
+    package: "fixture",
+  } satisfies INestiaMigrateConfig);
+
+  const workspace: string | undefined = files["pnpm-workspace.yaml"];
+  if (workspace === undefined)
+    throw new Error("Missing pnpm-workspace.yaml in the nest output.");
+
+  const { version } = createRequire(path.join(process.cwd(), "package.json"))(
+    "@nestia/migrate/package.json",
+  ) as { version: string };
+  if (workspace.includes(`nestia: &nestia ^${version}`) === false)
+    throw new Error(
+      `pnpm-workspace.yaml must stamp \`nestia: &nestia ^${version}\`.`,
+    );
+  for (const alias of ["@nestia/core", "@nestia/sdk", "@nestia/fetcher"])
+    if (workspace.includes(`"${alias}": *nestia`) === false)
+      throw new Error(`The ${alias} entry must keep its *nestia alias.`);
+  if (/^\s+ttsc: &ttsc \^\d/m.test(workspace) === false)
+    throw new Error("The ttsc catalog entry must keep its anchor and version.");
+  if (/^\s+typia: \^\d/m.test(workspace) === false)
+    throw new Error("The typia catalog entry must keep a caret version.");
+
+  const backend: string | undefined = files["packages/backend/package.json"];
+  if (backend === undefined)
+    throw new Error("Missing backend package.json in the nest output.");
+  const parsed = JSON.parse(backend) as {
+    dependencies: Record<string, string>;
+  };
+  if (parsed.dependencies["@nestia/core"] !== "catalog:samchon")
+    throw new Error(
+      "The backend @nestia/core dependency must keep its catalog reference.",
+    );
+  if (parsed.dependencies["fixture-api"] !== "workspace:^")
+    throw new Error(
+      "The backend api dependency must keep its workspace reference.",
+    );
+};
+
+const DOCUMENT = {
+  openapi: "3.1.0",
+  info: {
+    title: "Workspace catalog stamp fixture",
+    version: "1.0.0",
+  },
+  paths: {
+    "/bbs/articles": {
+      get: {
+        operationId: "bbs.articles.index",
+        responses: {
+          "200": {
+            description: "Entire articles",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "array",
+                  items: {
+                    $ref: "#/components/schemas/IBbsArticle",
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {
+      IBbsArticle: {
+        type: "object",
+        properties: {
+          id: {
+            type: "string",
+            format: "uuid",
+          },
+          title: {
+            type: "string",
+          },
+          body: {
+            type: "string",
+          },
+        },
+        required: ["id", "title", "body"],
+      },
+    },
+  },
+} satisfies OpenApiV3_1.IDocument;

--- a/tests/test-migrate/src/features/test_migrate_sdk_key_snapshot.ts
+++ b/tests/test-migrate/src/features/test_migrate_sdk_key_snapshot.ts
@@ -1,0 +1,181 @@
+import {
+  INestiaMigrateConfig,
+  NestiaMigrateApplication,
+} from "@nestia/migrate";
+import { OpenApiV3_1 } from "@typia/interface";
+
+/**
+ * Verifies sdk-mode generation keeps its single-package file layout.
+ *
+ * The nest mode moved to the pnpm monorepo template, and several programmers
+ * (api, e2e, import) now branch on the generation mode. The sdk template is
+ * still the pinned single-package nestia-sdk-template, so its output keys are
+ * regression-locked here: any accidental leak of the monorepo paths (or a
+ * template re-pin) must fail loudly instead of silently reshaping migrated SDK
+ * projects.
+ *
+ * 1. Generate an sdk project from a synthetic OpenAPI document.
+ * 2. Compare the sorted key set against the snapshot taken before the monorepo
+ *    migration.
+ */
+export const test_migrate_sdk_key_snapshot = (): void => {
+  const app: NestiaMigrateApplication =
+    NestiaMigrateApplication.assert(DOCUMENT);
+  const files: Record<string, string> = app.sdk({
+    keyword: true,
+    simulate: true,
+    e2e: true,
+    package: "fixture",
+  } satisfies INestiaMigrateConfig);
+
+  const actual: string[] = Object.keys(files).sort();
+  if (JSON.stringify(actual) !== JSON.stringify(SNAPSHOT))
+    throw new Error(
+      [
+        "The sdk output keys changed:",
+        `- expected: ${JSON.stringify(SNAPSHOT, null, 2)}`,
+        `- actual: ${JSON.stringify(actual, null, 2)}`,
+      ].join("\n"),
+    );
+};
+
+const SNAPSHOT: string[] = [
+  ".gitignore",
+  ".vscode/launch.json",
+  ".vscode/settings.json",
+  "LICENSE",
+  "README.md",
+  "hello.js",
+  "package.json",
+  "prettier.config.js",
+  "rollup.config.js",
+  "src/HttpError.ts",
+  "src/IConnection.ts",
+  "src/functional/bbs/articles/index.ts",
+  "src/functional/bbs/index.ts",
+  "src/functional/index.ts",
+  "src/index.ts",
+  "src/module.ts",
+  "src/structures/IAttachmentFile.ts",
+  "src/structures/IBbsArticle.ts",
+  "swagger.json",
+  "test/TestGlobal.ts",
+  "test/features/api/test_api_bbs_articles_get.ts",
+  "test/features/api/test_api_bbs_articles_post.ts",
+  "test/index.ts",
+  "test/start.ts",
+  "test/swagger.ts",
+  "test/tsconfig.json",
+  "test/utils/ArgumentParser.ts",
+  "tsconfig.json",
+];
+
+const DOCUMENT = {
+  openapi: "3.1.0",
+  info: {
+    title: "SDK key snapshot fixture",
+    version: "1.0.0",
+  },
+  paths: {
+    "/bbs/articles": {
+      post: {
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                $ref: "#/components/schemas/IBbsArticle.IStore",
+              },
+            },
+          },
+        },
+        responses: {
+          "201": {
+            description: "Newly archived article",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/IBbsArticle",
+                },
+              },
+            },
+          },
+        },
+      },
+      get: {
+        responses: {
+          "200": {
+            description: "Attached files of every article",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "array",
+                  items: {
+                    $ref: "#/components/schemas/IAttachmentFile",
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {
+      IBbsArticle: {
+        type: "object",
+        properties: {
+          id: {
+            type: "string",
+            format: "uuid",
+          },
+          title: {
+            type: "string",
+          },
+          body: {
+            type: "string",
+          },
+          files: {
+            type: "array",
+            items: {
+              $ref: "#/components/schemas/IAttachmentFile",
+            },
+          },
+        },
+        required: ["id", "title", "body", "files"],
+      },
+      "IBbsArticle.IStore": {
+        type: "object",
+        properties: {
+          title: {
+            type: "string",
+          },
+          body: {
+            type: "string",
+          },
+          files: {
+            type: "array",
+            items: {
+              $ref: "#/components/schemas/IAttachmentFile",
+            },
+          },
+        },
+        required: ["title", "body", "files"],
+      },
+      IAttachmentFile: {
+        type: "object",
+        properties: {
+          name: {
+            type: "string",
+          },
+          url: {
+            type: "string",
+            format: "uri",
+          },
+        },
+        required: ["name", "url"],
+      },
+    },
+  },
+} satisfies OpenApiV3_1.IDocument;

--- a/tests/test-migrate/src/index.ts
+++ b/tests/test-migrate/src/index.ts
@@ -17,6 +17,11 @@ import type { IValidation } from "typia";
 import { test_migrate_api_accessor_collision } from "./features/test_migrate_api_accessor_collision";
 import { test_migrate_api_response_header_tags } from "./features/test_migrate_api_response_header_tags";
 import { test_migrate_dto_import_type } from "./features/test_migrate_dto_import_type";
+import { test_migrate_nest_dto_package_import } from "./features/test_migrate_nest_dto_package_import";
+import { test_migrate_nest_keyword_config_path } from "./features/test_migrate_nest_keyword_config_path";
+import { test_migrate_nest_monorepo_layout } from "./features/test_migrate_nest_monorepo_layout";
+import { test_migrate_nest_workspace_catalog_stamp } from "./features/test_migrate_nest_workspace_catalog_stamp";
+import { test_migrate_sdk_key_snapshot } from "./features/test_migrate_sdk_key_snapshot";
 
 const TEST_ROOT: string = process.cwd();
 const ROOT: string = path.resolve(TEST_ROOT, "../..");
@@ -24,8 +29,19 @@ const FIXTURE: string = path.join(TEST_ROOT, "fixture");
 const GENERATED: string = path.join(TEST_ROOT, ".generated");
 const SWAGGER: string = path.join(GENERATED, "swagger.json");
 const OUTPUT: string = path.join(GENERATED, "output");
-const PNPM: string = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
 const NODE: string = process.execPath;
+// Launch the ttsc compiler through its JS entrypoint instead of `pnpm ttsc`:
+// spawning the `pnpm.cmd` shim without a shell raises EINVAL on Windows
+// (Node's CVE-2024-27980 mitigation), while the node launcher runs the same
+// pinned ttsc everywhere.
+const TTSC_BIN: string = path.join(
+  TEST_ROOT,
+  "node_modules",
+  "ttsc",
+  "lib",
+  "launcher",
+  "ttsc.js",
+);
 const TTSC_CACHE_DIR: string = path.resolve(
   ROOT,
   process.env.TTSC_CACHE_DIR ?? path.join(ROOT, "node_modules", ".ttsc"),
@@ -155,7 +171,7 @@ const execute = (
       const content: string | undefined = files[key];
       if (key.endsWith("tsconfig.json") && content !== undefined)
         files[key] = content.replace(
-          /^\s*\{\s*"transform":\s*"typescript-transform-paths"\s*\},\n/gm,
+          /^\s*\{\s*"transform":\s*"typescript-transform-paths"\s*\},\r?\n/gm,
           "",
         );
     }
@@ -170,15 +186,34 @@ const execute = (
 
     const ttsc = (project?: string): void => {
       spawn(directory, [
-        PNPM,
-        "ttsc",
+        NODE,
+        TTSC_BIN,
         "--cache-dir",
         TTSC_CACHE_DIR,
         ...(project !== undefined ? ["-p", project] : []),
       ]);
     };
-    ttsc();
-    ttsc("test/tsconfig.json");
+    if (mode === "nest") {
+      // The monorepo template's backend consumes the api workspace package
+      // by name (`<slug>-api`). The generated archive is compiled without a
+      // `pnpm install`, so emulate the workspace link with a junction/symlink
+      // that node module resolution can walk into.
+      const nodeModules: string = path.join(directory, "node_modules");
+      await fs.promises.mkdir(nodeModules, { recursive: true });
+      try {
+        fs.symlinkSync(
+          path.join(directory, "packages", "api"),
+          path.join(nodeModules, `${scenario.name}-api`),
+          "junction",
+        );
+      } catch {}
+      ttsc(path.join("packages", "api", "tsconfig.json"));
+      ttsc(path.join("packages", "backend", "tsconfig.json"));
+      ttsc(path.join("packages", "backend", "test", "tsconfig.json"));
+    } else {
+      ttsc();
+      ttsc("test/tsconfig.json");
+    }
   });
 };
 
@@ -209,6 +244,11 @@ const main = async (): Promise<void> => {
     test_migrate_api_accessor_collision(document);
     test_migrate_api_response_header_tags();
     test_migrate_dto_import_type();
+    test_migrate_nest_monorepo_layout();
+    test_migrate_nest_dto_package_import();
+    test_migrate_nest_workspace_catalog_stamp();
+    test_migrate_nest_keyword_config_path();
+    test_migrate_sdk_key_snapshot();
     for (const [mode, keyword] of [
       ["nest", true],
       ["nest", false],


### PR DESCRIPTION
# Summary

`@nestia/migrate`'s nest mode now emits the new nestia-start **pnpm monorepo** template, and version stamping moved from package.json dependency rewriting to **pnpm-workspace.yaml catalog rewriting**.

- **Template re-pin** (`packages/migrate/src/executable/bundle.js`): nest mode moves from `1057bccd` (last single-package commit) to `314d77f2` — the first monorepo revision whose config package is consumed through workspace dependencies (samchon/nestia-start#632/#634/#635). Exceptions updated to the monorepo paths; the template's `pnpm-lock.yaml` is excluded (160 KB of immediately-stale data once the catalogs are stamped; the old template shipped no lockfile either).
- **Catalog stamping**: a new `updateWorkspaceCatalog` transform rewrites `pnpm-workspace.yaml` line-by-line — `nestia: &nestia ^<repo version>`, tgrid/tstl/typia from the repo lock's `catalogs.samchon`, ttsc/typescript from `catalogs.typescript` — deliberately *not* a YAML round trip, which would inline and destroy the `&nestia`/`&ttsc` anchors that the `@nestia/*` and `@ttsc/*` entries alias. `update()` now skips `catalog:`/`workspace:` dependency specifiers, and the stale hardcoded `ttsc ??= "^0.10.2"` fallback is derived from the repo catalog instead (the sdk template now receives `^0.18.1`).
- **Programmer path moves** (nest mode only; sdk emission is unchanged):
  - `src/MyModule.ts` → `packages/backend/src/MyModule.ts`; controllers → `packages/backend/src/controllers/...`
  - DTOs → `packages/api/src/structures/<Name>.ts` plus a generated sorted barrel `packages/api/src/structures/index.ts` (the template's `module.ts` re-exports `./structures`)
  - functional → `packages/api/src/functional/...` (DTO imports stay relative within the api package)
  - e2e features → `packages/backend/test/features/api/...`
- **Package-name DTO imports**: controllers and e2e features import DTO types via `@ORGANIZATION/PROJECT-api` (→ `<slug>-api` after `renameSlug`) instead of relative `../api/structures/...` / deep `lib/structures/...` paths. `NestiaMigrateImportProgrammer.toStatements` now groups DTO imports by resolved specifier so package imports merge into a single type-only clause (relative specifiers are unique per file, so sdk output is unchanged).
- **`NestiaMigrateApplication.nest()`**: template filter keys and the `keyword: false` patch target the monorepo paths (`packages/backend/nestia.config.ts`).
- **Test harness** (`tests/test-migrate/src/index.ts` + `packages/migrate/src/test/index.ts`): nest outputs compile as a monorepo — `packages/api`, `packages/backend`, `packages/backend/test/tsconfig.json` — after emulating the pnpm workspace link with a `node_modules/<slug>-api` junction (Windows-safe).
- **New regression tests** (`tests/test-migrate/src/features/`):
  - `test_migrate_nest_monorepo_layout` — monorepo keys incl. barrel; no legacy `src/`/`test/` roots
  - `test_migrate_nest_dto_package_import` — merged type-only `<slug>-api` imports in controllers/e2e
  - `test_migrate_nest_workspace_catalog_stamp` — stamped `nestia: &nestia ^<version>` anchor, surviving aliases, intact `catalog:`/`workspace:` refs
  - `test_migrate_nest_keyword_config_path` — keyword patch at `packages/backend/nestia.config.ts`
  - `test_migrate_sdk_key_snapshot` — sdk single-package key-set snapshot lock

Note: `src/bundles/NEST_TEMPLATE.ts`/`SDK_TEMPLATE.ts` are gitignored and regenerated by the package's `prepare` script (also during publish), so there is no bundle artifact to commit — the bundle.js changes are the source of truth.

Two defects surfaced (and are fixed) while verifying on Windows:

- **`NestiaMigrateFileArchiver` never created the archive root** — masked before because the old template's first key was a root-level file; the monorepo template leads with the nested `.github/workflows/build.yml`. The archiver now mkdirs the root first (also fixes the CLI's `--output <new dir>` with any nested-first file set).
- **CRLF checkouts broke the line-targeted transforms** — with `core.autocrlf=true` (common Windows default) the template clones came out CRLF, silently skipping the tsconfig plugin stripping *and* the new catalog stamping, so a Windows-published bundle would differ from CI's. Clones now pass `--config core.autocrlf=false`, and the regexes tolerate `\r?\n` as belt-and-braces.
- The test harness now launches ttsc through its node entrypoint instead of `pnpm ttsc` — spawning the `pnpm.cmd` shim without a shell raises EINVAL on Windows (Node's CVE-2024-27980 mitigation); behavior on CI is the same pinned ttsc.

# Verification

All on Windows 11 (this branch's worktree):

```
pnpm install                              # regenerates gitignored bundles via prepare
pnpm --filter @nestia/migrate run bundle  # re-pinned clone + stamped pnpm-workspace.yaml
pnpm --filter @nestia/migrate build       # clean
pnpm build                                # workspace build (cli etc. needed by the suite)
pnpm --filter ./tests/test-migrate start
```

Suite result (end-to-end green):

```
- fixture-swagger: 7,054 ms
- fixture-nest-keyword: 9,690 ms
- fixture-nest-positional: 10,668 ms
- fixture-sdk-keyword: 8,724 ms
- fixture-sdk-positional: 7,218 ms
```

The 8 feature tests (3 existing + 5 new) run before the compile loop. Each nest scenario compiles `packages/api`, `packages/backend`, and `packages/backend/test/tsconfig.json` with a `node_modules/fixture-api` junction emulating the pnpm workspace link; sdk scenarios compile root + test tsconfigs as before. Spot-checked the generated output: stamped `nestia: &nestia ^12.0.0-rc.3` anchor, `packages/api/lib` declaration output, and `keyword: false` patched into `packages/backend/nestia.config.ts` for the positional variant.

The `updateWorkspaceCatalog` rewriter was additionally unit-checked against divergent versions (fake `^1.0.0`/`^0.1.0` inputs) to prove it stamps values while preserving `&nestia`/`&ttsc` anchors, alias lines, and the `typescript:` group header.

# Known gaps

- A real `pnpm install && pnpm build && pnpm test` inside a generated project (network install of NestJS etc.) was not run; the CI compile loop covers type-level integrity only.
- `@nestia/editor`'s StackBlitz hints for nest mode (`openFile: "test/start.ts"`, `startScript: "build:test,test"`) were already stale for the old nest template and remain untouched — the monorepo start command lives in the template root package.json's `stackblitz.startCommand`.
- sdk mode intentionally keeps the single-package template (upstream `nestia-sdk-template` HEAD is still the pinned `8cfb771e`); its generated `package.json` now receives `ttsc ^0.18.1` instead of the stale hardcoded `^0.10.2` fallback (coordinator-directed fix), keys unchanged and snapshot-locked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYUZ95W7jUpsnTgxBmamAH

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYUZ95W7jUpsnTgxBmamAH
