### PR TITLE
feat(editor): deliver composed projects as zip downloads instead of StackBlitz

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,7 @@ jobs:
           - { name: e2e, run: "pnpm --filter ./tests/test-e2e start" }
           - { name: benchmark, run: "pnpm --filter ./tests/test-benchmark start" }
           - { name: cli, run: "pnpm --filter ./tests/test-cli start" }
+          - { name: editor, run: "pnpm --filter ./tests/test-editor start" }
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -40,8 +40,8 @@
   "dependencies": {
     "@mui/material": "^5.15.6",
     "@nestia/migrate": "workspace:^",
-    "@stackblitz/sdk": "^1.11.0",
     "@typia/interface": "catalog:samchon",
+    "fflate": "^0.8.2",
     "js-yaml": "^4.1.0",
     "prettier": "catalog:typescript",
     "react-mui-fileuploader": "^0.5.2",

--- a/packages/editor/src/NestiaEditorIframe.tsx
+++ b/packages/editor/src/NestiaEditorIframe.tsx
@@ -1,6 +1,7 @@
 import {
   Alert,
   AlertTitle,
+  Button,
   CircularProgress,
   Step,
   StepContent,
@@ -8,24 +9,25 @@ import {
   Stepper,
   Typography,
 } from "@mui/material";
-import StackBlitzSDK from "@stackblitz/sdk";
 import { OpenApiV3, OpenApiV3_1, SwaggerV2 } from "@typia/interface";
 import { load } from "js-yaml";
 import React from "react";
 import { IValidation } from "typia";
 
+import { NestiaEditorArchiver } from "./internal/NestiaEditorArchiver";
 import { NestiaEditorComposer } from "./internal/NestiaEditorComposer";
 
 export function NestiaEditorIframe(props: NestiaEditorIframe.IProps) {
-  const [id] = React.useState(
-    `reactia-editor-div-${Math.random().toString().substring(2)}`,
-  );
   const [step, setStep] = React.useState(0);
   const [fetchError, setFetchError] = React.useState<string | null>(null);
   const [operations, setOperationCount] = React.useState<
     Record<string, number>
   >({});
   const [composerError, setComposerError] = React.useState<any | null>(null);
+  const [files, setFiles] = React.useState<Record<string, string> | null>(null);
+  const archive: string = NestiaEditorArchiver.name(
+    props.package ?? "@ORGANIZATION/PROJECT",
+  );
 
   React.useEffect(() => {
     (async () => {
@@ -69,29 +71,15 @@ export function NestiaEditorIframe(props: NestiaEditorIframe.IProps) {
         return;
       }
 
-      // COMPOSING STACKBLITZ PROJECT
+      // READY TO DOWNLOAD
       setStep(2);
-      StackBlitzSDK.embedProject(
-        id,
-        {
-          title: document.info?.title ?? "Nestia Editor",
-          template: "node",
-          files: result.data.files,
-        },
-        {
-          width: "100%",
-          height: "100%",
-          openFile: result.data.openFile,
-          startScript: result.data.startScript as any, // no problem
-        },
-      );
+      setFiles(result.data.files);
     })().catch((exp) => {
       console.error("unknown error", exp);
     });
   }, []);
   return (
     <div
-      id={id}
       style={{
         width: "100%",
         height: "100%",
@@ -176,9 +164,34 @@ export function NestiaEditorIframe(props: NestiaEditorIframe.IProps) {
           </Step>
           <Step key={2}>
             <StepLabel>
-              <Typography variant="h5">Composing TypeScript Project</Typography>
+              <Typography variant="h5">
+                Downloading TypeScript Project
+              </Typography>
             </StepLabel>
-            <StepContent></StepContent>
+            <StepContent>
+              <br />
+              {files !== null ? (
+                <>
+                  <p>
+                    {Object.keys(files).length.toLocaleString()} files are
+                    ready.
+                  </p>
+                  <Button
+                    variant="contained"
+                    color="success"
+                    size="large"
+                    onClick={() =>
+                      NestiaEditorArchiver.download({
+                        name: archive,
+                        files,
+                      })
+                    }
+                  >
+                    Download {archive}
+                  </Button>
+                </>
+              ) : null}
+            </StepContent>
           </Step>
         </Stepper>
       </div>

--- a/packages/editor/src/NestiaEditorUploader.tsx
+++ b/packages/editor/src/NestiaEditorUploader.tsx
@@ -8,10 +8,10 @@ import {
   Switch,
   TextField,
 } from "@mui/material";
-import StackBlitzSDK from "@stackblitz/sdk";
 import { OpenApiV3, OpenApiV3_1, SwaggerV2 } from "@typia/interface";
 import React from "react";
 
+import { NestiaEditorArchiver } from "./internal/NestiaEditorArchiver";
 import { NestiaEditorComposer } from "./internal/NestiaEditorComposer";
 import { NestiaEditorFileUploader } from "./internal/NestiaEditorFileUploader";
 
@@ -58,18 +58,10 @@ export function NestiaEditorUploader(props: NestiaEditorUploader.IProps) {
         package: name,
       });
       if (result.success === true) {
-        StackBlitzSDK.openProject(
-          {
-            title: document.info?.title ?? "Nestia Editor",
-            template: "node",
-            files: result.data.files,
-          },
-          {
-            newWindow: true,
-            openFile: result.data.openFile,
-            startScript: result.data.startScript as any,
-          },
-        );
+        NestiaEditorArchiver.download({
+          name: NestiaEditorArchiver.name(name),
+          files: result.data.files,
+        });
       } else {
         handleError(JSON.stringify(result.errors, null, 2));
       }
@@ -142,7 +134,7 @@ export function NestiaEditorUploader(props: NestiaEditorUploader.IProps) {
         disabled={progress === true || document === null}
         onClick={() => generate()}
       >
-        {progress ? "Generating..." : "Generate Editor"}
+        {progress ? "Generating..." : "Download Project"}
       </Button>
     </>
   );

--- a/packages/editor/src/internal/NestiaEditorArchiver.ts
+++ b/packages/editor/src/internal/NestiaEditorArchiver.ts
@@ -1,0 +1,43 @@
+import { strToU8, zipSync } from "fflate";
+
+/**
+ * Archives a composed project into a zip file and hands it to the browser.
+ *
+ * StackBlitz can no longer run nestia projects: the generated projects build
+ * through `ttsc`, whose TypeScript compiler is a native Go binary that a
+ * WebContainer cannot execute. The editor therefore delivers the composed
+ * project as a downloadable zip archive instead of an embedded StackBlitz
+ * workspace.
+ */
+export namespace NestiaEditorArchiver {
+  /** Pack the composed project files into a zip archive. */
+  export const pack = (files: Record<string, string>): Uint8Array => {
+    const entries: Record<string, Uint8Array> = {};
+    for (const [key, value] of Object.entries(files))
+      entries[key] = strToU8(value);
+    return zipSync(entries);
+  };
+
+  /** Compose a safe archive file name from a package name. */
+  export const name = (packageName: string): string =>
+    `${packageName.replace(/^@/, "").replace(/[^A-Za-z0-9._-]+/g, "-")}.zip`;
+
+  /** Trigger a browser download of the packed archive. */
+  export const download = (props: {
+    name: string;
+    files: Record<string, string>;
+  }): void => {
+    const blob: Blob = new Blob(
+      [pack(props.files) as Uint8Array<ArrayBuffer>],
+      {
+        type: "application/zip",
+      },
+    );
+    const url: string = URL.createObjectURL(blob);
+    const anchor: HTMLAnchorElement = window.document.createElement("a");
+    anchor.href = url;
+    anchor.download = props.name;
+    anchor.click();
+    setTimeout(() => URL.revokeObjectURL(url), 30_000);
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -352,12 +352,12 @@ importers:
       '@nestia/migrate':
         specifier: workspace:^
         version: link:../migrate
-      '@stackblitz/sdk':
-        specifier: ^1.11.0
-        version: 1.11.0
       '@typia/interface':
         specifier: catalog:samchon
         version: 13.0.0
+      fflate:
+        specifier: ^0.8.2
+        version: 0.8.3
       js-yaml:
         specifier: ^4.1.0
         version: 4.1.1
@@ -686,6 +686,28 @@ importers:
       cross-env:
         specifier: catalog:utils
         version: 10.1.0
+      ttsc:
+        specifier: catalog:typescript
+        version: 0.18.1
+
+  tests/test-editor:
+    dependencies:
+      '@nestia/e2e':
+        specifier: workspace:^
+        version: link:../../packages/e2e
+    devDependencies:
+      '@nestia/editor':
+        specifier: workspace:^
+        version: link:../../packages/editor
+      '@types/node':
+        specifier: catalog:utils
+        version: 25.9.0
+      cross-env:
+        specifier: catalog:utils
+        version: 10.1.0
+      fflate:
+        specifier: ^0.8.2
+        version: 0.8.3
       ttsc:
         specifier: catalog:typescript
         version: 0.18.1
@@ -1732,9 +1754,6 @@ packages:
 
   '@scarf/scarf@1.4.0':
     resolution: {integrity: sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==}
-
-  '@stackblitz/sdk@1.11.0':
-    resolution: {integrity: sha512-DFQGANNkEZRzFk1/rDP6TcFdM82ycHE+zfl9C/M/jXlH68jiqHWHFMQURLELoD8koxvu/eW5uhg94NSAZlYrUQ==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -2920,6 +2939,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
   figures@3.2.0:
     resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
@@ -5153,8 +5175,6 @@ snapshots:
 
   '@scarf/scarf@1.4.0': {}
 
-  '@stackblitz/sdk@1.11.0': {}
-
   '@standard-schema/spec@1.1.0': {}
 
   '@tokenizer/inflate@0.4.1':
@@ -6499,6 +6519,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fflate@0.8.3: {}
 
   figures@3.2.0:
     dependencies:

--- a/tests/test-editor/package.json
+++ b/tests/test-editor/package.json
@@ -1,0 +1,20 @@
+{
+  "private": true,
+  "name": "@nestia/test-editor",
+  "version": "12.0.0-rc.3",
+  "scripts": {
+    "dev": "ttsc --watch",
+    "start": "pnpm --filter @nestia/editor run build:lib && cross-env NODE_OPTIONS=\"--no-experimental-strip-types --no-experimental-detect-module\" ttsx src/index.ts"
+  },
+  "dependencies": {
+    "@nestia/e2e": "workspace:^"
+  },
+  "devDependencies": {
+    "@nestia/editor": "workspace:^",
+    "@types/node": "catalog:utils",
+    "cross-env": "catalog:utils",
+    "fflate": "^0.8.2",
+    "ttsc": "catalog:typescript"
+  },
+  "packageManager": "pnpm@10.6.4"
+}

--- a/tests/test-editor/src/features/test_editor_archiver_zip_roundtrip.ts
+++ b/tests/test-editor/src/features/test_editor_archiver_zip_roundtrip.ts
@@ -1,0 +1,39 @@
+import { strFromU8, unzipSync } from "fflate";
+
+import { EditorTestHarness } from "../internal/EditorTestHarness";
+
+/**
+ * Verifies NestiaEditorArchiver packs project files into a zip whose entries
+ * unzip back byte-identically.
+ *
+ * The editor's only delivery channel is now the zip download (StackBlitz cannot
+ * execute the Go-backed ttsc compiler), so a corrupted or lossy archive would
+ * leave users with no way to consume a composed project. This locks path
+ * nesting, non-ASCII content, and the sanitized archive name.
+ *
+ * 1. Pack a file map containing nested paths and non-ASCII content.
+ * 2. Unzip the produced archive with fflate.
+ * 3. Assert every entry round-trips byte-identically and the archive name drops
+ *    the npm scope marker.
+ */
+export const test_editor_archiver_zip_roundtrip = (): void => {
+  const archiver = EditorTestHarness.archiver();
+  const files: Record<string, string> = {
+    "package.json": JSON.stringify({ name: "x" }, null, 2),
+    "packages/api/src/index.ts": 'export * from "./module";\n',
+    "docs/한글.md": "비 ASCII 내용도 그대로 보존되어야 한다.\n",
+  };
+  const unzipped = unzipSync(archiver.pack(files));
+
+  const keys: string[] = Object.keys(unzipped).sort();
+  const expected: string[] = Object.keys(files).sort();
+  if (JSON.stringify(keys) !== JSON.stringify(expected))
+    throw new Error(`zip entries mismatch: ${JSON.stringify(keys)}`);
+  for (const [key, value] of Object.entries(files))
+    if (strFromU8(unzipped[key]!) !== value)
+      throw new Error(`zip content mismatch at ${key}`);
+
+  const name: string = archiver.name("@ORGANIZATION/PROJECT");
+  if (name !== "ORGANIZATION-PROJECT.zip")
+    throw new Error(`unexpected archive name: ${name}`);
+};

--- a/tests/test-editor/src/features/test_editor_composer_nest_monorepo_files.ts
+++ b/tests/test-editor/src/features/test_editor_composer_nest_monorepo_files.ts
@@ -1,0 +1,44 @@
+import { EditorTestHarness } from "../internal/EditorTestHarness";
+
+/**
+ * Verifies the editor's nest-mode composition emits the pnpm monorepo layout of
+ * the new nestia-start template.
+ *
+ * The editor feeds its zip download from @nestia/migrate, whose nest mode moved
+ * from the single-package `src/api` layout to the pnpm monorepo (`packages/api`
+ * + `packages/backend`). A regression back to legacy keys would hand users a
+ * project whose build scripts point at nothing.
+ *
+ * 1. Compose a nest-mode project from a minimal OpenAPI 3.1 document.
+ * 2. Assert monorepo markers exist: pnpm-workspace.yaml and
+ *    packages/backend/nestia.config.ts.
+ * 3. Assert no legacy `src/api/...` keys remain.
+ */
+export const test_editor_composer_nest_monorepo_files =
+  async (): Promise<void> => {
+    const composer = EditorTestHarness.composer();
+    const result = await composer.nest({
+      document: EditorTestHarness.document(),
+      e2e: false,
+      keyword: true,
+      simulate: false,
+      package: "@editor/test",
+    });
+    if (result.success !== true)
+      throw new Error(
+        `nest composition failed: ${JSON.stringify(result.errors)}`,
+      );
+
+    const keys: string[] = Object.keys(result.data!.files);
+    for (const marker of [
+      "pnpm-workspace.yaml",
+      "packages/backend/nestia.config.ts",
+    ])
+      if (keys.includes(marker) === false)
+        throw new Error(`missing monorepo marker: ${marker}`);
+    if (keys.some((key) => key.startsWith("packages/api/src/")) === false)
+      throw new Error("missing packages/api sources");
+    const legacy: string[] = keys.filter((key) => key.startsWith("src/api/"));
+    if (legacy.length !== 0)
+      throw new Error(`legacy layout keys leaked: ${legacy.join(", ")}`);
+  };

--- a/tests/test-editor/src/features/test_editor_composer_sdk_zip_entries.ts
+++ b/tests/test-editor/src/features/test_editor_composer_sdk_zip_entries.ts
@@ -1,0 +1,36 @@
+import { unzipSync } from "fflate";
+
+import { EditorTestHarness } from "../internal/EditorTestHarness";
+
+/**
+ * Verifies an sdk-mode composition survives the full download pipeline:
+ * compose, pack, unzip.
+ *
+ * This is the exact path a user triggers in the editor UI (compose through
+ * @nestia/migrate, then archive through NestiaEditorArchiver), so it locks the
+ * integration between the two internals rather than either in isolation.
+ *
+ * 1. Compose an sdk-mode project from a minimal OpenAPI 3.1 document.
+ * 2. Pack the composed files and unzip the archive.
+ * 3. Assert the project manifest and swagger document survive with content.
+ */
+export const test_editor_composer_sdk_zip_entries = async (): Promise<void> => {
+  const composer = EditorTestHarness.composer();
+  const archiver = EditorTestHarness.archiver();
+  const result = await composer.sdk({
+    document: EditorTestHarness.document(),
+    e2e: false,
+    keyword: true,
+    simulate: false,
+    package: "@editor/test",
+  });
+  if (result.success !== true)
+    throw new Error(`sdk composition failed: ${JSON.stringify(result.errors)}`);
+
+  const unzipped = unzipSync(archiver.pack(result.data!.files));
+  for (const marker of ["package.json", "swagger.json"]) {
+    const entry = unzipped[marker];
+    if (entry === undefined || entry.length === 0)
+      throw new Error(`zip is missing ${marker}`);
+  }
+};

--- a/tests/test-editor/src/index.ts
+++ b/tests/test-editor/src/index.ts
@@ -1,0 +1,24 @@
+import { DynamicExecutor } from "@nestia/e2e";
+
+async function main(): Promise<void> {
+  const report: DynamicExecutor.IReport = await DynamicExecutor.assert({
+    parameters: () => [],
+    location: __dirname + "/features",
+    prefix: "test",
+    onComplete: (exec) => {
+      const elapsed: number =
+        new Date(exec.completed_at).getTime() -
+        new Date(exec.started_at).getTime();
+      console.log(` - ${exec.name}: ${elapsed.toLocaleString()} ms`);
+    },
+    simultaneous: 1,
+    extension: __filename.substring(__filename.length - 2),
+  });
+  if (report.executions.length === 0)
+    throw new Error("No editor test function has been discovered.");
+  console.log(`Elapsed time: ${report.time.toLocaleString()} ms`);
+}
+main().catch((exp) => {
+  console.log(exp);
+  process.exit(-1);
+});

--- a/tests/test-editor/src/internal/EditorTestHarness.ts
+++ b/tests/test-editor/src/internal/EditorTestHarness.ts
@@ -1,0 +1,83 @@
+import path from "path";
+
+/**
+ * Local helpers for the `@nestia/editor` test suite.
+ *
+ * The suite exercises the built library artifacts under `packages/editor/lib`,
+ * not the TypeScript sources: the archiver and the composer are internal
+ * modules that the package's exports map does not expose, so they are loaded
+ * through absolute-path `require()` calls.
+ */
+export namespace EditorTestHarness {
+  /** Ttsx relocates compiled sources, so anchor on the workspace cwd. */
+  export const ROOT: string = path.resolve(process.cwd(), "..", "..");
+  export const LIB: string = path.join(ROOT, "packages", "editor", "lib");
+
+  export interface IArchiver {
+    pack: (files: Record<string, string>) => Uint8Array;
+    name: (packageName: string) => string;
+    download: (props: { name: string; files: Record<string, string> }) => void;
+  }
+  export interface IComposer {
+    nest: (props: IComposerProps) => Promise<IComposerResult>;
+    sdk: (props: IComposerProps) => Promise<IComposerResult>;
+  }
+  export interface IComposerProps {
+    document: object;
+    e2e: boolean;
+    keyword: boolean;
+    simulate: boolean;
+    package?: string;
+  }
+  export interface IComposerResult {
+    success: boolean;
+    data?: { files: Record<string, string> };
+    errors?: unknown;
+  }
+
+  export const archiver = (): IArchiver =>
+    require(path.join(LIB, "internal", "NestiaEditorArchiver.js"))
+      .NestiaEditorArchiver;
+
+  export const composer = (): IComposer =>
+    require(path.join(LIB, "internal", "NestiaEditorComposer.js"))
+      .NestiaEditorComposer;
+
+  /** Minimal OpenAPI 3.1 document accepted by the migrate application. */
+  export const document = (): object => ({
+    openapi: "3.1.0",
+    info: { title: "Editor Test", version: "1.0.0" },
+    paths: {
+      "/bbs/articles": {
+        get: {
+          responses: {
+            "200": {
+              description: "List up articles.",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "array",
+                    items: { $ref: "#/components/schemas/IBbsArticle" },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    components: {
+      schemas: {
+        IBbsArticle: {
+          type: "object",
+          properties: {
+            id: { type: "string" },
+            title: { type: "string" },
+            body: { type: "string" },
+          },
+          required: ["id", "title", "body"],
+        },
+      },
+    },
+  });
+}

--- a/tests/test-editor/tsconfig.json
+++ b/tests/test-editor/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../config/tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+  },
+  "include": ["src"],
+}


### PR DESCRIPTION
## Summary

StackBlitz cannot run migrate-generated projects on the @next line: they build through `ttsc`, whose TypeScript compiler is a **native Go binary that WebContainers cannot execute** — and the generated output is now a pnpm monorepo besides. The editor's StackBlitz embed/open therefore always hands users a dead project.

Per maintainer direction, the editor is repurposed as a **zip downloader**:
- New `NestiaEditorArchiver` (fflate) packs the composed file map and triggers a browser download.
- `NestiaEditorIframe`'s final step becomes a download button (file count + archive name); `NestiaEditorUploader`'s action button downloads directly.
- `@stackblitz/sdk` dependency removed; `fflate` added.

## Verification

New `tests/test-editor` workspace (registered as the `editor` CI matrix leg), function-per-file:
1. `test_editor_archiver_zip_roundtrip` — nested paths + non-ASCII content round-trip byte-identically; archive name sanitization.
2. `test_editor_composer_nest_monorepo_files` — nest mode emits `pnpm-workspace.yaml` + `packages/backend/nestia.config.ts` + `packages/api/src/**`, zero legacy `src/api/` keys.
3. `test_editor_composer_sdk_zip_entries` — sdk mode survives the full compose→pack→unzip path.

Local run: 3/3 green (971 ms) including `@nestia/editor` `build:lib`.

## Known gaps

- The actual anchor-click download is browser-only; its logic is a thin wrapper over the tested `pack()`.
- `packages/editor/package.json` may need a trivial merge after #1533 (both touch it in different sections).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYUZ95W7jUpsnTgxBmamAH