### PR TITLE
ci(dependabot): narrow updates to the catalog anchor dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    # Every workspace member declares these as "catalog:", so pnpm-workspace.yaml
+    # at the root is the only file holding a version to rewrite.
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    # Only the anchor holder of each catalog family is listed. '@nestjs/common'
+    # carries &nestjs, typia carries &typia, and ttsc carries &ttsc; the sibling
+    # entries are YAML aliases with no version of their own, so asking Dependabot
+    # to bump them makes it abandon the workspace file and write into the lockfile
+    # alone. Allowing the anchor leaves one edit per release, and the aliases
+    # follow it. The list also gates security updates, which is what keeps the
+    # transitive-dependency bumps out.
+    allow:
+      - dependency-name: "typescript"
+      - dependency-name: "ttsc"
+      - dependency-name: "typia"
+      - dependency-name: "@nestjs/common"


### PR DESCRIPTION
## Intent

The repository carried no `.github/dependabot.yml`. Every Dependabot pull request therefore came from repository-level automated security fixes, which default to "all lock file dependencies", and they targeted transitive packages the workspace never declares: vite, multer, js-yaml, ws, uuid, path-to-regexp, express, glob, yaml, fastify. All twelve open ones were closed as noise.

This adds the missing configuration and narrows the npm ecosystem to the four dependencies worth tracking, mirroring the approach already in place at [samchon/typia](https://github.com/samchon/typia/blob/master/.github/dependabot.yml).

## Scope

- `typescript`, `ttsc`, `typia`, `@nestjs/common` are exactly the `pnpm-workspace.yaml` catalog entries that hold a version of their own. `@ttsc/*`, `@typia/*`, `@nestjs/core`, `@nestjs/platform-express`, and `@nestjs/platform-fastify` are YAML aliases of the `&ttsc`, `&typia`, and `&nestjs` anchors; they carry no version to rewrite, and asking Dependabot to bump an alias makes it abandon the workspace file and write into the lockfile alone. Allowing the anchor holder leaves one edit per release, and the aliases follow it.
- A single `directory: "/"` is enough here. Every workspace member declares these four as `catalog:`, so the root workspace file is the only version source. No `groups` block is needed for the same reason: one directory means one pull request per release. This is where the configuration diverges from typia's, which needs extra directories and a `ttsc` group for its non-member `experiments/*` manifests.
- The `allow` list gates security updates as well as version updates, so the transitive bumps stop without disabling `automated-security-fixes` on the repository. That setting stays enabled, which keeps security alerts flowing for the four tracked dependencies.

## Verification

Configuration-only change; no source, test, or build surface is touched. `pnpm format` covers `packages/**`, `internals/**`, and `tests/**` TypeScript only, so it is not applicable. The effective behavior is observable only after this reaches `master`, when Dependabot re-reads the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
