### PR TITLE
docs(agents): sync agent instructions with typia and ttsc

### DIFF
--- a/.agents/skills/benchmark/SKILL.md
+++ b/.agents/skills/benchmark/SKILL.md
@@ -38,3 +38,18 @@ Benchmark prose follows AGENTS.md `## Maintenance` and the documentation skill.
 Every result table reported in chat or committed to the result archive must be preserved for the active pull request. When the user has authorized PR updates under the pull-request skill, maintain one sticky comment beginning with `<!-- nestia-benchmark-results -->`; update it with the latest table, report paths, and known invalid or missing categories.
 
 If no pull request exists or no update is authorized, keep the result in the final report and mark the comment as pending. Post it only after the user creates or authorizes updating the pull request.
+
+## Campaign Batching
+
+When benchmark findings produce multiple implementation issues, load the issue-campaign skill and use its planning and claim procedure unchanged for the dependency DAG, claim freeze, and official GitHub `createdAt`-to-`mergedAt` duration: [Plan One Cycle Pull Request](../issue-campaign/development.md#plan-one-cycle-pull-request) for a solo campaign, or [Plan And Claim A Pull Request Wave](../multi-agent/issue-campaign.md#plan-and-claim-a-pull-request-wave) with its batch admission test, merge pressure, and grouping and split ledger when the user explicitly requested a parallel campaign. This benchmark skill continues to own workload, fixture, measurement, result, and publication integrity; do not redefine pull-request batching here.
+
+## Campaign Cleanup
+
+When a benchmark campaign uses a disposable worktree or an isolated measurement root, finish cleanup before marking that assignment complete. Preserve the committed result archive and compact command evidence, but remove every disposable worktree and its assigned mutable roots: `GOCACHE`, `GOTMPDIR`, `TTSC_CACHE_DIR`, generated-program scratch tree, dependency install tree, and temporary consumer or report staging tree. Go temporary assets are never reusable campaign evidence.
+
+1. Record the measured commit, command, result paths and hashes, environment, and any retained published result archive.
+2. Confirm the worktree and mutable roots contain no unreported source or result artifact.
+3. Remove the mutable roots and, for an assigned disposable worktree, run `git worktree remove --force <path>` for its exact path.
+4. Verify every removed root and, when applicable, worktree path no longer exists, run `git worktree prune`, delete the associated disposable local topic branch when one was created, and confirm no worktree registration remains.
+
+If a measurement is abandoned or invalid, retain only the diagnostic record needed to explain it; remove its worktree and Go temporary assets by the same procedure.

--- a/.agents/skills/development/SKILL.md
+++ b/.agents/skills/development/SKILL.md
@@ -26,6 +26,7 @@ These four are never acceptable; choosing any one means the approach is already 
 
 ## Work Rules
 
+- Choose the principled course. Time, difficulty, and the breadth of consequences require more careful analysis and validation; they never justify a shortcut, leaving a verified consequence unaddressed, or a weaker acceptance standard.
 - Match existing conventions. Before adding a file, function, or test, open a nearby peer in the same package and mirror its naming, location, and code style; don't create parallel structures.
 - Respect package boundaries. The Go binary lives in `@nestia/core` and is shared with `@nestia/sdk` as a linked contributor. Don't fork a second native binary, don't give `@nestia/sdk` its own `ttsc` plugin entry, and don't reintroduce a TypeScript-side transformer.
 - Keep detection general and installation-safe. The native transform must locate target packages through their resolved package root, as `packages/core/src/transform.ts` does with `createRequire(...).resolve("@nestia/core/package.json")`. Workspace-only path substrings break the moment a consumer installs from npm. The same rule applies to the generators: no hard-coded DTO, controller, or feature names.
@@ -34,7 +35,7 @@ These four are never acceptable; choosing any one means the approach is already 
 - Migration templates ship without interactive dependencies — generated projects stay non-interactive.
 - Keep local outputs local. Do not commit `.env`, the tarballs under `deploy/tarballs/`, or any tree the harnesses regenerate (`tests/test-migrate/.generated`, the generated halves of `tests/test-sdk/features/*/src/api`, `tests/test-benchmark/BENCHMARK.md`).
 - When public behavior changes, update the matching page under `website/src/content/docs/**` in the same change. Follow `.agents/skills/documentation/SKILL.md`.
-- Run `pnpm format` before every ordinary commit and stage the result; never commit unformatted output. The script currently stops short of `tests/**/*.ts` for the reason recorded in `.agents/skills/project/SKILL.md`, so format a test-workspace change explicitly. The sole exception is an active issue campaign: campaign issue pull requests must not run the repository-wide formatter, and the issue-campaign skill performs one dedicated Post-Campaign Cleanup format pull request after the campaign ends.
+- Run `pnpm format` before every ordinary commit and stage the result; never commit unformatted output. The script currently stops short of `tests/**/*.ts` for the reason recorded in `.agents/skills/project/SKILL.md`, so format a test-workspace change explicitly. A solo issue campaign formats its unified cycle pull request. The sole exception is an explicit multi-agent campaign implementation batch: those pull requests must not run the repository-wide formatter, and that procedure performs one dedicated Post-Campaign Cleanup format pull request after the campaign ends.
 
 ## Consequence Analysis
 
@@ -140,6 +141,6 @@ A `test-sdk` e2e feature gets three silent attempts and then one final attempt w
 
 Treat tests, fixtures, snapshots, CI workflows, package wiring, dependencies, core algorithms, generated baselines, and benchmark results as part of the specification. Changing them requires an explicit user request or a clear product reason, and the final report must call it out.
 
-When Go source under `packages/*/native` changes, bump the package version in the same commit or pull request. The npm packages ship their `native/` trees and ttsc compiles that source on first use; without a new package version, npm consumers keep installing the previous native source tree. Ordinary version numbers otherwise belong to the release flow — see `.agents/skills/pull-request/SKILL.md`.
+Go source under `packages/*/native` must ship under a version newer than the latest published packages, because the npm packages ship their `native/` trees and ttsc compiles that source on first use; without a new package version, npm consumers keep installing the previous native source tree. Assign that version once in a maintainer-owned release change, where `bumpp -r` moves all eight packages together; multiple unreleased native changes belong to the same future release instead of consuming one patch number each. Issue implementation pull requests never change package versions. A maintainer-owned release change may begin only after campaign completion, or after the user explicitly suspends the campaign and lifts the freeze, and it uses the version the user assigned. See `.agents/skills/pull-request/SKILL.md`.
 
 For mechanical ports, migrations, or broad rewrites, preserve the existing algorithm and public behavior in reviewable slices. Prefer a concrete exemplar over abstract instructions, and inspect the diff before trusting a green test run.

--- a/.agents/skills/discussion/SKILL.md
+++ b/.agents/skills/discussion/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: discussion
-description: Runs structured multi-agent discussions for open-ended nestia topics. Use only when the user explicitly asks for Discussion or a team debate with transcripts and conclusions; do not use for Self-Review, Review Cycle, research review, or issue discovery.
+description: Runs structured multi-agent discussions for open-ended nestia topics. Use only when the user explicitly asks for Discussion or a team debate with transcripts and conclusions; do not use for Self-Review, a solo or multi-agent review, research review, or issue discovery.
 ---
 
 # Discussion

--- a/.agents/skills/documentation/SKILL.md
+++ b/.agents/skills/documentation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: documentation
-description: Defines README and website-guide structure, audience, prose formatting, and voice for nestia. Use before writing, modifying, renaming, or moving repository documentation.
+description: Defines README, website-guide, and agent-instruction structure, audience, prose formatting, and voice for nestia. Use before writing, modifying, renaming, or moving repository documentation.
 ---
 
 # Documentation
@@ -30,6 +30,19 @@ Every docs folder and `src/content/` itself carries a `_meta.ts` that Nextra rea
 When emitted code is the point, pair the TypeScript source with the generated SDK, Swagger, or e2e output in side-by-side tabs so the reader sees what the transform produces. Back performance claims with a specific `benchmark/results/**` figure instead of an adjective.
 
 Building the website is not a plain `next build`. Follow the prerequisites in `.agents/skills/development/SKILL.md`: the site depends on `../deploy/tarballs/editor.tgz` and `../deploy/tarballs/migrate.tgz`, so root `pnpm run package:tgz` must run first, and `prebuild` additionally rebuilds `@nestia/migrate` and `@nestia/editor` and runs TypeDoc over five packages into `website/public/api`.
+
+## Agent Instructions
+
+`AGENTS.md` and `SKILL.md` files are operational documents for humans and agents. Keep only the product-wide contract in `AGENTS.md`, the always-applicable procedure in `SKILL.md`, and conditional detail in a linked sibling document.
+
+Concise and clear means:
+
+- Include the context needed to act correctly. Do not make the reader infer prerequisites, exceptions, reasons, or stop conditions merely to shorten the document.
+- State each rule at its owning document and link to it elsewhere. Remove repeated wording, not necessary substance.
+- Give each paragraph one job. Separate purpose, rule, rationale, procedure, and consequence when combining them obscures the action.
+- Use structure to compress meaning: ordered lists for procedures, bullets for choices and checks, tables for repeated mappings, and code blocks for exact commands.
+- State the rule before its reason. Use a negative rule only when it prevents a named failure the affirmative rule does not already exclude.
+- Link to website guides, READMEs, or source comments instead of paraphrasing them.
 
 ## Prose line breaks
 

--- a/.agents/skills/issue-campaign/SKILL.md
+++ b/.agents/skills/issue-campaign/SKILL.md
@@ -1,13 +1,19 @@
 ---
 name: issue-campaign
-description: Defines repository-wide issue discovery, lead-vetted issue publication, per-push CI cancellation during implementation waves, and post-campaign cleanup for nestia. Use when the user asks for a broad audit, many issue candidates, or a repeated issue-to-pull-request campaign; do not use for one already-defined issue or an ordinary pull request.
+description: "Defines the default solo repository-wide issue campaign for nestia: exhaustive discovery, lead-vetted issue publication, one unified CI-validated implementation pull request per cycle, solo Self-Review, and repeated rediscovery until a full clean round. Use for broad audits, many issue candidates, or repeated issue-to-pull-request campaigns unless the user explicitly requests parallel or multi-agent execution; do not use for one already-defined issue or an ordinary pull request."
 ---
 
 # Issue Campaign
 
-An issue campaign is a repeatable sequence of exhaustive discovery, issue publication, implementation pull requests, and final repository cleanup. The user's requested phase boundary controls how far to proceed; do not infer permission to publish issues, push branches, open pull requests, or merge from an audit-only request.
+An issue campaign is a repeatable solo sequence of exhaustive discovery, issue publication, one unified implementation pull request, and renewed discovery. The main agent owns every phase and spawns no subagent other than the read-only commit early-warning pass that [development.md](development.md#implement-and-write-tests) defines.
 
-Read the project, development, and review skills before starting, and require every discovery-agent brief to do the same. Use the review skill's Issue Discovery Rounds; issue discovery is independent review, not discussion.
+Use the [multi-agent skill](../multi-agent/SKILL.md) and its issue-campaign procedure instead only when the user explicitly asks for a parallel or multi-agent issue campaign.
+
+The user's requested phase boundary controls how far to proceed; do not infer permission to publish issues, push branches, open pull requests, or merge from an audit-only request.
+
+Choose the principled course throughout the campaign. Its scale, duration, and consequence surface require stronger evidence, deeper consequence analysis, and complete verification; they never justify accepting an unverified candidate, a shortcut, or a weaker implementation or review standard.
+
+Read the project, development, and review skills before starting. Use the review skill's Solo Issue Discovery Rounds; issue discovery is independent review, not discussion. Read [development.md](development.md) in full only when implementation is authorized.
 
 ## Campaign Knowledge Base
 
@@ -15,32 +21,52 @@ Create `.wiki/<campaign>/` with a short filesystem-safe campaign name. Preserve 
 
 Keep concise, current Markdown documents for:
 
-- repository provenance, architecture, and ownership boundaries;
+- repository provenance, architecture, validation ownership, and product boundaries;
 - experiments, reproductions, dogfooding, and related issue or pull-request history;
-- candidates, evidence, dependencies, and lead disposition;
-- implementation pull requests, local verification, and cancelled campaign-run records when those phases apply.
+- every raw candidate, its evidence, dependencies, and final disposition, including combinations, splits, rejections, and deferrals with the evidence supporting each decision;
+- the published-issue DAG, internal implementation order, the unified cycle pull request, CI and Self-Review iterations, external blockers, and official GitHub `createdAt`-to-`mergedAt` cycle timing;
+- the exact commit, dependency lock, provisioning command, supported environment contract, and tracked-file census for each discovery round;
+- a mandatory coverage matrix that crosses decorators and their options, both HTTP adapters, the generated Swagger, SDK, simulator, and e2e output, `INestiaConfig` and CLI paths, declaration spellings and provenance, composition, transform options, input contexts and boundaries, packaging, and supported platforms;
+- a per-issue consequence matrix and implementation impact record that names every caller, equivalent spelling, provenance, option, context, boundary, artifact, consumer, and platform revalidated by the fix; and
+- an integration-command manifest that records and hashes the exact commands, environment, tool versions, triggering change classes, expected artifacts, and clean-consumer setup required before and after each integration-sensitive merge.
+
+Record raw candidates before fact-checking. The knowledge base is the durable place to collect overlapping observations, then combine, split, rewrite, reject, or defer them without losing why.
+
+Give every tracked path and matrix cell a stable ID. Record `round`, `base SHA`, `matrix hash`, `path or cell ID`, `status`, `evidence`, and `candidate` for each row, with status limited to `PASS`, `FAIL`, `N/A`, or `UNTESTED`. For a path, `PASS` means its contents, history, owner, and linked cells were audited; `FAIL` means a candidate remains; `N/A` requires evidence that the path is outside an explicitly authorized contract; and `UNTESTED` means the audit is absent. For an executable cell, `PASS` means the recorded oracle and controls passed; `FAIL` means they did not; `N/A` requires a product-contract reason; and `UNTESTED` means it did not run. Reconcile the path census with `git ls-files` and verify that the matrix covers every public operation and known historical dimension before the round begins. When the round discovers a missing owner, consumer, axis, or interaction, version and re-hash the canonical matrix and execute the added cells. Reconcile the finished rows against the frozen census and final matrix; any missing row, `UNTESTED`, unsupported `N/A`, or absent evidence makes the round `INCOMPLETE`.
 
 The knowledge base supports the campaign but is not the final issue body. A published issue must stand alone without access to `.wiki`.
 
 ## Discover Issues
 
-Run the review skill's Issue Discovery Rounds over the entire declared campaign scope. Every agent independently audits the whole surface in every round. Never divide it by package, file, concern, platform, candidate class, agent, or round.
+Freeze one exact commit before every discovery round. Derive the supported environment contract from package engines, public documentation, repository CI, peer requirements, published package behavior, and explicit user decisions; do not narrow it ad hoc, and treat an unresolved conflict as a blocker on `CLEAN`. Work from that commit with a recorded lockfile and provisioning command, and require the review skill's full tracked-file census and mandatory coverage matrix. Never combine results from different commits or accept a stale, unprovisioned, skipped, contaminated, or sampled harness as full-round evidence.
 
-Source is only one evidence layer. Exercise real workflows and inspect relevant upstream behavior, history, generated artifacts, consumers, fixtures, and public documentation. For nestia that means running the generators and reading what they emit — Swagger documents, SDK libraries, mockup simulators, and generated e2e suites are product output, and a defect visible only in emitted code is still a defect.
+Perform one complete Solo Issue Discovery Round over every tracked repository surface. Never divide it by package, file, concern, platform, candidate class, or pass. Only an explicit user instruction or existing public product contract can exclude a surface or environment; the campaign cannot narrow itself, and an unresolved support-policy question makes the round `INCOMPLETE`.
+
+Source is only one evidence layer. Exercise real workflows and inspect relevant upstream behavior, history, generated artifacts, consumers, fixtures, public documentation, and closed decisions. For nestia that means running the generators and reading what they emit — Swagger documents, SDK libraries, mockup simulators, and generated e2e suites are product output, and a defect visible only in emitted code is still a defect.
+
+The coverage matrix is a minimum experiment contract, not a task list to trim. It must include every decorator and its option set; Express and Fastify for every request and response path; the Swagger document, SDK library, mockup simulator, and generated e2e suite one controller produces; `INestiaConfig` options and CLI flags, including the `--project` and `--config` paths; equivalent aliases, interfaces, classes, intersections, unions, generics, and re-exported or ambient declarations; user-global, default-library, module, package, and runtime-native provenance; transform-option interactions; valid, invalid, malformed, maximum-width, and one-past-boundary inputs; repeated generated-byte identity; clean tarball consumers; and supported Node, module-resolution, operating-system, and CLI paths. Every interaction that reaches shared control flow is a separate cell, and every positive cell has a one-axis negative twin. Add repository-specific dimensions discovered from source and history instead of treating this list as exhaustive.
+
+Continue after finding a candidate until the complete census and matrix are finished. A round with an unexecuted required cell is `INCOMPLETE`; it cannot support a `CLEAN` state. Record negative results and killed hypotheses so a later round knows which exact experiment was run, but do not let earlier coverage replace a fresh full round.
 
 Treat the development skill's **Forbidden** section as an explicit retrospective audit contract, not only a rule for future changes. In every complete round, inspect the current implementation and its history for violations, including code that predates the campaign or passes every test. A verified violation is a meaningful issue candidate. Prove the classification from purpose, control flow, consequence, and history; resemblance or stylistic preference alone is not evidence.
 
-Discovery ends only when a complete round from every agent produces no meaningful candidate that survives lead verification.
+Do not stop after finding enough work for a pull request. Complete the entire scope, adjudicate the full candidate pool, and publish only the surviving issues when authorized.
+
+A verified in-repository correctness, contract, data-integrity, build, test-oracle, documentation, packaging, workflow, or **Forbidden** violation is meaningful regardless of severity, rarity, legacy status, or malformed-input trigger. Do not downgrade a proved defect to an observation to satisfy the stop rule. An unresolved, deferred, or unimplemented verified defect blocks campaign completion.
+
+After the cycle pull request merges, begin a fresh full-scope round against the integrated repository. Earlier rounds are not coverage. Discovery ends only when a complete fresh round produces no meaningful candidate that survives verification.
 
 ## Vet And Publish Issues
 
-The lead, not a discovery agent, owns every publication decision. For each candidate:
+The same main agent owns every publication decision. For each candidate:
 
 1. Reopen its evidence and reproduce the behavior.
 2. Verify ownership, provenance, and any claimed classification under the development skill's **Forbidden** section. A defect that actually belongs to `typia`, `ttsc`, or NestJS is reported upstream, not filed here.
 3. Trace the full consequence surface.
 4. Compare open and closed issues and pull requests.
 5. Record accept, partial acceptance, rewrite, combine, split, reject, or defer with the supporting evidence.
+
+Revalidate every disposition from primary evidence in a fresh state, including rejection, narrowing, combination, split, deferral, and confirmed-invalid conclusions, rather than trusting the note that first recorded it. A disposition that cannot be reproduced leaves the candidate surviving and blocks `CLEAN`; it cannot be hidden by omitting publication. The [multi-agent procedure](../multi-agent/issue-campaign.md) assigns this audit to an independent critic agent; a solo campaign performs it as a separate pass with its own recorded evidence.
 
 Publish only the adjudicated form and only with user authorization.
 
@@ -51,14 +77,16 @@ Write enough context for a fresh AI agent to begin implementation from the issue
 - **Problem:** current and expected behavior, impact, and affected users.
 - **Evidence:** exact reproduction, outputs or artifacts, stable symbols, verified root cause, ownership, and provenance. For a violation of the development skill's **Forbidden** section, prove the classification from behavior, control flow, and history instead of merely naming the prohibition. Line numbers are navigation, not proof.
 - **Consequence surface:** affected consumers, states, platforms, compatibility and failure paths, plus the complete case matrix for the cause.
-- **Approach:** the invariant and architectural owner, without prescribing an unverified implementation.
+- **Invariant:** the required behavior and architectural owner, without prescribing an implementation mechanism. Discovery explanations, closed issue approaches, and candidate mechanisms remain hypotheses for the implementer to validate; executed evidence establishes constraints and rejected alternatives, not a prescribed solution.
 - **Acceptance and verification:** positive, negative, boundary, and regression outcomes with narrow and broader proving commands.
-- **Coordination:** dependencies, safe parallelism, exclusions, migration concerns, and related open, closed, accepted, or rejected work.
+- **Coordination:** dependencies, exclusions, migration concerns, external blockers, and related open, closed, accepted, or rejected work.
 
 Use tables for repeated case mappings. Read the rendered issue back and keep its body as the current operative handoff; use comments only for chronology.
 
+Before publication, reproduce the current failure and its independent oracle once more in a fresh state, and verify the invariant, complete owner and consumer census, supported-environment boundary, equivalent-spelling and provenance matrix, positive and negative twins, boundary cases, and a counterfactual proving that the reproduction distinguishes the expected behavior. Pass-after and fix-mutation evidence belong to implementation verification. Strike any prescribed implementation mechanism, including one that appears to fit the current evidence.
+
 ## Develop And Repeat The Campaign
 
-Read [development.md](development.md) in full when the user authorizes implementation pull requests or ends a campaign that entered implementation. It owns per-push campaign CI cancellation, DAG-based batching, claim pull requests, implementation waves, worktree cleanup, renewed discovery, the no-format rule, and Post-Campaign Cleanup. Do not continue after a push until its cancellation gate passes.
+Read [development.md](development.md) in full when the user authorizes implementation pull requests or the end of a campaign that entered implementation. It owns the single cycle pull request, empty claim, internal DAG order, test authoring, formatting, ordinary CI, red-CI repair, solo Self-Review, the integration-sensitive gate, merge, branch and temporary-asset cleanup, and renewed discovery.
 
-An audit or issue-publication-only campaign does not load this campaign's [implementation procedure](development.md) or mutate repository Actions.
+An audit-only or issue-publication-only campaign does not load the development procedure or mutate repository, Actions, or GitHub state beyond the authorized publications.

--- a/.agents/skills/issue-campaign/development.md
+++ b/.agents/skills/issue-campaign/development.md
@@ -114,7 +114,7 @@ When any gate finds a defect:
 
 Fix every red CI lane in the same pull request even when the failure predates the campaign or is unrelated to the campaign's original issues. Do not dismiss it as another contributor's failure.
 
-A `test-sdk` e2e feature gets three silent attempts and then one final attempt with inherited stdio, so a lane that passes on retry is not a clean result. Treat an intermittent failure as a campaign finding, not as noise to re-run away.
+The development skill records that a `test-sdk` e2e feature retries before the attempt whose output you see. In a campaign, treat an intermittent lane as a finding to adjudicate, not as noise to re-run away.
 
 Do not merge a head whose green checks belong to an older SHA or whose clean review predates a correction. Continue the loop until the same immutable head has green required checks, a complete Self-Review round with no sound improvement, and every applicable integration and mutation record final.
 

--- a/.agents/skills/issue-campaign/development.md
+++ b/.agents/skills/issue-campaign/development.md
@@ -1,121 +1,148 @@
-# Campaign Development
+# Solo Campaign Development
 
-Read this document in full when the user authorizes implementation pull requests or ends a campaign that entered implementation. Also read the repository development, pull-request, and review skills before acting.
+Read this document in full when the user authorizes implementation pull requests or the end of a solo issue campaign that entered implementation. Also read the repository development, pull-request, and review skills before acting.
 
 ## Flow
 
-- [Cancel Campaign CI After Every Push](#cancel-campaign-ci-after-every-push)
-- [Plan And Claim A Pull Request Wave](#plan-and-claim-a-pull-request-wave)
-- [Implement And Revalidate A Batch](#implement-and-revalidate-a-batch)
-- [Remove Every Finished Worktree](#remove-every-finished-worktree)
-- [While Campaign CI Is Cancelled](#while-campaign-ci-is-cancelled)
-- [Repeat A Campaign Cycle](#repeat-a-campaign-cycle)
-- [Post-Campaign Cleanup](#post-campaign-cleanup)
+- [Plan One Cycle Pull Request](#plan-one-cycle-pull-request)
+- [Claim The Complete Cycle](#claim-the-complete-cycle)
+- [Implement And Write Tests](#implement-and-write-tests)
+- [Keep Working While Commands Run](#keep-working-while-commands-run)
+- [Validate With CI And Self-Review](#validate-with-ci-and-self-review)
+- [Merge And Clean Up](#merge-and-clean-up)
+- [Repeat Until A Clean Round](#repeat-until-a-clean-round)
 
-Three rules govern the entire implementation phase:
+Five rules govern the implementation phase:
 
-- Local tests, lead verification, and solo Self-Review are the implementation gates.
-- Do not run `pnpm format` during discovery, issue publication, or implementation. Post-Campaign Cleanup owns the repository-wide formatter result.
-- Never disable repository Actions or any workflow for a campaign. After every campaign push and pull-request creation, immediately cancel only the runs for that campaign commit and verify cancellation before continuing.
+- The main agent performs all implementation, test authoring, CI diagnosis, review, and cleanup. Spawn no subagent except the read-only [commit early-warning pass](#implement-and-write-tests).
+- Put every accepted, implementation-ready issue in the current cycle into one pull request. The issue DAG controls implementation order inside that pull request, not pull-request count.
+- Work in the current checkout and one topic branch. Do not create a clone or worktree for a solo campaign or its Self-Review; a disposable checkout for a mutation experiment is a verification tool, not a second implementation home.
+- The pull request's ordinary CI, a clean solo Self-Review, and every applicable integration gate are the acceptance gates. Repair every red CI lane in that same pull request, even when the failure predates the campaign or is unrelated to its original issues.
+- Campaign branches and pull requests freeze package versions, release tags, and publication state throughout campaign implementation. They never choose a release number or publish a package. A maintainer release may begin only after campaign completion, or after the user explicitly suspends the campaign and lifts the freeze; it remains a separate task and does not relax this rule for campaign changes.
 
-## Cancel Campaign CI After Every Push
+## Plan One Cycle Pull Request
 
-Repository-wide Actions and workflow settings must remain unchanged. Before the first push, record `gh api repos/{owner}/{repo}/actions/permissions` and `gh workflow list --all --limit 1000 --json id,name,path,state` in `.wiki/<campaign>/ci-state.md` so the lead can prove the campaign did not alter them.
+Recompute the published-issue dependency DAG after publication. Record dependencies because they determine safe edit order and when one fix can expose another, but do not partition ready issues into separate pull requests.
 
-Every push gets its own cancellation gate:
+Before claiming, freeze the campaign knowledge base's integration-command manifest. Record its content hash and exact commands, environment, tool versions, triggering change classes, expected artifacts, and clean-consumer setup. Any later correction to the manifest is a reviewed campaign-state change and invalidates integration evidence recorded under the previous hash.
 
-1. Record the campaign branch and pushed commit SHA.
-2. List runs for that exact SHA with `gh run list --commit <sha> --limit 100 --json databaseId,headBranch,headSha,status,conclusion,url`.
-3. Cancel every `queued`, `in_progress`, `waiting`, `pending`, or `requested` run for that SHA with `gh run cancel <run-id>`. Never cancel by broad repository, workflow, or contributor filters.
-4. Poll again because push, pull-request, chained, and ruleset runs can appear after the first query. Continue until two consecutive polls find no new run and every observed run is terminal; every run observed as active must end `cancelled`, while a run already terminal when first observed is only recorded.
-5. Record the run IDs and final states in `.wiki/<campaign>/ci-state.md`. Stop further pushes or pull-request mutations if enumeration, cancellation, or readback fails.
+Build the cycle scope in this order:
 
-Four workflow files trigger on `pull_request` here — `build`, `test`, `website`, and `spell-check` — and `test` alone fans out to eight matrix jobs. All but `spell-check` carry path filters, so the set that actually starts depends on the batch's touched paths.
+1. Reopen every published, unclaimed issue and verify it still belongs to this repository and campaign.
+2. Remove only issues proved duplicate, invalid, out of scope, or externally blocked, and record the exact disposition. An accepted unresolved issue prevents campaign completion.
+3. Check open pull requests and remote branches for overlapping work before claiming.
+4. Put every remaining issue into one cycle ledger with its acceptance matrix, consequence surface, affected files, and DAG predecessors.
+5. Record the issue count before grouping and the result as one pull-request unit.
 
-`.github/workflows/` is not the whole check surface. CodeQL default setup and the Socket Security app also report on pull requests without a workflow file in the repository, and `gh run cancel` does not apply to app-reported checks. This is why the gate enumerates by SHA rather than by an expected job list. Note too that `test` already sets a cancel-in-progress concurrency group — an automatic supersede is not the same as a recorded cancellation.
+Different packages, invariants, or validation lanes do not split the solo cycle. A native Go transform fix, a decorator change, a generated SDK baseline, and a website guide update belong in the same cycle pull request when they are all accepted campaign work. Keep issue-level commits when that improves diagnosis, but the pull request remains the integrated campaign unit.
 
-Opening or updating a pull request can enqueue additional runs for the already-pushed SHA. Run the same gate immediately after pull-request creation and after any operation that retriggers checks. The exact-SHA boundary is mandatory: never cancel unrelated contributors' runs.
+An issue whose only predecessor is another issue in the same cycle is implementation-ready for this purpose. Order the edits through the DAG instead of deferring it to another pull request.
 
-## Plan And Claim A Pull Request Wave
+Difficulty never removes an issue from the cycle. When a resolution needs a judgment call about design, invariant ownership, or an acceptable behavior change, settle it from the issue's evidence and implement that decision inside the cycle. A proved duplicate, an invalid premise, an out-of-scope finding, and an external blocker remain the only dispositions that remove one.
 
-Build the issue dependency DAG before assigning implementation. Use it to form cohesive batches, not to create one worktree per issue.
+## Claim The Complete Cycle
 
-Batching follows these rules:
+Claim the whole cycle before implementation:
 
-- Group dependency-ready issues when their change surfaces and verification are compatible.
-- Assign one batch to one agent, worktree, branch, and pull request.
-- Split jointly implementable issues only for a concrete dependency, ownership, atomicity, or validation reason. Record that reason in the campaign knowledge base.
-- Immediately before claiming a batch, check again for an overlapping implementation pull request or branch.
+1. Use the current checkout, update `master` with `git pull --ff-only`, and create one topic branch. Do not create a clone or worktree.
+2. Create one implementation-free commit with `git commit --allow-empty`.
+3. Push the branch and open one draft pull request.
+4. Reference every cycle issue by number, mark verification pending, and state that the pull request owns the complete accepted cycle.
+5. Record the checkout, branch, pull request, head SHA, issue set, manifest hash, and external temporary-asset ledger in `.wiki`.
 
-The agent assigned a batch claims it as its first action, before writing any code:
+Keep every closing keyword out of the claim body. The body is written before any code exists, so a claim-time closing list closes whatever the cycle later drops, defers, or disproves, burying the analysis those issues carry. The cycle's closing set is the union of the [commit closing lines](#implement-and-write-tests), which makes the merge close exactly what landed.
 
-1. Create one isolated worktree and topic branch.
-2. Create one implementation-free claim commit with `git commit --allow-empty`.
-3. Push the branch and pass the exact-SHA cancellation gate.
-4. Open a draft pull request that overviews the batch scope and links every batched issue, then pass the gate again for runs triggered by pull-request creation.
-5. Mark verification as pending, and record the batch, worktree, branch, issues, pull request, and cancelled run IDs in the campaign knowledge base.
+The empty pull request prevents overlapping contributor work before code is written. Measure official duration from its GitHub `createdAt` timestamp through `mergedAt`, including implementation, CI, review, fixes, rebases, and merge. Use the GitHub timestamps, not commit dates or a local stopwatch, and record the issue count beside the duration. A claim that never merges has no official duration; record it separately as cancelled or unresolved instead of substituting `closedAt`.
 
-The draft pull request reserves the whole batch before code is written, preventing another contributor from starting overlapping work.
+## Implement And Write Tests
 
-Worktrees in this repository are not free: each needs its own `pnpm install`, and a batch that touches the native transform rebuilds the Go plugin into that worktree's cache. Set `TTSC_CACHE_DIR` to the shared root cache when the batch does not change Go source, and prefer fewer, larger batches over many thin ones.
+Work through the DAG on the claimed topic branch. Analyze the full consequence and case surface across every issue before editing, then implement the complete cycle and its tests.
 
-## Implement And Revalidate A Batch
+Before editing, turn each issue invariant into an executed consequence matrix. Enumerate every owning helper and caller, decorator and option combination, both HTTP adapters, equivalent TypeScript spelling and declaration provenance, union/intersection/generic and transform-option interaction, input context, positive and one-axis negative twin, boundary and malformed case, generated Swagger/SDK/simulator/e2e artifact, workspace and packed consumer, and supported platform affected by the owner. The issue's examples are seeds, not the matrix boundary. Record the matrix and every non-applicable cell with evidence in the campaign knowledge base and pull request.
 
-Analyze the full consequence and case surface across every issue in the batch. Follow the repository development skill for implementation, tests, documentation, generated artifacts, and narrow-then-broad local verification.
+Implement without interruption. Write each piece's tests as that piece lands instead of leaving the tests for the end of the cycle, and keep committing as each unit becomes coherent. Do not pause the sequence for a check run; [CI is read once per settled head](#validate-with-ci-and-self-review).
 
-An implementation agent may find that an issue is false or too broad. The lead must independently validate that conclusion before changing campaign state:
+Close each issue from the commit that earns it. End the commit message with one `Close #n: <issue title>` line per resolved issue, so a commit that resolves several issues carries several lines. GitHub matches the keyword and the number and ignores the title tail, so the line closes the issue normally while the log stays legible without opening each number.
 
-- For a narrowed issue, record the evidence on the issue and pull-request thread, then update the batch scope.
-- For a confirmed-invalid issue, record the evidence and close the issue.
-- If no issue remains in the batch, close the claim pull request instead of leaving an orphan reservation.
+Post a pull-request comment after each commit naming what that commit landed and which issues it resolved. The comment is the running ledger for a reader who does not read the diff, not a closing mechanism: GitHub closes an issue only from a commit message or the pull-request body.
 
-Commit and push every coherent implementation increment to the claimed branch. Immediately pass the exact-SHA cancellation gate after each push; do not hold a completed implementation locally until handoff or continue working while that gate is unresolved.
+Once a commit lands, the main agent may spawn one read-only subagent as a commit early-warning pass over that commit and keep implementing while it runs. The pass reads that one commit and reports candidates. It never edits, commits, pushes, or makes an implementation decision. Its value is timing: a defect named while that code is the newest thing written costs little to correct, and nothing has been built on top of it yet.
 
-Before merge, complete solo Self-Review, opening each round by commenting its findings and remediation plan on the pull request before acting on them so the thread records why every follow-up change happened. The implementing agent then merges its own pull request with the repository's established method — no separate lead approval — once implementation, that Self-Review, and the batch's package-scoped local verification all pass. Under an ordinary campaign it waits for explicit user authorization; under a standing autonomous mandate — an autonomous or remote-control campaign, or an instruction to carry the campaign through merge — it merges as soon as those gates pass, without a per-pull-request request.
+The pass never reduces the [Self-Review](#validate-with-ci-and-self-review) that gates the merge. A reader holding one commit cannot see what appears only across files: a helper that duplicates one the package already has, a native transform branch whose emitted decorator arguments no test workspace exercises, or a guide claiming a behavior the generator no longer performs. The main agent's own complete round over the whole base-to-head diff is what finds those, and no number of passes substitutes for it. The [review skill](../review/SKILL.md#commit-early-warning-pass) owns that boundary and the name the pass must not take.
 
-## Remove Every Finished Worktree
+Each issue remains an evidence and acceptance unit inside the combined diff. Keep its positive, negative, boundary, and regression cases identifiable. Near-100% coverage of changed behavior is required; a green happy path is not completion.
 
-Worktree removal is part of finishing an assignment, not optional housekeeping.
+Promote every reproduced defect class, consequence-matrix boundary, and mutation that caught an implementation error into a permanent regression discoverable by and executed from a canonical package or root command. A maintained repository probe is acceptable only when its exact command is a required, non-skippable coverage-matrix cell and mutation evidence proves that command fails. A dormant or one-off scratch witness is not enough when the same class could recur after the campaign.
 
-After a pull request merges:
+Follow the development skill for test shape and narrow-then-broad local evidence. Do not treat a local build or test result as a substitute for the pull request's ordinary CI acceptance gate. After the source, tests, documentation, fixtures, and generated consequences are ready, run `pnpm format` and include its integrated result in the same pull request; the script stops short of `tests/**/*.ts` for the reason recorded in `.agents/skills/project/SKILL.md`, so format a touched test workspace explicitly.
 
-1. Verify GitHub records it as merged into the intended target. This works for merge, squash, and rebase strategies.
-2. Confirm the worktree has no unpushed or uncommitted work worth preserving.
-3. Run `git worktree remove --force <path>` so ignored build artifacts are deleted too.
-4. Verify the directory no longer exists.
-5. Run `git worktree prune` and delete the local topic branch.
-6. Confirm `git worktree list --porcelain` contains no record of the removed path.
+If implementation disproves, narrows, or externally blocks an issue, reopen the evidence and revalidate that conclusion from primary sources before changing the claimed scope. Record the evidence on the issue and pull-request thread, update the campaign ledger, and close a confirmed-invalid issue. Do not leave an orphan issue or pretend an unresolved accepted issue was completed.
 
-A campaign worktree accumulates `node_modules`, `lib/`, `bin/`, compiled Go plugin caches, and the regenerated trees under `tests/test-sdk` and `tests/test-migrate/.generated`. `--force` is what removes them; leaving the directory behind leaves gigabytes on disk.
+## Keep Working While Commands Run
 
-If an assignment ends without a merge, first record retained evidence and confirm the remaining contents are disposable. Then remove its worktree and local branch by the same standard.
+Start every long command asynchronously and continue with work that does not depend on its result. `pnpm install`, package builds, Go plugin compilation, and test suites are all background work. Watching a CLI process, repeatedly polling it without a decision to make, or idling until a run finishes is not campaign work.
 
-Apply this rule to every campaign-created worktree, including one used for Post-Campaign Cleanup. Do not mark an assignment complete while its worktree remains on disk.
+Maintain a compact command record containing the command, source snapshot, start time, dependent decision, and final result. Check a running command at a genuine decision boundary, when it exits, or before merge. Do not use sleep loops or foreground waits merely to discover that a command is still running.
 
-## While Campaign CI Is Cancelled
+Two boundaries remain strict because overlap would destroy the evidence:
 
-- Record local verification for each pull request. Do not dispatch replacement CI.
-- Keep repository Actions and workflow settings unchanged. Cancel only exact-SHA campaign runs after every push or pull-request retrigger.
-- If work pauses, report local verification and the final state of every run for the latest campaign SHAs.
+- **A Self-Review round must not race a source change.** Freeze and commit the snapshot before opening the round, then inspect its complete diff while tests run. If review or a test result requires a change, commit the correction and restart from a fresh complete round over the new snapshot.
+- **A merge must not precede its evidence.** Every required local verification result, CI conclusion, and integration gate must be final before merge.
 
-## Repeat A Campaign Cycle
+## Validate With CI And Self-Review
 
-Report the wave after every surviving issue is covered by its assigned batch pull request.
+Commit and push the formatted integrated snapshot, then let every ordinary pull-request check run. Start solo Self-Review immediately over that exact base-to-head diff while CI executes.
 
-When the user requests another discovery cycle, return to the parent skill's Discover Issues phase and start new unlimited full rounds over the entire campaign scope. Earlier rounds are not coverage. Repository Actions remains unchanged, and discovery alone does not authorize issue publication, pull requests, or merging.
+Read CI once per settled head. It gates the cycle, not each commit. Only `test.yml` sets `cancel-in-progress`, so an intermediate commit's other lanes run to completion against a snapshot the cycle has already moved past; waiting on that result stalls implementation and proves nothing about the head that will merge. Note also that `.github/workflows/` is not the whole check surface: CodeQL default setup and the Socket Security app report on pull requests without a workflow file in this repository.
 
-## Post-Campaign Cleanup
+CI and review are independent gates:
 
-Run this phase only after the user ends the campaign, every campaign pull request is resolved, every campaign worktree is removed, and no campaign branch needs another push.
+- CI must prove every configured build, type-check, test, packaging, and platform lane.
+- Self-Review must prove requirement fidelity, consequence coverage, issue-by-issue acceptance, test quality, documentation, generated output, and risks not encoded in CI.
 
-1. Return to `master` in the main checkout and confirm it contains no unrelated user changes.
-2. Pull the final campaign result with `git pull --ff-only origin master`.
-3. Run `pnpm format` once against the integrated repository.
-4. If formatting produces no diff, report that no cleanup pull request was needed and stop.
-5. If formatting changes files, create a dedicated topic branch containing the formatter result and only directly necessary fixes.
-6. Commit and push under the pull-request skill, pass the exact-SHA cancellation gate, open the Post-Campaign Cleanup pull request, and pass the gate again for pull-request-triggered runs.
-7. Diagnose any locally reproducible failure, fix it, commit, push, and cancel the new commit's runs by the same gate.
-8. Merge once required checks pass: with explicit user authorization, or on a standing autonomous mandate without a separate request.
-9. If cleanup used the main checkout, return it to `master`, pull with `git pull --ff-only origin master`, and delete the local cleanup branch.
-10. If cleanup used an auxiliary worktree, remove it and its branch under Remove Every Finished Worktree, then pull `master` in the main checkout.
-11. Require the main checkout to be clean. Compare the final repository Actions permission and workflow inventory with the initial record and require that the campaign made no change.
+Treat the native Go transform, the SDK and Swagger generators, shared metadata, common runtime helpers, package manifests or declarations, CLI code, and test or oracle infrastructure as integration-sensitive. Before merging such a change, record the exact `origin/master` and pull-request head SHAs plus the integration-command manifest hash, construct their prospective merge result in a disposable checkout, and run the complete frozen canonical command set for root build, test, static analysis, generated artifacts, and clean packed consumers. Add a gate when the change warrants one, but never omit a manifest gate on a narrower consequence claim. An unavailable or failed mandatory gate blocks merge. Re-read `origin/master` before merge and restart the gate if it changed, and verify the exact merge SHA with the same command set afterward. Do not turn master red.
+
+Prove the regression tests are sensitive before merge: in a disposable checkout, revert or mutate only the product fix while retaining the tests, and require the expected assertions to fail while adjacent controls still pass.
+
+When any gate finds a defect:
+
+1. Diagnose the real cause from the CI log, review evidence, or gate output.
+2. Correct the source and complete the corresponding regression coverage.
+3. Run `pnpm format`.
+4. Commit and push the correction to the same pull request.
+5. Let the new CI run to completion and restart Self-Review as a fresh complete round over the new head.
+
+Fix every red CI lane in the same pull request even when the failure predates the campaign or is unrelated to the campaign's original issues. Do not dismiss it as another contributor's failure.
+
+A `test-sdk` e2e feature gets three silent attempts and then one final attempt with inherited stdio, so a lane that passes on retry is not a clean result. Treat an intermittent failure as a campaign finding, not as noise to re-run away.
+
+Do not merge a head whose green checks belong to an older SHA or whose clean review predates a correction. Continue the loop until the same immutable head has green required checks, a complete Self-Review round with no sound improvement, and every applicable integration and mutation record final.
+
+## Merge And Clean Up
+
+Merge only with user authorization, including a campaign-local standing authorization that explicitly covers merge.
+
+After merge:
+
+1. Verify GitHub records the pull request as merged into the intended target and every linked issue has the correct final state.
+2. Confirm the checkout has no unpushed or uncommitted work worth preserving.
+3. Switch back to `master`, pull with `git pull --ff-only`, and delete the local topic branch.
+4. Preserve compact command evidence and result hashes in the campaign knowledge base, then remove every disposable mutable root the cycle created: disposable mutation checkouts, `GOCACHE`, `GOTMPDIR`, `TTSC_CACHE_DIR`, generated-output roots, tarballs under `deploy/tarballs/`, the regenerated trees under `tests/test-sdk` and `tests/test-migrate/.generated`, and clean-consumer install roots. Confirm no live process uses a path before deleting it, delete only the exact proven path, and verify it is absent.
+5. Never bulk-delete a shared temporary directory, a shared ttsc cache directory, an installed toolchain, or an asset whose ownership is uncertain.
+
+Formatting belongs to the unified cycle pull request, so a separate post-campaign formatting pull request is not part of this solo workflow.
+
+## Repeat Until A Clean Round
+
+After every merged cycle, return to the parent skill's Discover Issues phase and perform another complete fresh round over the entire declared scope against one frozen integrated commit. Earlier rounds are not coverage, and a surviving issue or recent implementation never permits a residual-only review.
+
+If any meaningful candidate survives fact-checking, adjudicate and publish it when authorized, then claim the next single cycle pull request containing every implementation-ready issue. Repeat discovery, implementation, CI, review, merge, and cleanup without a fixed round limit. If the user authorized discovery but not implementation, preserve the `NOT CLEAN` campaign state and wait for implementation authority; never treat the absence of authority as completion.
+
+The campaign succeeds only when all of these are true:
+
+- one complete fresh full-scope discovery round finishes the entire census and matrix, is not `INCOMPLETE`, and produces no meaningful candidate after fact-checking;
+- no accepted or published campaign issue remains unresolved or deferred;
+- no campaign pull request, branch, process, or assignment-owned temporary asset remains; and
+- the target checkout is clean and synchronized.
+
+If an external blocker makes those conditions impossible, report the campaign as blocked rather than complete.

--- a/.agents/skills/multi-agent/SKILL.md
+++ b/.agents/skills/multi-agent/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: multi-agent
+description: "Defines the explicitly parallel variants of nestia review and issue campaigns. Use only when the user explicitly requests a team, parallel, or multi-agent review or campaign. Route review work to review.md and issue campaigns to issue-campaign.md. Self-Review and unqualified review remain solo. Multi-agent issue campaigns parallelize discovery and implementation by default, but an explicit request may limit parallelism to discovery and return implementation to the solo campaign."
+---
+
+# Multi-Agent Workflows
+
+This skill is the single entry point for every explicitly parallel review or campaign. Read the base solo skill first, then enter through the detailed document below for the requested workflow. That document names any shared multi-agent topic procedures it also requires.
+
+| Explicit request | Base skill | Detailed multi-agent procedure |
+| --- | --- | --- |
+| Team, parallel, or multi-agent review | [review](../review/SKILL.md) | [review.md](review.md) |
+| Parallel or multi-agent issue campaign | [issue-campaign](../issue-campaign/SKILL.md) | [issue-campaign.md](issue-campaign.md) |
+
+`nestia` has no benchmark-campaign skill. Use [benchmark](../benchmark/SKILL.md) for measurement integrity, then the applicable issue-campaign workflow for authorized benchmark-driven implementation.
+
+Do not load this skill for Self-Review, an unqualified review, a discussion, or a campaign that does not explicitly request parallel agents.
+
+## Shared Parallelism Rules
+
+- Use the smallest number of agents that adds independent evidence or owns immediately executable disjoint work. Available thread capacity is not a reason to create an agent, and a review or discovery round is the one place where every available slot should carry a full independent pass.
+- Keep the total at ten agents including the lead, so at most nine children run at once.
+- Never create a waiter, poller, coordinator-only child, duplicate implementation owner, or agent that cannot begin useful work immediately.
+- Give every review or discovery agent the complete declared surface. Parallel review adds independent full passes; it never partitions coverage by package, file, concern, platform, or test lane.
+- Partition implementation only through verified dependency and file-ownership boundaries. One agent owns one coarse batch, branch, pull request, and worktree.
+- Keep the lead active on fact-checking, integration, conflict resolution, and decisions that do not duplicate an assigned agent.
+- Do not let agents re-delegate.
+- Self-Review remains solo for every author and every implementation branch. An independent verifier or critic is a separate agent auditing someone else's work, never a substitute for the author's own round.
+- Create worktrees only for parallel implementation batches, verification, mutation, and integrated cleanup. Solo implementation and review use the current checkout.
+- Remove every finished worktree, local branch, process, and assignment-owned temporary asset before declaring its assignment complete.
+
+The solo campaign's [commit early-warning pass](../review/SKILL.md#commit-early-warning-pass) is a different topology and relaxes neither the full-surface rule nor the solo Self-Review rule above. A parallel review gives several reviewers the entire declared surface independently and the lead adjudicates their findings. The pass gives one read-only reader one commit's slice, reports candidates to the author who is still implementing, and leaves that author's own whole-surface round as the gate. A batch implementation agent here runs no pass, because agents do not re-delegate; the carve-out in the solo development procedure belongs to a solo campaign's main agent.

--- a/.agents/skills/multi-agent/issue-campaign.md
+++ b/.agents/skills/multi-agent/issue-campaign.md
@@ -1,0 +1,204 @@
+# Multi-Agent Issue Campaign
+
+Read this document only through the multi-agent skill for an explicitly parallel issue campaign. Read the base issue-campaign, project, development, pull-request, review, and [multi-agent review](review.md) procedures before acting.
+
+The base issue-campaign skill owns authorization, the knowledge base, candidate adjudication, self-contained issue bodies, and the clean full-scope completion gate. This document overrides only discovery and implementation topology.
+
+## Flow
+
+- [Select The Parallel Boundary](#select-the-parallel-boundary)
+- [Parallel Discovery](#parallel-discovery)
+- [Cancel Campaign CI](#cancel-campaign-ci)
+- [Plan And Claim A Pull Request Wave](#plan-and-claim-a-pull-request-wave)
+- [Keep Working While Commands Run](#keep-working-while-commands-run)
+- [Implement And Revalidate A Batch](#implement-and-revalidate-a-batch)
+- [Remove Every Finished Worktree](#remove-every-finished-worktree)
+- [While Campaign CI Is Cancelled](#while-campaign-ci-is-cancelled)
+- [Repeat A Campaign Cycle](#repeat-a-campaign-cycle)
+- [Post-Campaign Cleanup](#post-campaign-cleanup)
+
+Four rules govern the parallel implementation phase, which is the wave of concurrent batch pull requests. A campaign whose implementation returns to the solo procedure has no such phase, so its cycle pull request follows the solo rules and ordinary CI instead:
+
+- Local and package verification, solo Self-Review, independent verification, lead readback, and every applicable integration gate are mandatory implementation gates.
+- Do not run `pnpm format` during discovery, issue publication, or parallel batch implementation. Post-Campaign Cleanup owns the repository-wide formatter result. A campaign that returns implementation to the solo procedure formats its cycle pull request there instead, and then needs no cleanup format pull request.
+- Never disable repository Actions or any workflow for a campaign. After every campaign push and pull-request creation, immediately start an exact-SHA cancellation record for only the runs caused by that campaign commit, except when the user designated that exact integration SHA before its push. Keep the record current and complete it before merge, but never make local development wait for it.
+- Campaign branches and pull requests freeze package versions, release tags, and publication state throughout campaign implementation. They never choose a release number or publish a package. A maintainer release may begin only after campaign completion, or after the user explicitly suspends the campaign and lifts the freeze; it remains a separate task and does not relax this rule for campaign changes.
+
+## Select The Parallel Boundary
+
+A multi-agent issue campaign parallelizes both discovery and implementation by default.
+
+Switch to parallel discovery with solo implementation only when the user explicitly requests that combination. In that mode:
+
+1. Run Parallel Discovery and let the lead complete candidate adjudication and authorized publication.
+2. Stop every discovery agent before implementation begins.
+3. Read the base issue campaign's [solo development procedure](../issue-campaign/development.md).
+4. Put every implementation-ready issue into its one empty-claim pull request, use the current checkout without a worktree, run `pnpm format`, validate through ordinary CI, and complete solo Self-Review while CI runs.
+5. Apply that procedure's implementation, CI, merge, branch cleanup, and temporary-asset rules, but return here for the next parallel discovery round instead of switching to solo discovery.
+
+Do not infer solo implementation from quota concerns, a small issue count, or the fact that the lead performs publication. Only the user's explicit phase boundary selects it.
+
+## Parallel Discovery
+
+Use [review.md](review.md)'s Parallel Issue Discovery Rounds. Every discovery agent audits the whole declared scope independently against one frozen commit, one provisioning contract, and one canonical coverage matrix. The lead alone fact-checks and publishes, and an independent critic audits every disposition.
+
+Source is only one evidence layer for nestia. Run the generators and read what they emit: the Swagger document, SDK library, mockup simulator, and generated e2e suite are product output, and a defect visible only in emitted code is still a defect.
+
+Pool raw candidates in `.wiki`, then reproduce and combine, split, rewrite, reject, or defer them before publication. Parallel discovery changes evidence breadth, not publication authority.
+
+## Cancel Campaign CI
+
+A parallel campaign runs many concurrent branches, so its implementation waves rely on local verification, independent verification, and integration gates instead of ordinary pull-request checks. Repository-wide Actions and workflow settings must remain unchanged. Before the first push, record `gh api repos/{owner}/{repo}/actions/permissions` and `gh workflow list --all --limit 1000 --json id,name,path,state` in `.wiki/<campaign>/ci-state.md` so the lead can prove the campaign did not alter them.
+
+Every push gets its own cancellation record. Start it immediately in a background supervisor rather than leaving an implementation agent to poll it:
+
+1. Record the campaign branch and pushed commit SHA.
+2. List runs for that exact SHA with `gh run list --commit <sha> --limit 100 --json databaseId,headBranch,headSha,status,conclusion,url`.
+3. Cancel every `queued`, `in_progress`, `waiting`, `pending`, or `requested` run for that SHA with `gh run cancel <run-id>`. Never cancel by broad repository, workflow, or contributor filters. For an exact integration SHA the user designated before its push, do not cancel; record every run and poll it to a terminal result.
+4. Poll again because push, pull-request, chained, and ruleset runs can appear after the first query. Continue until two consecutive polls find no new run and every observed run is terminal; every ordinary campaign run observed as active must end `cancelled`, while a run already terminal when first observed or a designated integration run is recorded with its actual conclusion.
+5. Record the run IDs and final states in `.wiki/<campaign>/ci-state.md`. If enumeration, cancellation, or readback fails, surface the failure and suspend later remote mutations and merge until it is repaired.
+
+Four workflow files trigger on `pull_request` here — `build`, `test`, `website`, and `spell-check` — and `test` alone fans out to eight matrix jobs. All but `spell-check` carry path filters, so the set that actually starts depends on the batch's touched paths.
+
+`.github/workflows/` is not the whole check surface. CodeQL default setup and the Socket Security app also report on pull requests without a workflow file in the repository, and `gh run cancel` does not apply to app-reported checks. This is why the record enumerates by SHA rather than by an expected job list. Note too that `test` alone sets a cancel-in-progress concurrency group — an automatic supersede is not the same as a recorded cancellation.
+
+Opening or updating a pull request can enqueue additional runs for the already-pushed SHA. Start the same background record immediately after pull-request creation and after any operation that retriggers checks. The exact-SHA boundary is mandatory: never cancel unrelated contributors' runs.
+
+A live cancellation record does not block reading source, changing code, writing tests, starting local commands, committing, or Self-Review. It is a remote-progression and merge gate, not an excuse to idle. The initial claim push and the immediately following claim pull request are one reservation transaction, so opening that pull request does not wait for the first poll. Before merge, read every campaign SHA record back and require the final terminal state described above.
+
+## Plan And Claim A Pull Request Wave
+
+Recompute the published-issue dependency DAG after publication and before every implementation wave. A published issue is an evidence and acceptance unit, not a default pull-request boundary. Form the smallest number of maximal cohesive batches that the verified dependencies and implementation surfaces permit.
+
+Before claiming the first wave, freeze the campaign knowledge base's integration-command manifest. Record its content hash and exact commands, environment, tool versions, triggering change classes, expected artifacts, and clean-consumer setup. Any later correction to the manifest is a reviewed campaign-state change and invalidates integration evidence recorded under the previous hash.
+
+Admit two or more dependency-ready issues to one batch only when every row below supports the same implementation unit:
+
+| Decision axis | Group when | Split when |
+| --- | --- | --- |
+| Dependency readiness | Every issue is ready on the same DAG frontier and the batch can finish without waiting for another member or an external state transition. | An issue has a different prerequisite, external blocker, release gate, or target-branch timing. |
+| Owner and root cause | The issues repair the same verified root cause or closely coupled invariants under one architectural owner. | They belong to different repositories, target branches, product owners, independently releasable contracts, or unrelated root causes. |
+| Change and consequence surface | The owned files overlap, must move together, or form one traceable consequence surface. Disjoint files may still group when one invariant requires all of them. | The changes can land and roll back independently without leaving either issue incomplete. |
+| Shared verification | The issues share most setup, focused harnesses, generated consequences, broad validation lanes, and clean-consumer gates. | They require materially different environments, validation owners, or merge gates, or one failure would unnecessarily block the others. |
+| Atomicity and review | One diff can keep every issue's acceptance matrix explicit and can be reviewed, reverted, and diagnosed as one coherent change. | Combining them obscures root cause, issue-level acceptance, rollback, or failure attribution. |
+
+Topic, label, package proximity, reporter, and issue count do not justify a batch by themselves. File disjointness does not require a split when the same root cause and verification lane bind the files, and file overlap does not justify grouping issues with different readiness, ownership, or atomicity.
+
+Apply merge pressure only after admission. Among partitions for which every row still supports grouping, choose fewer pull-request units because each extra batch adds a claim, rebase, cancellation, integration, and merge gate. A split result on any row wins; reducing pull-request count never overrides correctness, rollback, failure attribution, or a dependency.
+
+Worktrees in this repository are not free, which sharpens that merge pressure: each needs its own `pnpm install`, and a batch that touches the native transform rebuilds the Go plugin into that worktree's cache. Set `TTSC_CACHE_DIR` to the shared root cache when the batch does not change Go source.
+
+Build each wave in this order:
+
+1. Take every published, admitted, unclaimed node on the current dependency frontier.
+2. Partition the nodes by architectural owner and verified root cause.
+3. Merge partitions that share a change surface and most verification work while preserving issue-level acceptance and rollback.
+4. Split only for a named dependency, ownership, root cause, atomicity, or validation reason from the table.
+5. Check open pull requests and remote branches for overlapping implementation immediately before claiming.
+6. Freeze the batch once its empty claim pull request exists. Do not close, move, split, or combine an active claim merely to improve throughput statistics; change it only when correctness, overlap, or invalidated evidence requires a lead decision.
+
+Run disjoint dependency-ready batches concurrently up to practical capacity and serialize batches that overlap or depend on one another. Assign one batch to one agent, worktree, branch, and pull request.
+
+Record the DAG edges, the issues in each batch, the owned change and consequence surfaces, the shared verification lane, every grouping reason, and every split reason in the campaign knowledge base. Report the pull-request unit count before batching and after batching before opening claims.
+
+The agent assigned a batch claims it as its first action, before installing dependencies or writing implementation code:
+
+1. Create one isolated worktree and topic branch.
+2. Create one implementation-free claim commit with `git commit --allow-empty`.
+3. Push the branch, start its exact-SHA cancellation record, and immediately open a draft pull request that overviews the batch scope and links every batched issue. This is an empty reservation pull request, not a request to wait for setup or validation.
+4. Start the pull-request-triggered cancellation record, mark verification as pending, and record the batch, worktree, branch, issues, pull request, and cancellation records in the campaign knowledge base.
+5. Start `pnpm install` asynchronously in the worktree, then begin the source, consequence-surface, and test-design work immediately.
+
+Keep every closing keyword out of the claim body for the reason the [solo claim rule](../issue-campaign/development.md#claim-the-complete-cycle) states. The batch's closing set is the union of its commit closing lines.
+
+The draft pull request reserves the whole batch before code is written, preventing another contributor from starting overlapping work.
+
+Measure the official duration of a claimed batch from the empty claim pull request's GitHub `createdAt` timestamp through its `mergedAt` timestamp. Use the GitHub timestamps, not commit dates or a local stopwatch, and include installation, implementation, validation, review, dependency waiting, rebases, cancellation completion, and merge. Do not remove outliers from the official mean. Record the issue count beside the duration so batch density remains visible, but do not replace the official per-pull-request measure with a commit-to-merge or per-issue metric. A claim that never merges has no official duration; record it separately as cancelled or unresolved instead of substituting `closedAt`.
+
+## Keep Working While Commands Run
+
+Start every long command asynchronously and continue with work that does not depend on its result. `pnpm install`, package builds, Go plugin compilation, and test suites are all background work. Watching a CLI process, repeatedly polling it without a decision to make, or reserving an agent solely to wait is not campaign work.
+
+Maintain a compact command record containing the command, worktree, source snapshot, start time, dependent decision, and final result. Check a running command at a genuine decision boundary, when it exits, or before merge. Do not use sleep loops or foreground waits merely to discover that a command is still running.
+
+The usual overlap follows the state of the batch. While installation runs, read the batched issue and nearby implementation, map the consequence surface, and write the implementation and regression test. Once a stable source-and-test snapshot is committed and pushed, launch the narrow package-scoped tests and begin Self-Review at once. A test process may run during review because it does not change the snapshot. When several independent checks are needed, start them together rather than serially discovering that each needs the same environment.
+
+Some boundaries remain strict because overlap would destroy the evidence:
+
+- **A Self-Review round must not race a source change.** Freeze and commit the snapshot before opening the round, then inspect its complete diff while tests run. If review or a test result requires a change, commit the correction and restart from a fresh complete round over the new snapshot.
+- **A merge must not precede its evidence.** Every required local and independent verification result, integration gate, and cancellation or designated-integration record must be final before merge.
+- **A failed cancellation record stops remote progression, not local thought.** Repair it before the next remote mutation or merge, while the agent continues the local work that is still safe and useful.
+
+Report any command still running, its dependency, and its last observed state when handing work off. Waiting is only justified when the next decision genuinely depends on the completed result and no safe, independent work remains.
+
+## Implement And Revalidate A Batch
+
+Analyze the full consequence and case surface across every issue in the batch. Follow the repository development skill for implementation, tests, documentation, generated artifacts, and narrow-then-broad local verification.
+
+Before editing, turn each issue invariant into an executed consequence matrix. Enumerate every owning helper and caller, decorator and option combination, both HTTP adapters, equivalent TypeScript spelling and declaration provenance, union/intersection/generic and transform-option interaction, input context, positive and one-axis negative twin, boundary and malformed case, generated Swagger/SDK/simulator/e2e artifact, workspace and packed consumer, and supported platform affected by the owner. The issue's examples are seeds, not the matrix boundary. Record the matrix and every non-applicable cell with evidence in the campaign knowledge base and pull request.
+
+Close each issue from the commit that earns it. End the commit message with one `Close #n: <issue title>` line per resolved issue, and post a pull-request comment naming what that commit landed.
+
+An implementation agent may find that an issue is false or too broad. The lead and an independent critic must validate that conclusion in separate fresh worktrees before changing campaign state. Any disagreement keeps the original issue and batch state active:
+
+- For a narrowed issue, record the evidence on the issue and pull-request thread, then update the batch scope.
+- For a confirmed-invalid issue, record the evidence and close the issue.
+- If no issue remains in the batch, close the claim pull request instead of leaving an orphan reservation.
+
+Commit and push every coherent implementation increment to the claimed branch as soon as its source and test program are complete. Do not hold a completed snapshot locally while waiting for the tests it already launched. Start the exact-SHA cancellation record immediately after the push, consume the test results when they become available, and make any correction in a new commit with the same discipline.
+
+Before merge, complete solo Self-Review, opening each round by commenting its findings and remediation plan on the pull request before acting on them so the thread records why every follow-up change happened. A pending narrow test never delays the start of that review, but its final result is required before merge. Then require an independent verifier who did not implement the batch to use fresh base and head worktrees, inspect the complete tree and diff including file modes, links, ignored generated output, worktree status, and packed contents, reproduce fail-before, inspect pass-after emitted or packed behavior, execute every applicable consequence-matrix cell, validate every non-applicable disposition, confirm the negative twins and boundaries, and prove the regression test is sensitive by reverting or mutating only the product fix while retaining the test in a disposable worktree; the expected assertion must fail while adjacent controls still pass. The implementing agent may merge only after implementation, Self-Review, independent verification, package-scoped verification, and the full integration-sensitive gate when the change triggers one. Under an ordinary campaign it waits for explicit user authorization; under a standing autonomous mandate it merges as soon as those gates pass, without a per-pull-request request.
+
+Treat the native Go transform, the SDK and Swagger generators, shared metadata, common runtime helpers, package manifests or declarations, CLI code, and test or oracle infrastructure as integration-sensitive. Immediately before its integration gate, record the exact `origin/master` and pull-request head SHAs plus the integration-command manifest hash, construct their prospective merge result in a disposable worktree, and run the complete frozen canonical command set for root build, test, static analysis, generated artifacts, and clean packed consumers; the lead may add gates but may not omit one based on a narrower consequence claim. An unavailable or failed mandatory gate blocks merge. Re-read `origin/master` before merge and restart the gate if it changed. After GitHub merges, verify the exact merge SHA with the same command set and manifest hash before any later campaign pull request merges. Do not turn master red or stack another batch on a package-only-tested integration state. If campaign CI is deliberately cancelled, record the equivalent local integration gates; when the user authorizes one designated integration SHA before its push, allow only that exact commit's runs to finish.
+
+Promote every reproduced defect class, consequence-matrix boundary, and mutation that caught an implementation error into a permanent regression discoverable by and executed from a canonical package or root command. A maintained repository probe is acceptable only when its exact command is a required, non-skippable coverage-matrix cell and mutation evidence proves that command fails. A dormant or one-off scratch witness is not enough when the same class could recur after the campaign.
+
+## Remove Every Finished Worktree
+
+Worktree removal is part of finishing an assignment, not optional housekeeping.
+
+After a pull request merges:
+
+1. Verify GitHub records it as merged into the intended target. This works for merge, squash, and rebase strategies.
+2. Confirm the worktree has no unpushed or uncommitted work worth preserving.
+3. Preserve compact command evidence and result hashes in the campaign knowledge base, then remove every disposable mutable root assigned to that worktree: `GOCACHE`, `GOTMPDIR`, `TTSC_CACHE_DIR`, generated-output root, tarballs under `deploy/tarballs/`, and clean-consumer install root. Never retain a Go temporary cache after its assignment ends; logs and recorded hashes are evidence, not a reason to retain compiled cache contents.
+4. Run `git worktree remove --force <path>` so ignored build artifacts are deleted too.
+5. Verify the worktree directory and every assigned Go temporary root no longer exist.
+6. Run `git worktree prune` and delete the local topic branch.
+7. Confirm `git worktree list --porcelain` contains no record of the removed path.
+
+A campaign worktree accumulates `node_modules`, `lib/`, `bin/`, compiled Go plugin caches, and the regenerated trees under `tests/test-sdk` and `tests/test-migrate/.generated`. `--force` is what removes them; leaving the directory behind leaves gigabytes on disk.
+
+If an assignment ends without a merge, first record retained evidence and confirm the remaining contents are disposable. Then remove its worktree, assigned Go temporary roots, and local branch by the same standard.
+
+Apply this rule to every campaign-created worktree, including one used for Post-Campaign Cleanup and every verifier or mutation worktree. Do not mark an assignment complete while its worktree or assigned Go temporary assets remain on disk.
+
+## While Campaign CI Is Cancelled
+
+- Record local verification for each pull request. Do not dispatch replacement CI unless the user designated one exact integration SHA before its push.
+- Keep repository Actions and workflow settings unchanged. Cancel only exact-SHA campaign runs after every push or pull-request retrigger, and let only a pre-designated exact integration SHA run to its actual conclusion.
+- If work pauses, report local verification and the final state of every run for the latest campaign SHAs.
+
+## Repeat A Campaign Cycle
+
+Report the wave after every surviving issue is covered by its assigned batch pull request.
+
+After every integrated implementation wave that resolves a discovery round's accepted issues, return automatically to the parent skill's Discover Issues phase and start new unlimited full rounds over the entire repository scope. Earlier rounds are not coverage. If the user authorized discovery but not implementation, preserve the `NOT CLEAN` campaign state and wait for implementation authority; never treat the absence of authority as completion. Repository Actions remains unchanged, and discovery alone does not authorize issue publication, pull requests, or merging.
+
+Freeze one integrated commit before briefing the next round, and give every reviewer that same commit, full repository scope, provisioning contract, and mandatory matrix. A surviving issue or recent implementation never permits lane assignment or a residual-only review: every reviewer starts again from the entire repository and continues after finding candidates until the full census is complete.
+
+## Post-Campaign Cleanup
+
+Run normal completion cleanup only after the terminal repository-wide round satisfies the review skill's stop rule, every campaign pull request is resolved, every campaign worktree is removed, and no campaign branch needs another push. If the user ends the campaign before that terminal clean round, record the campaign as `CANCELLED` or `INCOMPLETE`, apply Remove Every Finished Worktree to disposable campaign state, remove other safe campaign artifacts, then stop. The early-termination path skips steps 1-11 below, performs no format commit, push, or merge, and is never presented as campaign completion.
+
+1. Return to `master` in the main checkout and confirm it contains no unrelated user changes.
+2. Pull the final campaign result with `git pull --ff-only origin master`.
+3. Run `pnpm format` once against the integrated repository. It stops short of `tests/**/*.ts` for the reason recorded in `.agents/skills/project/SKILL.md`, so format a touched test workspace explicitly.
+4. If formatting produces no diff, report that no cleanup pull request was needed and stop.
+5. If formatting changes files, create a dedicated topic branch containing the formatter result and only directly necessary fixes.
+6. Commit and push under the pull-request skill, pass the exact-SHA cancellation gate, open the Post-Campaign Cleanup pull request, and pass the gate again for pull-request-triggered runs.
+7. Diagnose any locally reproducible failure, fix it, commit, push, and cancel the new commit's runs by the same gate.
+8. Merge once required checks pass: with explicit user authorization, or on a standing autonomous mandate without a separate request.
+9. If cleanup used the main checkout, return it to `master`, pull with `git pull --ff-only origin master`, and delete the local cleanup branch.
+10. If cleanup used an auxiliary worktree, remove it and its branch under Remove Every Finished Worktree, then pull `master` in the main checkout.
+11. Require the main checkout to be clean. Compare the final repository Actions permission and workflow inventory with the initial record and require that the campaign made no change.

--- a/.agents/skills/multi-agent/review.md
+++ b/.agents/skills/multi-agent/review.md
@@ -1,0 +1,58 @@
+# Multi-Agent Review
+
+Read this document only through the multi-agent skill for an explicitly requested team, parallel, or multi-agent review. The base review skill's Non-Negotiable Review Law still governs every reviewer: one agent performs one complete review of the entire declared surface from scratch, under all six rules.
+
+Do not use this procedure for Self-Review. The author always completes Self-Review alone even when a separate team review is also authorized.
+
+## Bound The Team
+
+Form the largest practical team that adds meaningful independent evidence, up to nine review agents so the lead and reviewers fit the ten-agent session limit. Open a reviewer slot only when it owns one complete independent pass and can run immediately, and record the objective runtime or resource reason for every unused slot.
+
+Give every reviewer the same complete surface. Different analytical lenses are welcome; package, file, concern, platform, or test-lane partitions are forbidden.
+
+## Share One Immutable State
+
+Every reviewer in a team or issue-discovery round uses the same immutable recorded snapshot, dependency lock, provisioned workspace contract, supported environment contract, and mandatory test matrix.
+
+Issue discovery and committed pull-request review use an exact commit. A team reviewing uncommitted work uses one base commit plus a complete diff, untracked-file manifest, and content hash copied into isolated worktrees. If a shared target changes before every report finishes, the round is invalid; restart every reviewer on one new snapshot instead of combining results from different states.
+
+## Brief Every Agent
+
+Review agents may start without conversation history or loaded repository instructions. Give each a self-contained brief containing:
+
+- the objective and complete declared surface;
+- constraints and evidence locations;
+- the required output format; and
+- the exact repository instructions and skills to read.
+
+State facts and constraints, not a preferred conclusion. Agents execute the brief directly and do not re-delegate.
+
+For issue discovery, include the frozen commit, reproducible provisioning command, full repository scope, mandatory coverage matrix, supported environment contract, required evidence schema, and explicit instruction to finish the entire review after finding a candidate. A brief that assigns a subsystem or lens invalidates that agent as a complete-round reviewer.
+
+## Team Review Cycle
+
+1. Freeze the exact surface and record its base and head.
+2. Give each reviewer its self-contained brief.
+3. Require every reviewer to inspect the full surface independently and report evidence-backed findings directly to the lead. Reviewers do not negotiate a consensus or use discussion transcripts.
+4. The lead independently reproduces and validates every proposal against the repository and relevant provenance. Accept, rewrite, combine, partially accept, or reject it according to evidence.
+5. Apply every accepted in-scope improvement, complete the authorized verification, and freeze a new exact surface.
+6. If anything changed, replace the team and begin another complete cycle. Stop only when one whole team cycle yields no accepted improvement.
+
+## Research Review Round
+
+Use a Research Review Round when the review needs external primary sources or sibling-repository provenance, such as the upstream `typia` and `ttsc` checkouts the native transform composes, the NestJS request lifecycle on either HTTP adapter, or the authoritative OpenAPI specification the Swagger generator must satisfy.
+
+Each reviewer still inspects the complete change surface and all relevant primary sources independently. Agents submit evidence-backed proposals directly to the lead without a discussion phase. External research adds evidence; it does not relax full-surface coverage or the fresh-cycle stop rule.
+
+## Parallel Issue Discovery Rounds
+
+Use this mode only through the multi-agent issue-campaign procedure.
+
+1. Freeze one exact commit and fully provision one reproducible workspace contract before briefing. Give every reviewer an isolated clean worktree and isolated mutable build, generated-output, and consumer directories; immutable download and compiler caches may be shared. Give every agent the same entire campaign scope and require the issue-campaign, project, development, and review skills in its brief. Never assign A/B/C/D lanes, preferred packages, exclusive lenses, or exclusions owned by another reviewer.
+2. Before examining candidates, every agent independently inventories all tracked files, package and public API families, implementation owners, generated artifacts, test harnesses, workflows, documentation contracts, supported platforms, and open and closed issue or pull-request history. For a repository-wide issue campaign, this inventory is every tracked repository surface; only an explicit user instruction or an existing public product contract can exclude one, never the lead or reviewer. The report must reconcile its inventory with the campaign's mandatory coverage matrix; a grep lens, sampled file set, assigned subsystem, or statement that the surface was reviewed is not coverage.
+3. Every agent independently audits the entire inventory and executes the whole mandatory matrix. Audit source, tests, documentation, CI, packaging, generated artifacts, platform behavior, upstream and downstream provenance, and history against the development skill's **Forbidden** section. Continue through the full inventory after finding candidates. Report every killed hypothesis and every surviving candidate with exact evidence; do not stop at the first sound issue.
+4. The mandatory matrix is a floor, not a partition or completeness shortcut. Each reviewer must cover every decorator and its option set; both HTTP adapters; the Swagger document, SDK library, mockup simulator, and generated e2e suite one controller produces; `INestiaConfig` and CLI flag paths; equivalent TypeScript spellings and local/re-exported/module/package/user-global/default-library provenance; union/intersection/generic and transform-option interactions; positive, one-axis negative, boundary, malformed, and mutation controls; generated-byte and executed-runtime behavior; deterministic repeat generation; workspace and clean packed consumers; supported Node, module-resolution, operating-system, and CLI paths. Treat every interaction of axes that reaches shared control flow as its own cell, and give every positive cell a one-axis negative twin. Run mutations only in a disposable checkout, keep the regression probe unchanged, and require the probe's canonical command to fail. The lead versions and hashes one canonical matrix before briefing; if any reviewer discovers a new owner, consumer, axis, or interaction, add it without sharing candidate conclusions and require every reviewer, including one that already reported, to execute the new cells before the round can complete.
+5. Each agent submits its own full-surface report without discussion or a shared candidate list. It must identify the exact commit and environment, canonical matrix hash, tracked-file census, matrix results, commands and artifacts, candidates, killed hypotheses, and every gap. The report is `COMPLETE` only when the full inventory and current matrix finished; otherwise it is `INCOMPLETE`. A complete report may contain candidates, which the lead must adjudicate rather than asking the reviewer to suppress.
+6. The lead reopens the evidence in a fresh isolated worktree, reproduces every candidate and independent oracle, checks ownership, provenance, complete consequence surface, and any claimed **Forbidden** classification, and compares existing issues and pull requests. A defect that actually belongs to `typia`, `ttsc`, or NestJS is reported upstream, not filed here. Reject, rewrite, combine, partially accept, or return a proposal as the evidence requires. An independent critic audits every lead disposition, including rejection, narrowing, combination, deferral, and invalidation, in another fresh worktree; for accepted candidates the critic also repeats the current failure and oracle and checks the invariant, consequence census, boundaries, and regression matrix. The critic returns `PASS` or `REJECT`; any lead-critic disagreement remains a surviving candidate and keeps the round `NOT CLEAN`. Implementation mechanisms remain hypotheses.
+7. Record every lead and critic disposition in the campaign knowledge base. If any meaningful candidate survives, finish adjudicating the whole round. When the user authorized end-to-end implementation, implement every accepted issue, replace the review team, freeze the new integrated commit, and run another complete repository-wide round under the same rules. Otherwise preserve the `NOT CLEAN` campaign state and stop at the authorized phase without mutation. A prior finding is not permission to narrow the next round to its owner or neighbors.
+8. Stop only when every agent in one immutable-state round completes the entire repository inventory and mandatory matrix, no report is `INCOMPLETE`, and lead plus critic verification leaves no meaningful candidate. Any verified in-repository correctness, contract, data-integrity, build, test-oracle, documentation, packaging, workflow, or **Forbidden** violation is meaningful regardless of severity, rarity, legacy status, or malformed-input trigger. An unresolved or deferred verified defect blocks `CLEAN`. One lane's clean result, one agent's clean result, or green existing suites cannot satisfy the stop rule.

--- a/.agents/skills/pull-request/SKILL.md
+++ b/.agents/skills/pull-request/SKILL.md
@@ -11,13 +11,13 @@ Act on this skill only when the user explicitly requests the corresponding remot
 
 Branch from the pull-request target (`master` unless stated otherwise); never commit or push directly to the target. Name the branch for the merged outcome with the repository's established type and scope, such as `feat/<scope>`, `fix/<scope>`, `docs/<scope>`, or `ci/<scope>`.
 
-If the current checkout contains unrelated or protected work, create an isolated worktree from the target branch instead of stashing, reverting, or mixing it.
+Solo work never creates a clone or worktree; only an explicit multi-agent campaign batch owns one. If the current checkout contains unrelated or protected work, stage only the authorized paths; if that cannot keep the pull request isolated, report the conflict rather than stashing, reverting, mixing, or relocating the work.
 
 ## Commit Logical Units
 
 Use one commit per coherent unit when the diff is large. Follow the repository's `<type>(<scope>): <subject>` history with an imperative lowercase subject and no trailing period.
 
-Run the validation required by the development skill. Run `pnpm format` before ordinary commits. During an issue campaign, do not run `pnpm format` on implementation branches; the campaign's dedicated Post-Campaign Cleanup pull request owns the repository-wide formatter result.
+Run the validation required by the development skill. Run `pnpm format` before ordinary commits. A solo issue campaign formats its unified cycle pull request. Only an explicit multi-agent campaign implementation batch defers the repository-wide formatter result to its Post-Campaign Cleanup pull request.
 
 Stage explicit paths when the worktree is mixed. Never include unrelated user changes silently.
 
@@ -33,11 +33,11 @@ Keep one GitHub issue per branch and pull request unless two issues are genuinel
 
 ## Version Bumps Are Release Commits
 
-`bumpp -r` through `pnpm release` owns version numbers across the workspace; every published package moves together. Do not hand-edit a `version` field in an ordinary pull request. The exception the development skill defines is a native Go source change, which requires the matching package version bump in the same change so npm consumers receive the new native tree.
+`bumpp -r` through `pnpm release` owns version numbers across the workspace; every published package moves together. Do not hand-edit a `version` field in an ordinary pull request. A native Go source change under `packages/*/native` must reach npm consumers under a newer version, but the development skill assigns that number once in a maintainer-owned release change rather than in the implementation pull request.
 
 ## Issue Campaign Override
 
-Before any issue-campaign push or pull request, complete `.agents/skills/issue-campaign/development.md`. Its no-format, local-verification, suspended-Actions, and Post-Campaign Cleanup rules override the ordinary commit and check flow here; cleanup returns to the ordinary check loop after restoring Actions.
+Before any issue-campaign push or pull request, complete `.agents/skills/issue-campaign/development.md`. A solo campaign uses one formatted cycle pull request and the ordinary check loop, plus its integration-sensitive gate. Only `.agents/skills/multi-agent/issue-campaign.md` overrides that flow with worktree batches, exact-SHA campaign-run cancellation, local implementation gates, and Post-Campaign Cleanup.
 
 ## Watch Checks After Every Ordinary Push
 
@@ -47,4 +47,4 @@ After each ordinary push, including every Post-Campaign Cleanup push, monitor th
 
 Do not merge, squash-merge, rebase, or update the target branch on unprompted initiative. Merge when the user explicitly asks, or when a standing autonomous mandate authorizes end-to-end delivery; use the repository's established merge method unless another is specified. Under an autonomous mandate the author that owns the pull request merges it themselves once the merge gate below passes, without separate approval.
 
-Before merging an ordinary or Post-Campaign Cleanup pull request, confirm required checks pass. For a campaign implementation pull request whose automatic CI is deliberately suspended, confirm the issue-campaign local-verification and lead-review gates instead. If branch protection blocks the requested merge, report the blocker rather than bypassing it.
+Before merging an ordinary or Post-Campaign Cleanup pull request, confirm required checks pass. For a multi-agent campaign implementation pull request whose automatic CI is deliberately suspended, confirm its local-verification, independent-verification, and integration gates instead. If branch protection blocks the requested merge, report the blocker rather than bypassing it.

--- a/.agents/skills/pull-request/SKILL.md
+++ b/.agents/skills/pull-request/SKILL.md
@@ -29,7 +29,7 @@ Do not rewrite the body after every follow-up push. Record later CI fixes, newly
 
 Push only the topic branch with upstream tracking. Use a file-backed body for multiline Markdown when opening through `gh`.
 
-Keep one GitHub issue per branch and pull request unless two issues are genuinely the same defect. Record verification and any known gap in the body.
+An ordinary pull request carries one GitHub issue unless two issues are genuinely the same defect. Issue campaigns override that boundary: a solo cycle pull request owns every implementation-ready issue in the cycle, and a multi-agent batch owns its admitted set. Record verification and any known gap in the body.
 
 ## Version Bumps Are Release Commits
 

--- a/.agents/skills/review/SKILL.md
+++ b/.agents/skills/review/SKILL.md
@@ -1,68 +1,59 @@
 ---
 name: review
-description: Defines exhaustive solo and team review workflows for nestia changes and issue discovery. Use when reviewing or self-reviewing a change or pull request, running a Review Cycle or Research Review Round, or conducting repository-wide issue-discovery rounds. Self-Review and unqualified review requests are always solo; review agents work independently rather than discussing.
+description: Defines exhaustive solo review, Self-Review, and solo repository-wide issue-discovery rounds for nestia. Use for every self-review or unqualified review request and as the default review mode inside issue campaigns. This skill never spawns review agents; use the multi-agent skill only when the user explicitly requests a team, parallel, or multi-agent review.
 ---
 
 # Review
 
 ## Non-Negotiable Review Law
 
-Every review mode uses the same unit of work: one reviewer performs one complete, from-scratch review of the entire declared surface. A team adds independent complete reviews; it never divides one review among agents.
+One reviewer performs every review in this skill from scratch over the entire declared surface. Do not spawn a subagent, delegate a concern, or load the discussion skill. Do not create a clone or worktree for solo review or Self-Review.
 
-A complete round must satisfy all four rules:
+Choose the principled conclusion. Review duration, difficulty, and consequence surface are reasons to inspect more deeply and verify more carefully, never reasons to overlook a sound improvement, accept an unsupported claim, or lower the completion standard.
 
-- **Whole surface:** read every changed file and hunk. For issue discovery, audit the entire campaign scope. Never partition by file, package, concern, platform, agent, or round, and never substitute another reviewer's coverage.
+A complete round must satisfy all six rules:
+
+- **Whole surface:** read every changed file and hunk. For issue discovery, audit the entire campaign scope. Never partition by file, package, concern, platform, or pass, and never substitute another reviewer's coverage.
 - **Consequence surface:** inspect affected code paths, tests, generated artifacts, CI, packaging, documentation, and consumers. Trace side effects, state transitions, concurrency, platforms, boundaries, compatibility, and failure and recovery paths beyond the named symptom or diff.
 - **Fresh start:** use the current state and repeat the whole inspection. Earlier rounds, sampled files, and a recheck of only the latest fix do not count as coverage.
-- **Unlimited rounds:** whenever a solo reviewer applies an improvement, or a lead accepts an improvement or meaningful issue candidate, update the work and start another complete round. Stop only after a complete round produces nothing that survives verification.
+- **Unlimited rounds:** whenever the reviewer applies an improvement or accepts a meaningful issue candidate, update the work and start another complete round. Stop only after a complete round produces nothing that survives verification.
+- **One immutable state:** a round runs against one recorded state, dependency lock, provisioned workspace contract, supported environment contract, and mandatory test matrix. Issue discovery and committed pull-request review use an exact commit. A solo review records its exact starting diff and refreshes that snapshot after every edit; a review round must not race a source change. The [multi-agent review procedure](../multi-agent/review.md) states how a team shares one snapshot.
+- **Auditable completeness:** the reviewer accounts for every tracked file and every mandatory decorator, generator-output, consumer, boundary, transform-option, HTTP-adapter, packaging, and supported-platform matrix cell in the declared surface. Finding a candidate never ends or narrows the review. A skipped file, unprovisioned harness, unsupported claim, or unexecuted required cell makes the report `INCOMPLETE`, never `COMPLETE`.
 
 ## Self-Review
 
-Self-Review is strictly solo. The author does not spawn subagents, form a team, or load the discussion skill. An ordinary review request also defaults to this solo workflow unless the user explicitly asks for a team.
+Self-Review and an unqualified review request use this solo workflow:
 
-1. Establish the complete change surface, including the pull request base-to-head diff and any uncommitted changes.
-2. Perform one complete round under the Non-Negotiable Review Law. Include correctness and boundaries, Windows and POSIX behavior, concurrency and state, data loss and security, cache and recovery invariants, public API and compatibility, generated SDK, Swagger, and e2e output, test isolation, CI and packaging, documentation, and migration effects.
-3. Apply every sound improvement and run the narrowest verification that proves it.
-4. If anything changed, restart at step 1 as a fresh full round.
-5. Finish only when a complete round finds nothing to improve. Report the final clean round and any verification that could not run.
+1. Establish the complete change surface, including the pull-request base-to-head diff and any uncommitted changes.
+2. Perform one complete round under the Non-Negotiable Review Law. Include correctness and boundaries, Express and Fastify behavior, Windows and POSIX behavior, concurrency and state, data loss and security, cache and recovery invariants, public API and compatibility, generated SDK, Swagger, and e2e output, test isolation, CI and packaging, documentation, and migration effects.
+3. Reproduce every suspected defect before accepting it.
+4. Apply every sound improvement and run the narrowest verification authorized by the owning workflow.
+5. If anything changed, restart at step 1 as a fresh full round.
+6. Finish only when a complete round finds nothing to improve. Report the final clean round and every verification that could not run.
 
 Self-Review does not authorize creating, pushing, updating, or merging a pull request. If the user separately requests one of those actions, follow the pull-request skill.
 
-## Team Review Cycle
+## Commit Early-Warning Pass
 
-Use Review Cycle only when the user explicitly asks for a team or multi-agent review.
+A commit early-warning pass is not a review under this skill. It is the read-only per-commit reader a solo campaign author may run while still implementing, defined by the [solo campaign development document](../issue-campaign/development.md#implement-and-write-tests).
 
-1. Form the largest practical team, up to nine review agents so the lead and reviewers fit the ten-agent session limit. Give every agent the same complete surface and require an independent complete round. Different analytical lenses are welcome; divided coverage is forbidden.
-2. Agents submit independent findings to the lead. They do not negotiate a consensus or use discussion transcripts.
-3. The lead independently reproduces and validates every proposal against the repository. Apply only technically sound, in-scope improvements; rewrite, combine, partially accept, or reject proposals as the evidence warrants.
-4. If the lead applies any improvement, replace the team and begin another complete cycle. Stop only after a full cycle yields no accepted improvement.
+It delegates nothing the Non-Negotiable Review Law governs. The law governs the author's own round, which still runs alone over the whole surface before merge under all six rules. One commit is not a declared surface, a reported candidate is not an accepted finding, and the passes do not add up to a round.
 
-## Research Review Round
+Never call the pass a Self-Review, and never report it as one. A reader who sees that name concludes the gate already ran, and the whole-surface round disappears without anyone deciding to drop it.
 
-Use Research Review Round when a team review needs external or cross-repository evidence before proposing changes.
+## Solo Issue Discovery Rounds
 
-Each agent independently reviews the complete change surface and all relevant primary sources or sibling repositories, including the upstream `typia` and `ttsc` checkouts when the change touches the native transform boundary. Agents submit evidence-backed proposals directly to the lead without a discussion phase.
+Use these rounds only through the solo issue-campaign skill.
 
-The lead validates every proposal and applies the Team Review Cycle stop rule. External research adds evidence; it does not relax full-surface coverage.
+1. Freeze one exact commit and record the dependency lock, provisioning command, and supported environment contract before starting. Derive that environment contract from package engines, public documentation, repository CI, peer requirements, published package behavior, and explicit user decisions; do not narrow it ad hoc, and treat an unresolved conflict as a blocker on `CLEAN`.
+2. Inventory all tracked files, package and public API families, implementation owners, generated artifacts, test harnesses, workflows, documentation contracts, supported platforms, and open and closed issue or pull-request history before examining candidates. Reconcile that inventory with `git ls-files` and with the campaign's mandatory coverage matrix. A grep lens, a sampled file set, or a statement that the surface was reviewed is not coverage.
+3. Audit the entire inventory and execute the whole mandatory matrix. Audit source, tests, documentation, CI, packaging, generated artifacts, platform behavior, upstream and downstream provenance, and history against the development skill's **Forbidden** section. Continue through the full inventory after finding a candidate.
+4. Treat the matrix as a floor. Cover every decorator and its option set; both HTTP adapters; the Swagger document, SDK library, mockup simulator, and generated e2e suite that one controller produces; `INestiaConfig` and CLI flag paths; equivalent TypeScript spellings and local, re-exported, module, package, user-global, and default-library provenance; union, intersection, generic, and transform-option interactions; positive, one-axis negative, boundary, malformed, and mutation controls; generated-byte and executed-runtime behavior; deterministic repeat generation; workspace and clean packed consumers; and supported Node, module-resolution, operating-system, and CLI paths. Every interaction that reaches shared control flow is its own cell, and every positive cell has a one-axis negative twin. Run mutations only in a disposable checkout, keep the regression probe unchanged, and require the probe's canonical command to fail. When the round discovers a new owner, consumer, axis, or interaction, version and re-hash the canonical matrix and execute the added cells before the round can complete.
+5. Record every raw candidate, killed hypothesis, command, and artifact in the campaign knowledge base with the exact commit, environment, matrix hash, and census results. The round is `COMPLETE` only when the full inventory and current matrix finished; otherwise it is `INCOMPLETE` and cannot support a `CLEAN` campaign state.
+6. Reopen each candidate from primary evidence in a fresh state, reproduce it, verify ownership and provenance, trace its complete consequence surface, and compare existing issues and pull requests. A defect that actually belongs to `typia`, `ttsc`, or NestJS is reported upstream, not filed here. Record accept, partial acceptance, rewrite, combine, split, reject, or defer with the supporting evidence, so a later round does not rediscover a rejected premise as new. Implementation mechanisms remain hypotheses.
+7. Publish only the surviving adjudicated form when the campaign is authorized to publish. If any meaningful candidate survives, finish the authorized issue and implementation flow, then freeze the new integrated commit and begin another fresh full-scope round. A prior finding never permits narrowing the next round to its owner or neighbors.
+8. Stop only when one immutable-state round completes the entire repository inventory and mandatory matrix, no round is `INCOMPLETE`, and no meaningful candidate survives verification. Any verified in-repository correctness, contract, data-integrity, build, test-oracle, documentation, packaging, workflow, or **Forbidden** violation is meaningful regardless of severity, rarity, legacy status, or malformed-input trigger. An unresolved or deferred verified defect blocks `CLEAN`, and green existing suites cannot satisfy the stop rule.
 
-## Issue Discovery Rounds
+## Explicit Multi-Agent Reviews
 
-Use issue discovery only as part of the issue-campaign skill.
-
-1. Form the largest practical review team, up to nine agents so the lead and reviewers fit the ten-agent session limit, and apply the briefing rules below. Give every agent the entire campaign scope and require the issue-campaign, project, development, and review skills in its brief.
-2. Every agent independently audits source, tests, documentation, CI, packaging, generated artifacts, platform behavior, upstream or downstream provenance, and open and closed issue or pull-request history. Audit the current implementation and history against the repository development skill's **Forbidden** section; a verified violation remains a meaningful candidate even when existing tests pass. Never divide the repository by package, file, concern, agent, or round.
-3. Each agent submits its own evidence-backed candidates without discussion or a shared list.
-4. The lead reopens the evidence, reproduces the behavior, checks ownership, provenance, and any claimed **Forbidden** classification, and compares existing issues and pull requests. Reject, rewrite, combine, partially accept, or return a proposal as the evidence requires.
-5. Record only surviving candidates in the campaign knowledge base. If any meaningful candidate survives, replace the team and run another complete discovery round.
-6. Stop only when a complete round from every agent produces no meaningful candidate that survives lead verification.
-
-## Briefing Review Agents
-
-Review agents may start without conversation history or loaded repository instructions. Give each a self-contained brief containing:
-
-- the objective and complete declared surface;
-- constraints and evidence locations;
-- the required output format; and
-- the exact repository instructions and skills to read.
-
-State facts and constraints, not a preferred conclusion. Agents execute the brief directly and do not re-delegate.
+When the user explicitly asks for a team, parallel, or multi-agent review, load the [multi-agent skill](../multi-agent/SKILL.md) and its [review procedure](../multi-agent/review.md) instead of this workflow. It inherits the same whole-surface, immutable-state, and auditable-completeness law while defining independent parallel reviewers, agent briefing, and lead and critic adjudication. A Research Review Round that needs external primary sources or sibling-repository provenance, such as the upstream `typia` and `ttsc` checkouts or the authoritative OpenAPI specification, lives there too.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,11 +8,12 @@ Follow the literal request; it is the contract, not a hint at what the user "rea
 
 - **Scope is the user's to widen.** Reinterpret the goal, weigh alternatives, or expand the task only on an explicit hand-off ("figure it out", "you decide"). Take a confident, specific ask as given.
 - **Fidelity binds the goal, not the effort.** Within that goal, act with full initiative: do the substeps it needs, verify your work, surface what you notice. Literal scope is no excuse for passive execution.
+- **Match the user's language.** Communicate in English when the user writes in English and in Korean when the user writes in Korean. Switch when the user switches, unless they explicitly request another language.
+- **Choose the principled course.** Decide from evidence, correctness, product boundaries, and the durable consequence. Time, difficulty, and consequence surface are reasons to investigate and validate more carefully, never reasons to settle for a shortcut, workaround, or weaker standard.
 - **Evidence precedes correction.** Treat issue reports, review proposals, and claims that something is wrong or missing as hypotheses. Verify the real code path, tests, generated artifacts, upstream ownership, and history before accepting the premise or changing behavior.
 - **Trace the consequence surface.** A named file or failing case is the starting point, not the investigation boundary. Follow the same cause through downstream consumers, side effects, state transitions, platforms, and boundary cases, then address the whole verified class of failure within the requested goal.
 - **Default over ask.** On an ambiguous detail, pick the sensible default and say what you chose; reserve questions for forks only the user can settle.
 - **Preserve the worktree.** Never reset, revert, or silently stage unrelated user changes.
-- **Fill the available agent pool when parallel work is independent.** Use up to ten concurrent agents in total, including the lead, when the runtime provides that capacity; keep at most nine child agents active so the lead retains one coordination slot.
 
 ## Skills
 
@@ -28,15 +29,19 @@ Work rules, testing, validation, consequence analysis, and change integrity, `.a
 
 ### Documentation
 
-README and website guide authoring rules, `.agents/skills/documentation/SKILL.md`. Read before writing or modifying documentation.
+README, website-guide, and agent-instruction authoring rules, `.agents/skills/documentation/SKILL.md`. Read before writing or modifying documentation.
 
 ### Issue Campaigns
 
-Repository-wide issue discovery, lead-verified issue writing, CI-suspended DAG-batched implementation, and cleanup, `.agents/skills/issue-campaign/SKILL.md`. Read when the user asks for a broad audit, many issue candidates, or an issue-to-implementation campaign; do not use it for one already-defined issue.
+Default solo repository-wide issue discovery, issue publication, one CI-validated implementation pull request per cycle, and renewed discovery, `.agents/skills/issue-campaign/SKILL.md`. Read when the user asks for a broad audit, many issue candidates, or an issue-to-implementation campaign without explicitly requesting parallel agents; do not use it for one already-defined issue.
 
 ### Review
 
-Solo review, team Review Cycle, research review, and exhaustive issue-discovery rounds, `.agents/skills/review/SKILL.md`. Every agent inspects the whole declared surface independently, and rounds continue until a complete pass produces no sound improvement or meaningful issue candidate. Self-Review and any unqualified review request are always solo.
+Default solo Self-Review, unqualified review, and exhaustive issue-discovery rounds, `.agents/skills/review/SKILL.md`. The reviewer inspects the whole declared surface and repeats fresh rounds until a complete pass produces no sound improvement or meaningful issue candidate.
+
+### Multi-Agent Workflows
+
+Explicitly parallel review and issue-campaign variants live under one entry point, `.agents/skills/multi-agent/SKILL.md`. Read it only when the user explicitly asks for a team, parallel, or multi-agent workflow. Multi-agent issue campaigns parallelize discovery and implementation by default and switch to solo implementation only on an explicit discovery-only parallel request; Self-Review remains solo.
 
 ### Discussion
 
@@ -54,15 +59,7 @@ Benchmark runners, fixture integrity, measurement integrity, result archives, an
 
 ### Writing style
 
-AGENTS.md and SKILL.md files are read by humans as well as agents.
-
-- **Optimize for comprehension, not minimum length.** A shorter document that forces the reader to infer prerequisites, reasons, exceptions, or stop conditions is not concise. Add the context needed to execute correctly.
-- **Remove repetition, not substance.** State a rule once at its owner and link to it elsewhere. Keep the rationale when it prevents a plausible mistake.
-- **Give each paragraph one job.** Split purpose, rule, rationale, procedure, and consequence when combining them would make the reader unpack a dense block.
-- **Use structure as compression.** Use numbered lists for ordered procedures, bullets for choices or checklists, tables for repeated mappings, and code blocks for exact commands. Do not hide a workflow inside one long sentence.
-- **State the rule before its reason.** Use negative phrasing only for a named failure mode that the affirmative rule does not already exclude.
-- **Skills point, not paraphrase.** Do not restate what the website, READMEs, or source comments already say; link to them.
-- **Source lines are not paragraphs.** Keep each prose paragraph on one source line and never hard-wrap it, but insert as many blank-line paragraph boundaries as the ideas require.
+`AGENTS.md` and `SKILL.md` files are operational documents for humans as well as agents. Read the documentation skill before editing either; it defines concise, clear agent-instruction writing and the prose-line rule.
 
 ### AGENTS.md
 
@@ -76,5 +73,6 @@ Update AGENTS.md only for repository-contract changes: a new skill area, a renam
 - **Core in SKILL.md, conditional topics as sibling documents.** Keep always-applicable procedure in SKILL.md. Move a topic needed only under a specific condition to a one-level-deep sibling document and link it with that read condition.
 - **Two trigger surfaces, one scope.** The frontmatter description is the full trigger contract, including exclusions. The AGENTS.md pointer mirrors that scope more briefly. Correct the frontmatter first when the scope changes.
 - **Create or merge.** Add a skill when a substantial repository concern would otherwise inflate AGENTS.md beyond an index. Merge sibling concerns when they share most of their structure.
+- **Repository skill files only.** Keep repository skills to `SKILL.md` and conditionally loaded sibling documents. Do not add separate `multi-agent-*` skills; the parallel variants live under the one `multi-agent` skill.
 - **Headings are plain.** No chapter numbers in skill or AGENTS.md headings. Use descriptive titles.
-- **Current set.** The repository skills are `project`, `development`, `documentation`, `issue-campaign`, `review`, `discussion`, `pull-request`, and `benchmark`.
+- **Current set.** The repository skills are `project`, `development`, `documentation`, `issue-campaign`, `review`, `multi-agent`, `discussion`, `pull-request`, and `benchmark`.


### PR DESCRIPTION
## Intent

Bring nestia's agent instructions up to the generation that `samchon/typia` and `samchon/ttsc` now run, adapted to nestia's own packages, generators, HTTP adapters, workflows, and cache layout. The prior nestia documents assumed a team-first review and a CI-suspended campaign as the *default*; the sibling repositories moved to a solo default with parallelism as an explicitly requested variant, and the two campaigns had diverged enough that a shared reader could not carry rules between repositories.

## Scope

**`AGENTS.md`**

- Adds the **Match the user's language** and **Choose the principled course** attitude rules.
- Moves the agent-pool rule out of `## Attitude` into the new multi-agent skill, where the rest of the parallelism contract lives.
- Delegates the writing-style rules to the documentation skill instead of restating them.
- Indexes the new `multi-agent` skill and states each skill's solo/parallel default.

**New `.agents/skills/multi-agent/`**

- `SKILL.md`: the single entry point for every explicitly parallel workflow, plus the shared parallelism rules (ten agents including the lead, full surface per reviewer, no re-delegation, solo Self-Review, worktree ownership and removal).
- `review.md`: team review cycle, immutable-state sharing, agent briefing, the Research Review Round, and parallel issue-discovery rounds with lead-plus-critic adjudication.
- `issue-campaign.md`: the CI-suspended, DAG-batched campaign that previously lived in `issue-campaign/development.md`, now with the batch admission table, merge pressure, integration-sensitive gate, and independent verification. nestia's own facts are preserved — the four `pull_request` workflows, `test`'s eight matrix jobs, CodeQL and Socket Security reporting outside `.github/workflows/`, and the per-worktree `pnpm install` and Go plugin rebuild cost.

**Rewritten skills**

- `review`: solo by default under a six-rule review law (adds **one immutable state** and **auditable completeness**), the commit early-warning-pass boundary, and solo issue-discovery rounds. Team review moves to the multi-agent skill.
- `issue-campaign`: the solo campaign — one CI-validated cycle pull request per cycle, the knowledge-base census and coverage matrix with `PASS`/`FAIL`/`N/A`/`UNTESTED` rows, disposition revalidation, an `Invariant` issue section that forbids prescribing a mechanism, and renewed discovery until a clean full-scope round.
- `issue-campaign/development.md`: replaced with the solo cycle procedure (empty claim, `Close #n:` commit lines, early-warning pass, CI read once per settled head, mutation-sensitivity proof, cleanup).

**Adjusted skills**

- `development`: adds the principled-course work rule; the format rule and Change Integrity now distinguish solo from multi-agent campaigns. Native Go version assignment moves to the maintainer-owned release change — `bumpp -r` moves all eight packages together, so an implementation pull request bumping a version conflicts with that release flow and with the campaign version freeze.
- `documentation`: gains the **Agent Instructions** section that `AGENTS.md` now delegates to.
- `pull-request`: solo work no longer creates a worktree; the campaign override and merge gate name the solo and multi-agent paths separately.
- `benchmark`: gains Campaign Batching and Campaign Cleanup.
- `discussion`: exclusion list updated for the solo/multi-agent split.

## Verification

Documentation only; no source, test, or workflow file changes.

- Every relative link and heading anchor across `AGENTS.md` and `.agents/skills/**` resolves (scripted check, all OK).
- Repository facts restated in the new documents were re-verified against the tree: `.github/workflows/` has exactly four `pull_request` workflows, `test.yml` alone sets `cancel-in-progress`, its matrix has eight jobs, tarballs stage under `deploy/tarballs/`, and `pnpm format` still stops short of `tests/**/*.ts`.
- `pnpm format` is not applicable: it targets `*.ts` only and never formats Markdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
