### PR TITLE
Remove unused Rollup catalog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ pnpm test
 - Respect package boundaries. The Go binary lives in `@nestia/core` and is shared with `@nestia/sdk`. Don't fork a second native binary, and don't reintroduce a TypeScript-side transformer.
 - Preserve the contract. Decorator names, `INestiaConfig` options, CLI flags, and the generated SDK / Swagger / e2e surface are public. Renaming or removing any of them is a deliberate, separate change.
 - Keep detection general. The native transform must locate target packages through their resolved package root, not through workspace-only path substrings — substring matching breaks the moment a consumer installs from npm. The same rule applies to generators: no hard-coded DTO, controller, or feature names.
-- Use the workspace catalogs. `pnpm-workspace.yaml` pins versions under `catalog:typescript`, `catalog:samchon`, `catalog:nestjs`, `catalog:utils`, `catalog:rollup`. New dependencies go through the matching catalog; internal references use `workspace:^`.
+- Use the workspace catalogs. `pnpm-workspace.yaml` pins versions under `catalog:typescript`, `catalog:samchon`, `catalog:nestjs`, `catalog:utils`, `catalog:modelcontextprotocol`, and `catalog:rolldown`. New dependencies go through the matching catalog; internal references use `workspace:^`.
 - Migration templates ship without interactive dependencies — generated projects stay non-interactive.
 - When public behavior changes, update the matching guide page under `website/src/content/docs/**` in the same change.
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,10 +35,3 @@ catalogs:
     '@modelcontextprotocol/sdk': ^1.18.0
   rolldown:
     rolldown: ^1.1.5
-  rollup:
-    rollup: ^4.56.0
-    rollup-plugin-node-externals: ^8.1.2
-    '@rollup/plugin-commonjs': ^29.0.0
-    '@rollup/plugin-esm-shim': ^0.1.8
-    '@rollup/plugin-node-resolve': ^16.0.3
-    '@rollup/plugin-terser': ^0.4.4


### PR DESCRIPTION
## Summary

- remove the unused Rollup dependency catalog after the Rolldown migration
- update `AGENTS.md` so the workspace catalog map points to `catalog:rolldown`

## Impact

Nestia packages no longer advertise or pin direct Rollup tooling. The Rollup package that remains in `pnpm-lock.yaml` is an intentional transitive dependency of Vite in `@nestia/editor`; the setup guide also continues documenting the supported `@ttsc/unplugin/rollup` adapter.

## Validation

- `pnpm install --lockfile-only --frozen-lockfile`
- `git diff --check`
- repository-wide direct Rollup reference scan
- `pnpm why rollup -r`