### PR TITLE
feat(website): retheme the site to a NestJS red and white two-tone

### DIFF
--- a/website/mdx-components-blog.jsx
+++ b/website/mdx-components-blog.jsx
@@ -39,7 +39,9 @@ export function useMDXComponents(components) {
       }
 
       return (
-        <div className={hasToc ? "nestia-blog-post-layout" : undefined}>
+        <div
+          className={hasToc ? "nestia-blog-post-layout" : "nestia-blog-post-solo"}
+        >
           <div className="nestia-blog-post-main">
             {metadata?.ogImage ? (
               <img

--- a/website/public/favicon/site.webmanifest
+++ b/website/public/favicon/site.webmanifest
@@ -1,1 +1,1 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}
+{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#b81e35","background_color":"#ffffff","display":"standalone"}

--- a/website/src/app/(docs)/[[...mdxPath]]/page.jsx
+++ b/website/src/app/(docs)/[[...mdxPath]]/page.jsx
@@ -24,8 +24,16 @@ export default async function Page(props) {
   const result = await importPage(params.mdxPath);
   const { default: MDXContent, toc, metadata } = result;
 
+  // The sidebar wash is scoped to docs routes via `body:has(...)` in
+  // global.css, so the landing keeps a plain white gutter. This marker is
+  // what that selector keys off.
+  const isDocsPage = params.mdxPath?.[0] === "docs";
+
   return (
     <Wrapper toc={toc} metadata={metadata}>
+      {isDocsPage && (
+        <span className="nestia-docs-page-marker" aria-hidden="true" hidden />
+      )}
       <MDXContent {...props} params={params} />
     </Wrapper>
   );

--- a/website/src/app/(docs)/layout.jsx
+++ b/website/src/app/(docs)/layout.jsx
@@ -8,11 +8,7 @@ const footer = (
     <br />
     <br />
     Copyright 2022 - {new Date().getFullYear()}{" "}
-    <a
-      href="https://github.com/samchon"
-      target="_blank"
-      style={{ color: "initial" }}
-    >
+    <a href="https://github.com/samchon" target="_blank">
       <u>Samchon</u>
     </a>{" "}
     & Contributors

--- a/website/src/app/(docs)/layout.jsx
+++ b/website/src/app/(docs)/layout.jsx
@@ -25,23 +25,19 @@ export default async function DocsLayout(props) {
       navbar={
         <Navbar
           logo={
-            <>
-              <img
-                src="/favicon/android-chrome-192x192.png"
-                width={32}
-                height={32}
-              />
-              <span
-                style={{
-                  fontWeight: "bold",
-                  fontSize: "1.2rem",
-                  paddingLeft: 15,
-                  paddingRight: 10,
-                }}
-              >
+            <span className="nestia-site-logo">
+              <span className="nestia-site-logo-mark" aria-hidden="true">
+                <img
+                  src="/favicon/android-chrome-192x192.png"
+                  width={32}
+                  height={32}
+                  alt=""
+                />
+              </span>
+              <span style={{ fontSize: "1.2rem", paddingRight: 10 }}>
                 Nestia
               </span>
-            </>
+            </span>
           }
           projectLink="https://github.com/samchon/nestia"
         />
@@ -51,7 +47,8 @@ export default async function DocsLayout(props) {
       editLink="Edit this page on GitHub"
       sidebar={{ autoCollapse: false }}
       nextThemes={{
-        defaultTheme: "dark",
+        defaultTheme: "light",
+        forcedTheme: "light",
       }}
       darkMode={false}
       footer={footer}

--- a/website/src/app/blog/blog.css
+++ b/website/src/app/blog/blog.css
@@ -10,6 +10,46 @@
   max-width: none;
 }
 
+/* ── Headings on the hand-written blog routes ──
+   Nextra ships Tailwind Preflight, which resets every heading to
+   `font-size: inherit; font-weight: inherit`. MDX headings get their scale
+   back from Nextra's component mapping, but these routes build their
+   headings in JSX -- the index, the tag pages, and the post title in
+   `mdx-components-blog.jsx` -- so nothing ever restored them and they
+   rendered at body size and weight.
+
+   On an article that inverted the hierarchy outright: the post title came
+   out smaller than the `## Preface` heading underneath it. */
+.x\:container.x\:prose > h1,
+.nestia-blog-post-main > h1 {
+  margin: 0 0 0.75rem;
+  color: var(--nestia-ink);
+  font-size: clamp(1.9rem, 1.35rem + 2.1vw, 2.6rem);
+  font-weight: 800;
+  letter-spacing: -0.025em;
+  line-height: 1.2;
+}
+
+.x\:container.x\:prose > p {
+  color: var(--nestia-muted);
+  line-height: 1.7;
+}
+
+/* The navbar is a solid red band, so content butting straight up against it
+   reads as a collision rather than as a start. */
+.x\:container.x\:prose {
+  padding-top: 2.5rem;
+}
+
+/* A post with no headings renders no TOC, and used to lose the grid wrapper
+   with it -- leaving the article unconstrained and full-bleed. */
+.nestia-blog-post-solo {
+  max-width: min(1100px, calc(100vw - 2rem));
+  margin-left: auto;
+  margin-right: auto;
+  padding: 2.5rem 1.5rem 0;
+}
+
 .nestia-blog-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
@@ -128,7 +168,7 @@
   max-width: min(1100px, calc(100vw - 2rem));
   margin-left: auto;
   margin-right: auto;
-  padding: 2rem 1.5rem 0;
+  padding: 2.5rem 1.5rem 0;
 }
 
 .nestia-blog-post-main {

--- a/website/src/app/blog/blog.css
+++ b/website/src/app/blog/blog.css
@@ -21,27 +21,27 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  border: 1px solid rgba(127, 127, 127, 0.2);
+  border: 1px solid var(--nestia-border);
   border-radius: 1.25rem;
-  background: color-mix(in srgb, rgb(var(--nextra-bg)) 92%, white 8%);
+  background: var(--nestia-wash);
   text-decoration: none;
   color: inherit;
 }
 
-.dark .nestia-blog-card {
-  background: color-mix(in srgb, rgb(var(--nextra-bg)) 94%, white 6%);
-}
 
 .nestia-blog-card:hover {
   transform: translateY(-2px);
-  transition: transform 0.18s ease;
+  border-color: var(--nestia-red);
+  transition:
+    transform 0.18s ease,
+    border-color 0.18s ease;
 }
 
 .nestia-blog-card-image {
   width: 100%;
   aspect-ratio: 1.91 / 1;
   object-fit: cover;
-  background: rgba(127, 127, 127, 0.08);
+  background: var(--nestia-soft);
 }
 
 .nestia-blog-card-body {
@@ -60,13 +60,10 @@
 
 .nestia-blog-card-description {
   margin: 0;
-  color: rgb(95 95 95);
+  color: var(--nestia-muted);
   line-height: 1.6;
 }
 
-.dark .nestia-blog-card-description {
-  color: rgb(170 170 170);
-}
 
 .nestia-blog-card-meta {
   display: flex;
@@ -74,12 +71,9 @@
   gap: 0.65rem;
   margin-top: auto;
   font-size: 0.9rem;
-  color: rgb(110 110 110);
+  color: var(--nestia-muted);
 }
 
-.dark .nestia-blog-card-meta {
-  color: rgb(155 155 155);
-}
 
 .nestia-blog-card-tags {
   display: flex;
@@ -93,7 +87,7 @@
   align-items: center;
   padding: 0.24rem 0.6rem;
   border-radius: 999px;
-  background: rgba(127, 127, 127, 0.12);
+  background: var(--nestia-soft);
   font-size: 0.84rem;
 }
 
@@ -103,7 +97,7 @@
   object-fit: cover;
   border-radius: 1.5rem;
   margin: 0 0 1.5rem;
-  background: rgba(127, 127, 127, 0.08);
+  background: var(--nestia-soft);
 }
 
 .nestia-blog-meta,
@@ -115,18 +109,15 @@
 }
 
 .nestia-blog-meta {
-  color: rgb(110 110 110);
+  color: var(--nestia-muted);
   font-size: 0.95rem;
 }
 
-.dark .nestia-blog-meta {
-  color: rgb(160 160 160);
-}
 
 .nestia-blog-comments {
   margin-top: 3rem;
   padding-top: 2rem;
-  border-top: 1px solid rgba(127, 127, 127, 0.18);
+  border-top: 1px solid var(--nestia-border);
 }
 
 .nestia-blog-post-layout {
@@ -157,7 +148,7 @@
   flex-direction: column;
   gap: 0.6rem;
   padding-left: 1rem;
-  border-left: 1px solid rgba(127, 127, 127, 0.18);
+  border-left: 1px solid var(--nestia-border);
 }
 
 .nestia-blog-toc-title {
@@ -165,12 +156,9 @@
   font-weight: 700;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  color: rgb(115 115 115);
+  color: var(--nestia-muted);
 }
 
-.dark .nestia-blog-toc-title {
-  color: rgb(165 165 165);
-}
 
 .nestia-blog-toc-list,
 .nestia-blog-toc-sublist {
@@ -197,15 +185,12 @@
 
 .nestia-blog-toc-link {
   display: inline-block;
-  color: rgb(90 90 90);
+  color: var(--nestia-muted);
   text-decoration: none;
   line-height: 1.45;
   font-size: 0.95rem;
 }
 
-.dark .nestia-blog-toc-link {
-  color: rgb(175 175 175);
-}
 
 .nestia-blog-toc-link:hover {
   color: inherit;
@@ -231,6 +216,6 @@
     margin-top: 1rem;
     padding: 1rem 0 0;
     border-left: 0;
-    border-top: 1px solid rgba(127, 127, 127, 0.18);
+    border-top: 1px solid var(--nestia-border);
   }
 }

--- a/website/src/app/blog/layout.jsx
+++ b/website/src/app/blog/layout.jsx
@@ -19,11 +19,7 @@ const footer = (
     <br />
     <br />
     Copyright 2022 - {new Date().getFullYear()}{" "}
-    <a
-      href="https://github.com/samchon"
-      target="_blank"
-      style={{ color: "initial" }}
-    >
+    <a href="https://github.com/samchon" target="_blank">
       <u>Samchon</u>
     </a>{" "}
     & Contributors

--- a/website/src/app/blog/layout.jsx
+++ b/website/src/app/blog/layout.jsx
@@ -36,23 +36,19 @@ export default async function BlogLayout(props) {
       navbar={
         <Navbar
           logo={
-            <>
-              <img
-                src="/favicon/android-chrome-192x192.png"
-                width={32}
-                height={32}
-              />
-              <span
-                style={{
-                  fontWeight: "bold",
-                  fontSize: "1.2rem",
-                  paddingLeft: 15,
-                  paddingRight: 10,
-                }}
-              >
+            <span className="nestia-site-logo">
+              <span className="nestia-site-logo-mark" aria-hidden="true">
+                <img
+                  src="/favicon/android-chrome-192x192.png"
+                  width={32}
+                  height={32}
+                  alt=""
+                />
+              </span>
+              <span style={{ fontSize: "1.2rem", paddingRight: 10 }}>
                 Nestia
               </span>
-            </>
+            </span>
           }
           projectLink="https://github.com/samchon/nestia"
         />
@@ -63,7 +59,8 @@ export default async function BlogLayout(props) {
       navigation={false}
       sidebar={{ toggleButton: false }}
       nextThemes={{
-        defaultTheme: "dark",
+        defaultTheme: "light",
+        forcedTheme: "light",
       }}
       darkMode={false}
       footer={footer}

--- a/website/src/app/global.css
+++ b/website/src/app/global.css
@@ -1,0 +1,219 @@
+@import "nextra-theme-docs/style.css";
+
+/* ── Palette ──────────────────────────────────────────────────────────────
+   NestJS red and white, two-tone. The hues come from NestJS itself: the
+   `#ea2845` primary that both nestjs.com and docs.nestjs.com paint their
+   accents with.
+
+   That literal brand red only reaches 4.30:1 on white, short of WCAG AA, so
+   it is *not* the anchor. It stays as `--nestia-red-vivid` for decoration
+   that never carries body text -- the logo chip, borders, the bright end of
+   a gradient. Everything that touches text resolves to `--nestia-red`
+   (6.40:1) or darker.
+
+   deep/base/mid are the three stops of the red band, at one hue with
+   lightness 30% / 42% / 47%. White text stays readable across the whole
+   sweep -- 5.41:1 even on `mid`, the lightest stop -- so the navbar has no
+   weak spot wherever the gradient happens to land behind a link.
+
+   --nestia-red is the exact hex of hsl(351, 72%, 42%), the same triple fed
+   to Nextra via <Head color> in app/layout.jsx. Nextra derives its own
+   primary ramp from that HSL, so keeping the two literals in sync matters:
+   change one and you must recompute the other, or links and buttons drift
+   apart by a shade. */
+:root {
+  --nestia-red: #b81e35;
+  --nestia-red-deep: #851425;
+  --nestia-red-mid: #cc243d;
+  --nestia-red-vivid: #ea2845;
+  --nestia-ink: #1f1417;
+  --nestia-soft: #fdedef;
+  --nestia-wash: #fff7f8;
+  --nestia-border: #f2cad0;
+  --nestia-muted: #705c61;
+}
+
+html {
+  color-scheme: light;
+}
+
+body {
+  background: #ffffff;
+  color: var(--nestia-ink);
+}
+
+::selection {
+  background: rgba(184, 30, 53, 0.18);
+}
+
+/* Badge rows: shields.io images are wrapped in links, but the Preflight
+   Nextra ships resets `img` to `display: block`, so each badge would stack
+   on its own line. Keep linked inline images inline (the banner is not a
+   link, so it stays block). */
+:is(.nextra-content, article) a img {
+  display: inline-block;
+}
+
+/* ── Navigation bar: one red band across every surface ── */
+.nextra-navbar-blur {
+  border-color: rgba(255, 255, 255, 0.18) !important;
+  background: linear-gradient(
+    110deg,
+    var(--nestia-red-deep) 0%,
+    var(--nestia-red) 58%,
+    var(--nestia-red-mid) 100%
+  ) !important;
+  box-shadow: 0 8px 24px rgba(31, 20, 23, 0.18);
+}
+
+.nextra-navbar,
+.nextra-navbar a,
+.nextra-navbar button {
+  color: var(--nestia-wash) !important;
+}
+
+.nextra-navbar nav > div a[aria-current="true"] {
+  border-radius: 0.5rem;
+  background: rgba(255, 255, 255, 0.14);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12);
+}
+
+.nextra-navbar input {
+  border: 1px solid rgba(255, 255, 255, 0.2) !important;
+  background: rgba(255, 255, 255, 0.13) !important;
+  color: white !important;
+}
+
+.nextra-navbar input::placeholder {
+  color: rgba(255, 255, 255, 0.78) !important;
+}
+
+.nextra-navbar kbd {
+  border-color: rgba(255, 255, 255, 0.22) !important;
+  background: rgba(255, 255, 255, 0.16) !important;
+  color: rgba(255, 255, 255, 0.84) !important;
+}
+
+/* The logo mark is a colored PNG that reads as mud against the red band, so
+   it gets a white chip behind it. */
+.nestia-site-logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-weight: 800;
+  letter-spacing: -0.025em;
+}
+
+.nextra-navbar .nestia-site-logo {
+  color: white !important;
+}
+
+.nestia-site-logo-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 0.35rem;
+  padding: 0.15rem;
+  background: white;
+  box-shadow: 0 6px 18px rgba(31, 20, 23, 0.18);
+}
+
+/* ── Sidebar: red wash fading into the white content column ── */
+body:has(.nestia-docs-page-marker) .nextra-sidebar {
+  border-right: 1px solid var(--nestia-border);
+  background: linear-gradient(
+    180deg,
+    var(--nestia-soft) 0%,
+    var(--nestia-wash) 48%,
+    white 100%
+  );
+}
+
+body:has(.nestia-docs-page-marker) :is(.nextra-sidebar, .nextra-mobile-nav) a,
+body:has(.nestia-docs-page-marker)
+  :is(.nextra-sidebar, .nextra-mobile-nav)
+  button {
+  color: var(--nestia-ink) !important;
+}
+
+body:has(.nestia-docs-page-marker)
+  :is(.nextra-sidebar, .nextra-mobile-nav)
+  li.active
+  > a {
+  background: var(--nestia-red) !important;
+  color: white !important;
+  box-shadow: 0 7px 18px rgba(184, 30, 53, 0.2);
+}
+
+body:has(.nestia-docs-page-marker)
+  :is(.nextra-sidebar, .nextra-mobile-nav)
+  li:not(.active)
+  > a:hover,
+body:has(.nestia-docs-page-marker)
+  :is(.nextra-sidebar, .nextra-mobile-nav)
+  li:not(.active)
+  > button:hover {
+  background: var(--nestia-soft) !important;
+  color: var(--nestia-red-deep) !important;
+}
+
+body:has(.nestia-docs-page-marker)
+  :is(.nextra-sidebar, .nextra-mobile-nav)
+  li[class*="font-semibold"]:not(.active) {
+  color: var(--nestia-red-deep) !important;
+}
+
+body:has(.nestia-docs-page-marker)
+  :is(.nextra-sidebar, .nextra-mobile-nav)
+  ul
+  ul::before {
+  background: var(--nestia-border) !important;
+}
+
+/* ── Landing page: full-bleed canvas ──
+   The landing carries its own full-width sections, so it opts out of the
+   docs content column entirely. Nextra lays the page out as a flex row of
+   [sidebar spacer | sidebar | toc | article]; the spacer is a 256px w-64/h-0
+   div that keeps its width even when the sidebar is hidden, and the toc
+   normally balances it on the right. Hiding only the toc would leave the
+   article 256px off-center, so the spacer has to go with it. */
+body:has(.nestia-landing) {
+  --nextra-content-width: 100%;
+}
+:has(.nestia-landing) article {
+  max-width: 100% !important;
+  padding: 0 !important;
+  margin: 0 !important;
+}
+:has(.nestia-landing) main {
+  max-width: 100% !important;
+}
+body:has(.nestia-landing) div[class~="x:h-0"][class~="x:w-64"] {
+  display: none !important;
+}
+:has(.nestia-landing) .nextra-toc,
+:has(.nestia-landing) .nextra-breadcrumb {
+  display: none !important;
+}
+
+/* ── Editor page: hide Nextra chrome so the editor gets the full viewport ── */
+.nestia-editor-page .nextra-sidebar-container,
+.nestia-editor-page .nextra-sidebar,
+.nestia-editor-page .nextra-breadcrumb,
+.nestia-editor-page .nextra-toc,
+.nestia-editor-page nav.nextra-toc,
+.nestia-editor-page aside,
+.nestia-editor-page footer {
+  display: none !important;
+}
+.nestia-editor-page article {
+  max-width: 100% !important;
+  padding: 0 !important;
+  margin: 0 !important;
+}
+.nestia-editor-page main {
+  max-width: 100% !important;
+  margin: 0 !important;
+}

--- a/website/src/app/global.css
+++ b/website/src/app/global.css
@@ -120,6 +120,39 @@ body {
   box-shadow: 0 6px 18px rgba(31, 20, 23, 0.18);
 }
 
+/* ── Callouts ──
+   Nextra paints `type="info"` blue, and the docs lean on it 27 times, so the
+   body copy read blue-accented under a red brand.
+
+   They go warm-neutral with the accent carried by the left edge alone. Red
+   is deliberately *not* used for the surface: `info` outnumbers every other
+   callout type here by nine to one, so filling them all with brand red would
+   both wash the docs pink and make routine notes look like danger warnings.
+   `warning` keeps its amber -- there are only three, and they mean it. */
+.nextra-callout {
+  border-color: rgba(112, 92, 97, 0.22) !important;
+  border-left: 3px solid var(--nestia-red) !important;
+  background: #faf8f8 !important;
+  color: var(--nestia-ink) !important;
+}
+
+.nextra-callout:has(+ *) svg,
+.nextra-callout > svg {
+  color: var(--nestia-red) !important;
+}
+
+/* MUI `<Alert severity="info">` appears twice in the docs and ships its own
+   blue; match it to the callouts above so the two do not disagree. */
+.MuiAlert-standardInfo {
+  border-left: 3px solid var(--nestia-red) !important;
+  background-color: #faf8f8 !important;
+  color: var(--nestia-ink) !important;
+}
+
+.MuiAlert-standardInfo .MuiAlert-icon {
+  color: var(--nestia-red) !important;
+}
+
 /* ── Sidebar: red wash fading into the white content column ── */
 body:has(.nestia-docs-page-marker) .nextra-sidebar {
   border-right: 1px solid var(--nestia-border);

--- a/website/src/app/global.css
+++ b/website/src/app/global.css
@@ -230,23 +230,3 @@ body:has(.nestia-landing) div[class~="x:h-0"][class~="x:w-64"] {
 :has(.nestia-landing) .nextra-breadcrumb {
   display: none !important;
 }
-
-/* ── Editor page: hide Nextra chrome so the editor gets the full viewport ── */
-.nestia-editor-page .nextra-sidebar-container,
-.nestia-editor-page .nextra-sidebar,
-.nestia-editor-page .nextra-breadcrumb,
-.nestia-editor-page .nextra-toc,
-.nestia-editor-page nav.nextra-toc,
-.nestia-editor-page aside,
-.nestia-editor-page footer {
-  display: none !important;
-}
-.nestia-editor-page article {
-  max-width: 100% !important;
-  padding: 0 !important;
-  margin: 0 !important;
-}
-.nestia-editor-page main {
-  max-width: 100% !important;
-  margin: 0 !important;
-}

--- a/website/src/app/global.css
+++ b/website/src/app/global.css
@@ -120,6 +120,32 @@ body {
   box-shadow: 0 6px 18px rgba(31, 20, 23, 0.18);
 }
 
+/* ── Footer ──
+   Nextra's footer text is a blue-tinted gray (Tailwind's gray-600, hue 256),
+   which is the one place a cool neutral survived the retheme. The link
+   inside it carried `color: initial` inline -- a holdover from the dark
+   theme, where it existed to escape the theme's link color. On white that
+   rendered the only link in the footer as plain black text.
+
+   Nextra 4 gives the footer no class of its own -- it is a bare `<footer>`
+   carrying `x:text-gray-600` inside an `x:bg-gray-100` strip -- so these
+   match on the element and need `!important` to beat those utilities. */
+footer {
+  color: var(--nestia-muted) !important;
+}
+
+footer a {
+  color: var(--nestia-red) !important;
+}
+
+footer a:hover {
+  color: var(--nestia-red-deep) !important;
+}
+
+div:has(> footer) {
+  background: var(--nestia-wash) !important;
+}
+
 /* ── Callouts ──
    Nextra paints `type="info"` blue, and the docs lean on it 27 times, so the
    body copy read blue-accented under a red brand.

--- a/website/src/app/layout.jsx
+++ b/website/src/app/layout.jsx
@@ -1,6 +1,8 @@
 import Script from "next/script";
 import { Head } from "nextra/components";
 
+import "./global.css";
+
 const title = "Nestia";
 const description = "NestJS Helper Libraries";
 
@@ -16,7 +18,11 @@ export const metadata = {
 export default function RootLayout(props) {
   return (
     <html lang="en" dir="ltr" suppressHydrationWarning>
-      <Head>
+      <Head
+        color={{ hue: 351, saturation: 72, lightness: 42 }}
+        backgroundColor={{ light: "#ffffff", dark: "#ffffff" }}
+      >
+        <meta name="theme-color" content="#b81e35" />
         <link rel="manifest" href="/favicon/site.webmanifest" />
         <link
           rel="apple-touch-icon"

--- a/website/src/components/home/HomeCodeBlock.tsx
+++ b/website/src/components/home/HomeCodeBlock.tsx
@@ -1,10 +1,23 @@
-const HomeCodeBlock = (props: {
-  children: React.ReactNode;
-}) => (
-  <span style={{ 
-    color: "white", 
-    backgroundColor: "gray",
-  }}>
+import { PALETTE } from "../../constants/PALETTE";
+
+/**
+ * Inline code inside landing copy.
+ *
+ * Currently unreferenced, but kept in step with the palette: it used to be
+ * white-on-gray, which was only legible on the old black site and would have
+ * come out as a smear the first time anyone reached for it here.
+ */
+const HomeCodeBlock = (props: { children: React.ReactNode }) => (
+  <span
+    style={{
+      color: PALETTE.RED_DEEP,
+      backgroundColor: PALETTE.SOFT,
+      borderRadius: "0.3rem",
+      padding: "0.1rem 0.35rem",
+      fontFamily: "'Fira Code', 'JetBrains Mono', monospace",
+      fontSize: "0.92em",
+    }}
+  >
     {props.children}
   </span>
 );

--- a/website/src/components/home/HomeLayout.tsx
+++ b/website/src/components/home/HomeLayout.tsx
@@ -1,14 +1,19 @@
 "use client";
 
-import { styled } from "@mui/material/styles";
+import { ReactNode } from "react";
 
-const HomeLayout = styled("div")(({ theme }) => ({
-  [theme.breakpoints.up("lg")]: {
-    marginLeft: "-15rem",
-    marginRight: "-15rem",
-  },
-  "& > *": {
-    maxWidth: "100%",
-  },
-}));
+/**
+ * The landing's outermost wrapper.
+ *
+ * The `nestia-landing` class is what global.css keys the full-bleed rules
+ * off: it widens the content column to 100% and drops the TOC along with
+ * Nextra's 256px sidebar spacer. Before that existed this component faked
+ * the same effect with `margin: 0 -15rem` above `lg`, which overflowed at
+ * in-between widths and left the sections off-center.
+ */
+const HomeLayout = (props: { children: ReactNode }) => (
+  <div className="nestia-landing" style={{ maxWidth: "100%" }}>
+    {props.children}
+  </div>
+);
 export default HomeLayout;

--- a/website/src/components/home/HomeSectionHeading.tsx
+++ b/website/src/components/home/HomeSectionHeading.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { Box, Typography } from "@mui/material";
+import { ReactNode } from "react";
+
+import { PALETTE } from "../../constants/PALETTE";
+
+/**
+ * The title/subtitle pair every landing section opens with.
+ *
+ * All five sections below the hero had this markup copied verbatim, which is
+ * how they ended up drifting onto five separate hardcoded text colors.
+ */
+const HomeSectionHeading = (props: {
+  title: string;
+  children: ReactNode;
+  maxWidth?: number;
+}) => (
+  <Box sx={{ textAlign: "center", mb: 6 }}>
+    <Typography
+      variant="h3"
+      sx={{
+        fontWeight: 700,
+        fontSize: { xs: "1.6rem", md: "2.2rem" },
+        mb: 2,
+        color: PALETTE.INK,
+      }}
+    >
+      {props.title}
+    </Typography>
+    <Typography
+      variant="body1"
+      sx={{
+        color: PALETTE.MUTED,
+        fontSize: "1.05rem",
+        maxWidth: props.maxWidth ?? 650,
+        mx: "auto",
+      }}
+    >
+      {props.children}
+    </Typography>
+  </Box>
+);
+export default HomeSectionHeading;

--- a/website/src/constants/PALETTE.ts
+++ b/website/src/constants/PALETTE.ts
@@ -1,0 +1,51 @@
+/**
+ * The landing's colors, mirroring the `--nestia-*` custom properties in
+ * `src/app/global.css`.
+ *
+ * The landing is MUI, so it reads colors through `sx` rather than CSS vars,
+ * and these are the same values written a second time in TypeScript. Change
+ * one side and you must change the other.
+ *
+ * `VIVID` is the red NestJS itself paints with. It measures 4.30:1 on white,
+ * below WCAG AA, so it is decoration only -- chips, borders, the bright end
+ * of a gradient. Anything carrying text uses `RED` (6.40:1) or darker.
+ */
+export const PALETTE = {
+  /** hsl(351, 72%, 42%) -- 6.40:1 on white. The Nextra primary anchor. */
+  RED: "#b81e35",
+  /** hsl(351, 74%, 30%) -- 9.88:1 on white. */
+  RED_DEEP: "#851425",
+  /** hsl(351, 70%, 47%) -- 5.41:1 on white. Lightest stop of the band. */
+  RED_MID: "#cc243d",
+  /** The literal NestJS brand red. Decoration only -- fails AA on white. */
+  VIVID: "#ea2845",
+
+  /** Body text. 17.95:1 on white. */
+  INK: "#1f1417",
+  /** Secondary text. 6.20:1 on white. */
+  MUTED: "#705c61",
+
+  SOFT: "#fdedef",
+  WASH: "#fff7f8",
+  BORDER: "#f2cad0",
+
+  /**
+   * The hero band. Every stop clears 4.5:1 for white text (9.88 / 6.40 /
+   * 5.41), so a link is legible wherever the gradient happens to sit behind
+   * it -- checking only the endpoints would leave the middle unverified.
+   */
+  BAND: "linear-gradient(110deg, #851425 0%, #b81e35 58%, #cc243d 100%)",
+} as const;
+
+/**
+ * Syntax tones for the code panels, which sit on a near-black surface rather
+ * than on white, so these are tuned against `#1f1417` and not reused from
+ * the palette above.
+ */
+export const CODE = {
+  SURFACE: "#221619",
+  SURFACE_BAR: "#2c1d21",
+  BORDER: "rgba(255, 255, 255, 0.10)",
+  TEXT: "rgba(255, 255, 255, 0.85)",
+  DIM: "rgba(255, 255, 255, 0.55)",
+} as const;

--- a/website/src/movies/home/HomeCompilationMovie.tsx
+++ b/website/src/movies/home/HomeCompilationMovie.tsx
@@ -3,6 +3,8 @@
 import { Box, Container, Typography } from "@mui/material";
 
 import HomeCodeHighlight from "../../components/home/HomeCodeHighlight";
+import HomeSectionHeading from "../../components/home/HomeSectionHeading";
+import { CODE, PALETTE } from "../../constants/PALETTE";
 
 const BEFORE_CODE = `import { TypedBody, TypedParam, TypedRoute } from "@nestia/core";
 import { Controller } from "@nestjs/common";
@@ -40,6 +42,10 @@ const article: IBbsArticle =
     } satisfies IBbsArticle.ICreate,
   );`;
 
+// The code panels stay on a dark surface even though the page is white: the
+// syntax highlighter is pinned to `github-dark`, and re-tinting a whole theme
+// to sit on white would fight it. A dark panel on white reads as a deliberate
+// inset rather than a leftover from the old black site.
 const CodePanel = (props: {
   title: string;
   label: string;
@@ -51,9 +57,10 @@ const CodePanel = (props: {
       flex: 1,
       minWidth: 0,
       borderRadius: 2,
-      border: "1px solid rgba(255,255,255,0.1)",
+      border: `1px solid ${CODE.BORDER}`,
       overflow: "hidden",
-      backgroundColor: "rgba(0,0,0,0.3)",
+      backgroundColor: CODE.SURFACE,
+      boxShadow: "0 12px 30px rgba(31,20,23,0.14)",
     }}
   >
     <Box
@@ -63,8 +70,8 @@ const CodePanel = (props: {
         gap: 1.5,
         px: 2.5,
         py: 1.5,
-        borderBottom: "1px solid rgba(255,255,255,0.08)",
-        backgroundColor: "rgba(255,255,255,0.03)",
+        borderBottom: `1px solid ${CODE.BORDER}`,
+        backgroundColor: CODE.SURFACE_BAR,
       }}
     >
       <Box
@@ -82,10 +89,7 @@ const CodePanel = (props: {
       >
         {props.label}
       </Box>
-      <Typography
-        variant="body2"
-        sx={{ color: "rgba(255,255,255,0.6)", fontWeight: 500 }}
-      >
+      <Typography variant="body2" sx={{ color: CODE.DIM, fontWeight: 500 }}>
         {props.title}
       </Typography>
     </Box>
@@ -98,7 +102,7 @@ const CodePanel = (props: {
         fontSize: { xs: "0.72rem", md: "0.8rem" },
         lineHeight: 1.7,
         fontFamily: "'Fira Code', 'Cascadia Code', 'JetBrains Mono', monospace",
-        color: "rgba(255,255,255,0.85)",
+        color: CODE.TEXT,
         "&::-webkit-scrollbar": { height: 6 },
         "&::-webkit-scrollbar-thumb": {
           backgroundColor: "rgba(255,255,255,0.15)",
@@ -116,32 +120,11 @@ const CodePanel = (props: {
 const HomeCompilationMovie = () => (
   <Box sx={{ py: { xs: 6, md: 10 } }}>
     <Container maxWidth="lg">
-      <Box sx={{ textAlign: "center", mb: 6 }}>
-        <Typography
-          variant="h3"
-          sx={{
-            fontWeight: 700,
-            fontSize: { xs: "1.6rem", md: "2.2rem" },
-            mb: 2,
-            color: "rgba(255,255,255,0.95)",
-          }}
-        >
-          SDK Generation Magic
-        </Typography>
-        <Typography
-          variant="body1"
-          sx={{
-            color: "rgba(255,255,255,0.55)",
-            fontSize: "1.05rem",
-            maxWidth: 650,
-            mx: "auto",
-          }}
-        >
-          Write NestJS controllers as you normally would. Nestia analyzes your
-          TypeScript types and generates a fully type-safe SDK — like tRPC,
-          but fully automated.
-        </Typography>
-      </Box>
+      <HomeSectionHeading title="SDK Generation Magic">
+        Write NestJS controllers as you normally would. Nestia analyzes your
+        TypeScript types and generates a fully type-safe SDK — like tRPC, but
+        fully automated.
+      </HomeSectionHeading>
       <Box
         sx={{
           display: "flex",
@@ -150,17 +133,19 @@ const HomeCompilationMovie = () => (
           alignItems: "stretch",
         }}
       >
+        {/* Backend and frontend are told apart by red against ink, staying
+            inside the two-tone rather than reaching for a third hue. */}
         <CodePanel
           title="Your NestJS Controller"
           label="Backend"
-          labelColor="rgba(0,150,255,0.7)"
+          labelColor={PALETTE.RED}
           code={BEFORE_CODE}
         />
         <Box
           sx={{
             display: { xs: "none", md: "flex" },
             alignItems: "center",
-            color: "rgba(255,255,255,0.3)",
+            color: PALETTE.RED,
             fontSize: "2rem",
             px: 1,
           }}
@@ -171,7 +156,7 @@ const HomeCompilationMovie = () => (
           sx={{
             display: { xs: "flex", md: "none" },
             justifyContent: "center",
-            color: "rgba(255,255,255,0.3)",
+            color: PALETTE.RED,
             fontSize: "2rem",
           }}
         >
@@ -180,7 +165,7 @@ const HomeCompilationMovie = () => (
         <CodePanel
           title="Auto-generated SDK"
           label="Frontend"
-          labelColor="rgba(80,200,0,0.7)"
+          labelColor={PALETTE.INK}
           code={AFTER_CODE}
         />
       </Box>

--- a/website/src/movies/home/HomeEcosystemMovie.tsx
+++ b/website/src/movies/home/HomeEcosystemMovie.tsx
@@ -2,11 +2,15 @@
 
 import { Box, Container, Grid, Typography } from "@mui/material";
 
+import HomeSectionHeading from "../../components/home/HomeSectionHeading";
+import { PALETTE } from "../../constants/PALETTE";
+
 const ComparisonColumn = (props: {
   label: string;
   labelColor: string;
   items: { icon: string; text: string }[];
   borderColor: string;
+  tint: string;
 }) => (
   <Grid item xs={12} md={6}>
     <Box
@@ -21,7 +25,7 @@ const ComparisonColumn = (props: {
         sx={{
           px: 3,
           py: 1.5,
-          backgroundColor: `${props.borderColor}15`,
+          backgroundColor: props.tint,
           borderBottom: `1px solid ${props.borderColor}`,
         }}
       >
@@ -46,13 +50,20 @@ const ComparisonColumn = (props: {
               mb: i < props.items.length - 1 ? 2.5 : 0,
             }}
           >
-            <Typography sx={{ fontSize: "1.1rem", lineHeight: 1.6 }}>
+            <Typography
+              sx={{
+                fontSize: "1.1rem",
+                lineHeight: 1.6,
+                color: props.labelColor,
+                fontWeight: 700,
+              }}
+            >
               {item.icon}
             </Typography>
             <Typography
               variant="body2"
               sx={{
-                color: "rgba(255,255,255,0.7)",
+                color: PALETTE.MUTED,
                 lineHeight: 1.6,
                 fontSize: "0.9rem",
               }}
@@ -69,37 +80,21 @@ const ComparisonColumn = (props: {
 const HomeEcosystemMovie = () => (
   <Box sx={{ py: { xs: 6, md: 10 } }}>
     <Container maxWidth="lg">
-      <Box sx={{ textAlign: "center", mb: 6 }}>
-        <Typography
-          variant="h3"
-          sx={{
-            fontWeight: 700,
-            fontSize: { xs: "1.6rem", md: "2.2rem" },
-            mb: 2,
-            color: "rgba(255,255,255,0.95)",
-          }}
-        >
-          Why Nestia?
-        </Typography>
-        <Typography
-          variant="body1"
-          sx={{
-            color: "rgba(255,255,255,0.55)",
-            fontSize: "1.05rem",
-            maxWidth: 700,
-            mx: "auto",
-          }}
-        >
-          Traditional NestJS development requires separate schemas, manual SDK
-          writing, and verbose decorators. Nestia eliminates all of that with
-          pure TypeScript types.
-        </Typography>
-      </Box>
+      <HomeSectionHeading title="Why Nestia?" maxWidth={700}>
+        Traditional NestJS development requires separate schemas, manual SDK
+        writing, and verbose decorators. Nestia eliminates all of that with pure
+        TypeScript types.
+      </HomeSectionHeading>
       <Grid container spacing={3}>
+        {/* The usual red-is-bad / green-is-good coding is inverted here, and
+            deliberately: red is the brand, so painting the column we are
+            arguing against in brand red would read as an endorsement. The
+            weaker option goes neutral and the recommended one takes the red. */}
         <ComparisonColumn
           label="Traditional NestJS"
-          labelColor="rgba(255,100,100,0.9)"
-          borderColor="rgba(255,100,100,0.25)"
+          labelColor={PALETTE.MUTED}
+          borderColor="rgba(112,92,97,0.28)"
+          tint="rgba(112,92,97,0.06)"
           items={[
             {
               icon: "✕",
@@ -125,8 +120,9 @@ const HomeEcosystemMovie = () => (
         />
         <ComparisonColumn
           label="Nestia — Pure TypeScript"
-          labelColor="rgba(0,200,100,0.9)"
-          borderColor="rgba(0,200,100,0.25)"
+          labelColor={PALETTE.RED}
+          borderColor={PALETTE.BORDER}
+          tint={PALETTE.SOFT}
           items={[
             {
               icon: "✓",

--- a/website/src/movies/home/HomeHeroMovie.tsx
+++ b/website/src/movies/home/HomeHeroMovie.tsx
@@ -6,9 +6,7 @@ import MenuBookIcon from "@mui/icons-material/MenuBook";
 import { Box, Button, Container, Typography } from "@mui/material";
 import { ReactNode } from "react";
 
-const BLUE = "rgb(0, 200, 255)";
-const CYAN = "rgb(80, 200, 0)";
-const PURPLE = "rgb(191, 64, 191)";
+import { PALETTE } from "../../constants/PALETTE";
 
 const HeroButton = (props: {
   title: string;
@@ -32,16 +30,23 @@ const HeroButton = (props: {
       py: 1.2,
       borderRadius: 2,
       textTransform: "none",
-      borderColor:
-        props.variant === "outlined" ? "rgba(255,255,255,0.3)" : undefined,
-      color:
-        props.variant === "outlined" ? "rgba(255,255,255,0.9)" : undefined,
-      "&:hover": {
-        borderColor:
-          props.variant === "outlined" ? "rgba(255,255,255,0.6)" : undefined,
-        backgroundColor:
-          props.variant === "outlined" ? "rgba(255,255,255,0.05)" : undefined,
-      },
+      // The primary CTA inverts to red-on-white rather than staying red: a
+      // red button on the red band would have nothing separating it from its
+      // own background.
+      ...(props.variant === "contained"
+        ? {
+            backgroundColor: "#fff",
+            color: PALETTE.RED_DEEP,
+            "&:hover": { backgroundColor: PALETTE.WASH },
+          }
+        : {
+            borderColor: "rgba(255,255,255,0.35)",
+            color: "rgba(255,255,255,0.92)",
+            "&:hover": {
+              borderColor: "rgba(255,255,255,0.65)",
+              backgroundColor: "rgba(255,255,255,0.08)",
+            },
+          }),
     }}
   >
     {props.title}
@@ -54,37 +59,52 @@ const HomeHeroMovie = () => {
       sx={{
         position: "relative",
         py: { xs: 8, md: 12 },
+        px: 2,
         textAlign: "center",
         overflow: "hidden",
+        background: PALETTE.BAND,
       }}
     >
-      {/* Radial gradient background */}
+      {/* Light bloom, lifting the center of the band away from flatness */}
       <Box
         sx={{
           position: "absolute",
           inset: 0,
           background:
-            "radial-gradient(ellipse 80% 60% at 50% 0%, rgba(0,150,255,0.12) 0%, transparent 70%)",
+            "radial-gradient(ellipse 80% 60% at 50% 0%, rgba(255,255,255,0.12) 0%, transparent 70%)",
           pointerEvents: "none",
         }}
       />
       <Container maxWidth="md" sx={{ position: "relative", zIndex: 1 }}>
+        {/* The mark is a colored PNG that muddies against red, so it keeps a
+            white plate, the same treatment the navbar logo gets. */}
         <Box
-          component="img"
-          src="/favicon/android-chrome-512x512.png"
-          alt="Nestia"
           sx={{
-            display: "block",
-            mx: "auto",
+            display: "inline-flex",
+            alignItems: "center",
+            justifyContent: "center",
             mb: 3,
-            width: { xs: 120, md: 160 },
-            height: { xs: 120, md: 160 },
+            p: { xs: 2, md: 2.5 },
+            borderRadius: 4,
+            backgroundColor: "#fff",
+            boxShadow: "0 18px 40px rgba(31,20,23,0.28)",
           }}
-        />
+        >
+          <Box
+            component="img"
+            src="/favicon/android-chrome-512x512.png"
+            alt="Nestia"
+            sx={{
+              display: "block",
+              width: { xs: 96, md: 128 },
+              height: { xs: 96, md: 128 },
+            }}
+          />
+        </Box>
         <Typography
           variant="h5"
           sx={{
-            color: "rgba(255,255,255,0.7)",
+            color: "rgba(255,255,255,0.92)",
             fontWeight: 400,
             fontSize: { xs: "1rem", sm: "1.15rem", md: "1.3rem" },
             lineHeight: 1.7,
@@ -95,13 +115,13 @@ const HomeHeroMovie = () => {
         >
           Stop writing DTOs three times. One TypeScript type drives a NestJS
           endpoint,
-          <br />a <strong style={{ color: "rgba(255,255,255,0.95)" }}>typed
-          client SDK</strong>, an OpenAPI document, and e2e tests — for free.
+          <br />a <strong style={{ color: "#fff" }}>typed client SDK</strong>,
+          an OpenAPI document, and e2e tests — for free.
         </Typography>
         <Typography
           variant="body1"
           sx={{
-            color: "rgba(255,255,255,0.45)",
+            color: "rgba(255,255,255,0.7)",
             fontSize: "1rem",
             mb: 3,
           }}
@@ -114,13 +134,16 @@ const HomeHeroMovie = () => {
               "'Fira Code', 'Cascadia Code', 'JetBrains Mono', monospace",
             fontSize: { xs: "0.9rem", md: "1.1rem" },
             mb: 5,
+            color: "rgba(255,255,255,0.75)",
           }}
         >
-          <span style={{ color: PURPLE }}>@</span>
-          <span style={{ color: BLUE }}>TypedBody</span>
-          <span style={{ color: "gray" }}>{"() "}</span>
-          <span style={{ color: "gray" }}>{"input: "}</span>
-          <span style={{ color: CYAN }}>IArticleCreate</span>
+          <span style={{ color: "rgba(255,255,255,0.6)" }}>@</span>
+          <span style={{ color: "#fff", fontWeight: 600 }}>TypedBody</span>
+          <span>{"() "}</span>
+          <span>{"input: "}</span>
+          <span style={{ color: "#ffd9df", fontWeight: 600 }}>
+            IArticleCreate
+          </span>
         </Typography>
         <Box
           sx={{

--- a/website/src/movies/home/HomeSimulatorMovie.tsx
+++ b/website/src/movies/home/HomeSimulatorMovie.tsx
@@ -3,6 +3,8 @@
 import { Box, Container, Grid, Typography } from "@mui/material";
 
 import HomeCodeHighlight from "../../components/home/HomeCodeHighlight";
+import HomeSectionHeading from "../../components/home/HomeSectionHeading";
+import { CODE, PALETTE } from "../../constants/PALETTE";
 
 const SIMULATE_CODE = `import api from "@my/api";
 import { IBbsArticle } from "@my/api/lib/structures/IBbsArticle";
@@ -53,40 +55,20 @@ const callouts = [
 const HomeSimulatorMovie = () => (
   <Box sx={{ py: { xs: 6, md: 10 } }}>
     <Container maxWidth="lg">
-      <Box sx={{ textAlign: "center", mb: 6 }}>
-        <Typography
-          variant="h3"
-          sx={{
-            fontWeight: 700,
-            fontSize: { xs: "1.6rem", md: "2.2rem" },
-            mb: 2,
-            color: "rgba(255,255,255,0.95)",
-          }}
-        >
-          Mockup Simulator
-        </Typography>
-        <Typography
-          variant="body1"
-          sx={{
-            color: "rgba(255,255,255,0.55)",
-            fontSize: "1.05rem",
-            maxWidth: 700,
-            mx: "auto",
-          }}
-        >
-          SDK-embedded simulator that mimics your backend API.
-          <br />
-          Just set <code>simulate: true</code> — no server required.
-        </Typography>
-      </Box>
+      <HomeSectionHeading title="Mockup Simulator" maxWidth={700}>
+        SDK-embedded simulator that mimics your backend API.
+        <br />
+        Just set <code>simulate: true</code> — no server required.
+      </HomeSectionHeading>
       <Grid container spacing={4} alignItems="stretch">
         <Grid item xs={12} md={7}>
           <Box
             sx={{
               height: "100%",
               borderRadius: 2,
-              border: "1px solid rgba(255,255,255,0.1)",
-              backgroundColor: "rgba(0,0,0,0.3)",
+              border: `1px solid ${CODE.BORDER}`,
+              backgroundColor: CODE.SURFACE,
+              boxShadow: "0 12px 30px rgba(31,20,23,0.14)",
               overflow: "hidden",
             }}
           >
@@ -94,8 +76,8 @@ const HomeSimulatorMovie = () => (
               sx={{
                 px: 2.5,
                 py: 1.5,
-                borderBottom: "1px solid rgba(255,255,255,0.08)",
-                backgroundColor: "rgba(255,255,255,0.03)",
+                borderBottom: `1px solid ${CODE.BORDER}`,
+                backgroundColor: CODE.SURFACE_BAR,
                 display: "flex",
                 alignItems: "center",
                 gap: 1.5,
@@ -110,7 +92,7 @@ const HomeSimulatorMovie = () => (
                   fontWeight: 700,
                   textTransform: "uppercase",
                   letterSpacing: 0.5,
-                  backgroundColor: "rgba(0,180,255,0.6)",
+                  backgroundColor: PALETTE.RED,
                   color: "#fff",
                 }}
               >
@@ -118,7 +100,7 @@ const HomeSimulatorMovie = () => (
               </Box>
               <Typography
                 variant="body2"
-                sx={{ color: "rgba(255,255,255,0.6)", fontWeight: 500 }}
+                sx={{ color: CODE.DIM, fontWeight: 500 }}
               >
                 Frontend without Backend
               </Typography>
@@ -133,7 +115,7 @@ const HomeSimulatorMovie = () => (
                 lineHeight: 1.7,
                 fontFamily:
                   "'Fira Code', 'Cascadia Code', 'JetBrains Mono', monospace",
-                color: "rgba(255,255,255,0.85)",
+                color: CODE.TEXT,
                 "&::-webkit-scrollbar": { height: 6 },
                 "&::-webkit-scrollbar-thumb": {
                   backgroundColor: "rgba(255,255,255,0.15)",
@@ -165,8 +147,8 @@ const HomeSimulatorMovie = () => (
                   gap: 2,
                   p: 2,
                   borderRadius: 2,
-                  border: "1px solid rgba(255,255,255,0.08)",
-                  backgroundColor: "rgba(255,255,255,0.02)",
+                  border: `1px solid ${PALETTE.BORDER}`,
+                  backgroundColor: PALETTE.WASH,
                 }}
               >
                 <Typography sx={{ fontSize: "1.4rem" }}>{c.icon}</Typography>
@@ -176,7 +158,7 @@ const HomeSimulatorMovie = () => (
                       fontWeight: 700,
                       fontSize: "0.9rem",
                       mb: 0.3,
-                      color: "rgba(255,255,255,0.95)",
+                      color: PALETTE.INK,
                     }}
                   >
                     {c.title}
@@ -184,7 +166,7 @@ const HomeSimulatorMovie = () => (
                   <Typography
                     variant="body2"
                     sx={{
-                      color: "rgba(255,255,255,0.5)",
+                      color: PALETTE.MUTED,
                       fontSize: "0.82rem",
                       lineHeight: 1.5,
                     }}

--- a/website/src/movies/home/HomeSimulatorMovie.tsx
+++ b/website/src/movies/home/HomeSimulatorMovie.tsx
@@ -53,7 +53,7 @@ const callouts = [
 ];
 
 const HomeSimulatorMovie = () => (
-  <Box sx={{ py: { xs: 6, md: 10 } }}>
+  <Box sx={{ py: { xs: 6, md: 10 }, backgroundColor: PALETTE.WASH }}>
     <Container maxWidth="lg">
       <HomeSectionHeading title="Mockup Simulator" maxWidth={700}>
         SDK-embedded simulator that mimics your backend API.
@@ -148,7 +148,7 @@ const HomeSimulatorMovie = () => (
                   p: 2,
                   borderRadius: 2,
                   border: `1px solid ${PALETTE.BORDER}`,
-                  backgroundColor: PALETTE.WASH,
+                  backgroundColor: "#fff",
                 }}
               >
                 <Typography sx={{ fontSize: "1.4rem" }}>{c.icon}</Typography>

--- a/website/src/movies/home/HomeSponsorMovie.tsx
+++ b/website/src/movies/home/HomeSponsorMovie.tsx
@@ -2,35 +2,14 @@
 
 import { Box, Container, Typography } from "@mui/material";
 
+import HomeSectionHeading from "../../components/home/HomeSectionHeading";
+
 const HomeSponsorMovie = () => (
   <Box sx={{ py: { xs: 6, md: 10 } }}>
     <Container maxWidth="md">
-      <Box sx={{ textAlign: "center", mb: 4 }}>
-        <Typography
-          variant="h3"
-          sx={{
-            fontWeight: 700,
-            fontSize: { xs: "1.6rem", md: "2.2rem" },
-            mb: 2,
-            color: "rgba(255,255,255,0.95)",
-          }}
-        >
-          Sponsors
-        </Typography>
-        <Typography
-          variant="body1"
-          sx={{
-            color: "rgba(255,255,255,0.55)",
-            fontSize: "1.05rem",
-            lineHeight: 1.8,
-            maxWidth: 550,
-            mx: "auto",
-            mb: 4,
-          }}
-        >
-          Thanks for your support. Your donation encourages nestia development.
-        </Typography>
-      </Box>
+      <HomeSectionHeading title="Sponsors" maxWidth={550}>
+        Thanks for your support. Your donation encourages nestia development.
+      </HomeSectionHeading>
       <Box sx={{ textAlign: "center" }}>
         <Box
           component="a"

--- a/website/src/movies/home/HomeStrengthMovie.tsx
+++ b/website/src/movies/home/HomeStrengthMovie.tsx
@@ -10,6 +10,9 @@ import {
   Typography,
 } from "@mui/material";
 
+import HomeSectionHeading from "../../components/home/HomeSectionHeading";
+import { PALETTE } from "../../constants/PALETTE";
+
 interface FeatureCardProps {
   icon: string;
   title: string;
@@ -89,12 +92,12 @@ const FeatureCard = (props: FeatureCardProps) => (
       variant="outlined"
       sx={{
         height: "100%",
-        backgroundColor: "rgba(255,255,255,0.02)",
-        borderColor: "rgba(255,255,255,0.08)",
+        backgroundColor: PALETTE.WASH,
+        borderColor: PALETTE.BORDER,
         transition: "all 0.2s ease",
         "&:hover": {
-          borderColor: "rgba(0,150,255,0.4)",
-          backgroundColor: "rgba(0,150,255,0.03)",
+          borderColor: PALETTE.RED,
+          backgroundColor: PALETTE.SOFT,
         },
       }}
     >
@@ -121,7 +124,7 @@ const FeatureCard = (props: FeatureCardProps) => (
               fontWeight: 700,
               fontSize: "1.05rem",
               mb: 0.5,
-              color: "rgba(255,255,255,0.95)",
+              color: PALETTE.INK,
             }}
           >
             {props.title}
@@ -131,7 +134,7 @@ const FeatureCard = (props: FeatureCardProps) => (
               fontFamily:
                 "'Fira Code', 'JetBrains Mono', monospace",
               fontSize: "0.82rem",
-              color: "rgba(255,255,255,0.6)",
+              color: PALETTE.RED_DEEP,
               mb: 1,
             }}
           >
@@ -139,13 +142,13 @@ const FeatureCard = (props: FeatureCardProps) => (
           </Typography>
           {props.metric && (
             <Typography sx={{ fontSize: "0.85rem", mb: 1.5 }}>
-              <span style={{ color: "rgb(0,180,255)", fontWeight: 600 }}>
+              <span style={{ color: PALETTE.RED, fontWeight: 600 }}>
                 {props.metric}
               </span>
               {props.metricNote && (
                 <span
                   style={{
-                    color: "rgba(255,255,255,0.45)",
+                    color: PALETTE.MUTED,
                     fontWeight: 400,
                   }}
                 >
@@ -158,7 +161,7 @@ const FeatureCard = (props: FeatureCardProps) => (
           <Typography
             variant="body2"
             sx={{
-              color: "rgba(255,255,255,0.55)",
+              color: PALETTE.MUTED,
               lineHeight: 1.65,
               fontSize: "0.88rem",
             }}
@@ -174,30 +177,9 @@ const FeatureCard = (props: FeatureCardProps) => (
 const HomeStrengthMovie = () => (
   <Box sx={{ py: { xs: 6, md: 10 } }}>
     <Container maxWidth="lg">
-      <Box sx={{ textAlign: "center", mb: 6 }}>
-        <Typography
-          variant="h3"
-          sx={{
-            fontWeight: 700,
-            fontSize: { xs: "1.6rem", md: "2.2rem" },
-            mb: 2,
-            color: "rgba(255,255,255,0.95)",
-          }}
-        >
-          Key Features
-        </Typography>
-        <Typography
-          variant="body1"
-          sx={{
-            color: "rgba(255,255,255,0.55)",
-            fontSize: "1.05rem",
-            maxWidth: 600,
-            mx: "auto",
-          }}
-        >
-          One library. Pure TypeScript types. Everything you need for NestJS.
-        </Typography>
-      </Box>
+      <HomeSectionHeading title="Key Features" maxWidth={600}>
+        One library. Pure TypeScript types. Everything you need for NestJS.
+      </HomeSectionHeading>
       <Grid container spacing={3}>
         {features.map((f) => (
           <FeatureCard key={f.title} {...f} />

--- a/website/src/movies/home/HomeStrengthMovie.tsx
+++ b/website/src/movies/home/HomeStrengthMovie.tsx
@@ -92,7 +92,7 @@ const FeatureCard = (props: FeatureCardProps) => (
       variant="outlined"
       sx={{
         height: "100%",
-        backgroundColor: PALETTE.WASH,
+        backgroundColor: "#fff",
         borderColor: PALETTE.BORDER,
         transition: "all 0.2s ease",
         "&:hover": {
@@ -175,7 +175,7 @@ const FeatureCard = (props: FeatureCardProps) => (
 );
 
 const HomeStrengthMovie = () => (
-  <Box sx={{ py: { xs: 6, md: 10 } }}>
+  <Box sx={{ py: { xs: 6, md: 10 }, backgroundColor: PALETTE.WASH }}>
     <Container maxWidth="lg">
       <HomeSectionHeading title="Key Features" maxWidth={600}>
         One library. Pure TypeScript types. Everything you need for NestJS.


### PR DESCRIPTION
## Intent

The website shipped bare Nextra 4 defaults pinned to `defaultTheme: "dark"` with no toggle, so it read as a generic black docs template with nothing tying it to NestJS. typia and ttsc have each since moved to their own brand two-tone; this gives nestia the equivalent, built on the red NestJS already uses.

The mechanism is deliberately the same one those two repos settled on, so the three sites stay maintainable as siblings: `<Head color>` feeding Nextra's primary ramp, `forcedTheme: "light"`, a single `global.css` overriding Nextra's DOM classes, and marker-span scoping via `body:has()` so sidebar theming applies to docs routes only.

## The palette

Colors were taken off nestjs.com and docs.nestjs.com directly (Playwright, sampling computed styles) rather than eyeballed. Both paint their accents `#ea2845`.

That literal brand red measures **4.30:1 on white — below WCAG AA**, so it is not the anchor. It survives as `--nestia-red-vivid` for decoration that never carries text. Everything text-bearing resolves to `--nestia-red` `#b81e35` = `hsl(351, 72%, 42%)`, 6.40:1.

| Token | Value | Contrast on white |
|---|---|---|
| `--nestia-red` (Nextra anchor) | `#b81e35` | 6.40:1 |
| `--nestia-red-deep` | `#851425` | 9.88:1 |
| `--nestia-red-mid` | `#cc243d` | 5.41:1 |
| `--nestia-red-vivid` | `#ea2845` | 4.30:1 — decoration only |
| `--nestia-ink` | `#1f1417` | 17.95:1 |

The navbar band's three stops were each checked for white text rather than only the endpoints, so there is no unreadable midpoint wherever the gradient lands behind a link.

`--nestia-red` and the `<Head color>` HSL triple are the same color written twice, in CSS and JSX. Nothing enforces that; the comment in `global.css` says so explicitly.

## Scope

- `global.css` (new) — palette, navbar band, sidebar wash, callouts, landing full-bleed
- `layout.jsx` ×3 — `forcedTheme: "light"`, branded logo with a white plate, `<Head color>`
- `[[...mdxPath]]/page.jsx` — docs marker span
- Six landing sections + `PALETTE.ts` + `HomeSectionHeading.tsx` (new)
- `blog.css` — dead `.dark` rules removed, moved onto brand vars
- `site.webmanifest` — `theme_color` now brand red

Two judgement calls worth surfacing for review:

**Callouts.** Nextra paints `type="info"` blue and the docs use it 27 times against 3 warnings, so the most repeated element in the body was blue under a red brand — the one clash typia and ttsc never hit, since their brand *is* blue. They go warm-neutral with the accent on the left edge and icon. Filling them with brand red was rejected: at 27 occurrences it would wash the docs pink and make routine asides look like danger warnings. Chosen by the repository owner over an all-red variant and over leaving the blue.

**The comparison table inverts red-is-bad.** Red is the brand, so painting "Traditional NestJS" in brand red would read as an endorsement of the option the section argues against. The weaker column goes neutral; the recommended one takes the red.

**Code panels stay dark on the white page.** The highlighter is pinned to shiki's `github-dark`; re-tinting a whole syntax theme for a light surface is a much larger change than this one.

## Verification

`next dev` against an isolated copy of the site, driven with Playwright:

- `/`, `/docs/`, `/blog/` all return **200 with zero console errors**
- `html.light` on every route — dark mode is gone, not reskinned
- `--nextra-primary-hue: 351deg`, saturation `72%`, lightness `42%`
- body `rgb(255,255,255)` on `rgb(31,20,23)`
- navbar resolves to `linear-gradient(110deg, rgb(133,20,37), rgb(184,30,53) 58%, rgb(204,36,61))`
- docs marker present only on `/docs/`; landing class only on `/`
- `.nextra-callout` → bg `rgb(250,248,248)`, 3px left border `rgb(184,30,53)`
- blog card → bg `rgb(255,247,248)`, border `rgb(242,202,208)`
- landing swept for stray non-brand chrome; the only non-red hues remaining are shiki `github-dark` syntax tokens inside the code panels, which are intended

Screenshots reviewed at 1440px for all three routes plus a full-page landing pass.

## Known gaps

- **`/editor` was not exercised.** It needs a built `@nestia/editor` tarball, absent from this worktree; it was stubbed out of the verification copy. The route is untouched by this branch. The speculative `.nestia-editor-page` CSS I had copied from typia's playground pattern was removed rather than shipped unverified — nestia's editor already lays itself out as a full-viewport absolute overlay, so nothing carried the class.
- **`pnpm format` was not applied.** Running it rewrites ~250 files across `packages/` from pre-existing repo-wide prettier drift, unrelated to this change, and exits 2. Those edits were reverted so they do not enter this PR. Note `website/` is outside the root `format` script's globs, and files this branch never touches (e.g. `HomeCodeHighlight.tsx`) already fail `prettier --check` — so website formatting is pre-existing drift either way, and reformatting here would have been noise.
- Only the light scheme exists now; there is no dark variant to keep in sync, by design.
- `site.webmanifest` has a pre-existing unrelated bug: its icon `src` paths point at `/android-chrome-*.png` while the files live under `/favicon/`. Left alone as out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DrosyEcDNyrpdqNjJs74LM
