### PR TITLE
fix: issue campaign cycle 2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,21 +1,32 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    # Every workspace member declares these as "catalog:", so pnpm-workspace.yaml
-    # at the root is the only file holding a version to rewrite.
+    # Every workspace member declares its dependencies as "catalog:", so
+    # pnpm-workspace.yaml at the root is the only file holding a version to
+    # rewrite.
     directory: "/"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 10
-    # Only the anchor holder of each catalog family is listed. '@nestjs/common'
-    # carries &nestjs, typia carries &typia, and ttsc carries &ttsc; the sibling
-    # entries are YAML aliases with no version of their own, so asking Dependabot
-    # to bump them makes it abandon the workspace file and write into the lockfile
-    # alone. Allowing the anchor leaves one edit per release, and the aliases
-    # follow it. The list also gates security updates, which is what keeps the
-    # transitive-dependency bumps out.
-    allow:
-      - dependency-name: "typescript"
-      - dependency-name: "ttsc"
-      - dependency-name: "typia"
-      - dependency-name: "@nestjs/common"
+    # Version updates are off; security updates are not.
+    #
+    # `open-pull-requests-limit: 0` disables version updates for this ecosystem.
+    # Security updates run under their own internal limit and are unaffected,
+    # which is the property this file needs: the catalog layout makes automated
+    # version bumps awkward, but a vulnerability still has to reach a pull
+    # request.
+    #
+    # This replaces an `allow` list of the four catalog anchors. The list did
+    # suppress transitive version noise, but `allow` governs security updates
+    # too, so every alert outside those four names was excluded — and Dependabot
+    # answers a vulnerable dependency with no permitted version by failing the
+    # run (`all_versions_ignored`), not by skipping it. The result was 34 open
+    # alerts, 17 of them high, with no pull request proposing any of them and a
+    # red run every day.
+    #
+    # Why the anchors were listed, kept here because the constraint still holds:
+    # '@nestjs/common' carries &nestjs, typia carries &typia, and ttsc carries
+    # &ttsc, while the sibling entries are YAML aliases with no version of their
+    # own. Asking Dependabot to bump an alias makes it abandon the workspace file
+    # and write into the lockfile alone. Anchor versions are bumped by hand at
+    # release time instead.
+    open-pull-requests-limit: 0

--- a/packages/core/native/plugin/plan.go
+++ b/packages/core/native/plugin/plan.go
@@ -32,6 +32,23 @@ func (p Plan) UsesNestia() bool {
 	return p.Core || p.SDK
 }
 
+// Kind reports which plugin family an entry belongs to: "core", "sdk", "typia",
+// or "" when it is none of them.
+func (e Entry) Kind() string {
+	return classify(e)
+}
+
+// BoolConfig reads a boolean option from an entry's resolved plugin config. The
+// second result distinguishes an option explicitly set to false from one that is
+// absent, which the tri-state options depend on.
+func (e Entry) BoolConfig(key string) (bool, bool) {
+	if e.Config == nil {
+		return false, false
+	}
+	value, ok := e.Config[key].(bool)
+	return value, ok
+}
+
 func ParsePlan(payload string) (Plan, error) {
 	payload = strings.TrimSpace(payload)
 	if payload == "" {

--- a/packages/core/native/transform/build.go
+++ b/packages/core/native/transform/build.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"regexp"
 	"time"
 
 	shimcompiler "github.com/microsoft/typescript-go/shim/compiler"
@@ -114,7 +113,7 @@ func runBuild(args []string) int {
 	newPathsRewriter(prog).applyAll(prog.SourceFiles())
 	profileBuildStep(profile, "paths-rewrite", started)
 
-	typiaTransform := nestiaTypiaNodeTransform(prog, readTypiaPluginOptions(cwd, *tsconfigPath), addDiagnostic)
+	typiaTransform := nestiaTypiaNodeTransform(prog, readTypiaPluginOptions(plan), addDiagnostic)
 	coreTransform := nestiaCoreNodeTransform(prog, plan, addDiagnostic)
 
 	// Statically linked contributors (e.g. the @nestia/sdk OperationMetadata
@@ -289,38 +288,51 @@ func profileBuildDuration(enabled bool, name string, elapsed time.Duration) {
 		fmt.Fprintf(stderr, "ttsc-nestia profile: %s=%s\n", name, elapsed)
 	}
 }
-func readTypiaPluginOptions(cwd, tsconfigPath string) typiaadapter.PluginOptions {
-	path := tsconfigPath
-	if !filepath.IsAbs(path) {
-		path = filepath.Join(cwd, path)
-	}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return typiaadapter.PluginOptions{}
-	}
-	text := string(data)
-	return typiaadapter.PluginOptions{
-		Functional: typiaOptionFunctionalPattern.MatchString(text),
-		Numeric:    typiaOptionNumericPattern.MatchString(text),
-		Finite:     typiaOptionFinitePattern.MatchString(text),
-		Undefined:  readBooleanPluginOption(text, "undefined"),
-	}
-}
 
-func readBooleanPluginOption(text string, name string) *bool {
-	matched := regexp.MustCompile(`(?s)"` + regexp.QuoteMeta(name) + `"\s*:\s*(true|false)`).FindStringSubmatch(text)
-	if matched == nil {
-		return nil
+// readTypiaPluginOptions takes typia's transform options from the resolved plugin
+// payload ttsc hands this binary, not from the text of one tsconfig file.
+//
+// The file is the wrong source twice over. It is only the *entry* of an `extends`
+// chain, so an option declared in a base was invisible — the compile then
+// succeeded with a weaker validator than the project asked for, and nothing said
+// so. And a text scan matches anywhere, so `"numeric": true` inside a comment or
+// an unrelated object turned the option on for a project that never set it. ttsc
+// has already resolved the whole chain by the time it builds --plugins-json.
+//
+// Options are read from every plugin entry, with typia's own entry winning, so a
+// project that sets them on the composing @nestia/core entry keeps working.
+func readTypiaPluginOptions(plan plugin.Plan) typiaadapter.PluginOptions {
+	options := typiaadapter.PluginOptions{}
+	apply := func(entry plugin.Entry) {
+		if value, ok := entry.BoolConfig("functional"); ok {
+			options.Functional = value
+		}
+		if value, ok := entry.BoolConfig("numeric"); ok {
+			options.Numeric = value
+		}
+		if value, ok := entry.BoolConfig("finite"); ok {
+			options.Finite = value
+		}
+		// `undefined` is tri-state: an explicit false must stay distinguishable
+		// from an absent option, so copy into a fresh variable rather than
+		// aliasing the closure's parameter.
+		if value, ok := entry.BoolConfig("undefined"); ok {
+			flag := value
+			options.Undefined = &flag
+		}
 	}
-	value := matched[1] == "true"
-	return &value
+	for _, entry := range plan.Entries {
+		if entry.Kind() != "typia" {
+			apply(entry)
+		}
+	}
+	for _, entry := range plan.Entries {
+		if entry.Kind() == "typia" {
+			apply(entry)
+		}
+	}
+	return options
 }
-
-var (
-	typiaOptionFunctionalPattern = regexp.MustCompile(`(?s)"functional"\s*:\s*true`)
-	typiaOptionNumericPattern    = regexp.MustCompile(`(?s)"numeric"\s*:\s*true`)
-	typiaOptionFinitePattern     = regexp.MustCompile(`(?s)"finite"\s*:\s*true`)
-)
 
 func resolveCWD(label string, cwdOverride string) (string, bool) {
 	if cwdOverride != "" {

--- a/packages/core/native/transform/transform.go
+++ b/packages/core/native/transform/transform.go
@@ -78,7 +78,7 @@ func runTransform(args []string) int {
 	addDiagnostic := func(diag Diagnostic) {
 		transformDiags = append(transformDiags, diag)
 	}
-	typiaTransform := nestiaTypiaNodeTransform(prog, readTypiaPluginOptions(cwd, *tsconfigPath), addDiagnostic)
+	typiaTransform := nestiaTypiaNodeTransform(prog, readTypiaPluginOptions(plan), addDiagnostic)
 	coreTransform := nestiaCoreNodeTransform(prog, plan, addDiagnostic)
 	contributorTransforms, contributorDiags := collectContributorEmitTransforms(prog, plan)
 	if len(contributorDiags) > 0 {

--- a/packages/core/test/typia_plugin_options_from_payload_test.go
+++ b/packages/core/test/typia_plugin_options_from_payload_test.go
@@ -1,0 +1,61 @@
+package test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/samchon/nestia/packages/core/native/transform"
+)
+
+// TestTypiaPluginOptionsFromPayload verifies typia's transform options are taken
+// from the resolved --plugins-json payload rather than the text of one tsconfig.
+//
+// The reader used to open the entry tsconfig and regex-match `"numeric": true`.
+// That file is only the entry of an `extends` chain, so an option declared in a
+// base was invisible and the project silently got a weaker validator than it
+// configured. From this binary's side the extends case looks exactly like this
+// test: the option is present in the payload ttsc resolved, and absent from the
+// text of the tsconfig the run is pointed at. The negative twin covers the other
+// half of the same cause — a text scan also matched occurrences that were never
+// part of the effective plugin configuration.
+//
+//  1. Transform a bare `typia.assert<T>()` fixture with a typia entry carrying
+//     `numeric: true`, an option that appears nowhere in the tsconfig text.
+//  2. Assert the emitted validator carries the NaN guard that option produces.
+//  3. Transform the same fixture with the option absent and assert the guard is
+//     gone, so the positive case cannot pass for an unrelated reason.
+func TestTypiaPluginOptionsFromPayload(t *testing.T) {
+	const guard = "Number.isNaN"
+	run := func(typiaConfig string) string {
+		t.Helper()
+		temp := t.TempDir()
+		featureRoot := featureRootForCore(t, "app")
+		fixture := featureSource(t, "app", "test/transform_numeric_option_fixture.ts")
+		tsconfig := writeExtendingTsconfig(t, temp, featureRoot, "", []string{fixture})
+		outPath := filepath.Join(temp, "out.ts")
+		code := transform.Run([]string{
+			"transform",
+			"--cwd", temp,
+			"--tsconfig", tsconfig,
+			"--file", fixture,
+			"--out", outPath,
+			"--plugins-json",
+			`[{"name":"typia","stage":"transform","config":{"transform":"typia/lib/transform"` + typiaConfig + `}}]`,
+		})
+		if code != 0 {
+			t.Fatalf("transform.Run exited %d", code)
+		}
+		return mustReadFile(t, outPath)
+	}
+
+	with := run(`,"numeric":true`)
+	if !strings.Contains(with, guard) {
+		t.Fatalf("numeric option from the plugin payload produced no %s guard\n%s", guard, with)
+	}
+
+	without := run("")
+	if strings.Contains(without, guard) {
+		t.Fatalf("%s guard appeared without the numeric option, so the positive case proves nothing\n%s", guard, without)
+	}
+}

--- a/tests/test-sdk/features/app/src/test/transform_numeric_option_fixture.ts
+++ b/tests/test-sdk/features/app/src/test/transform_numeric_option_fixture.ts
@@ -1,0 +1,8 @@
+import typia from "typia";
+
+interface IMeasurement {
+  value: number;
+}
+
+export const check = (input: unknown): IMeasurement =>
+  typia.assert<IMeasurement>(input);


### PR DESCRIPTION
## Intent

Cycle 2 of the 2026-07 solo issue campaign. Both issues were discovered while
cycle 1 (#1553) was settling and were deliberately kept out of it, so its evidence
would not have to be re-established on a moving head.

| Issue | Area | Summary |
| --- | --- | --- |
| #1556 | `packages/core/native` | typia transform options dropped when the tsconfig reaches them through `extends` |
| #1557 | `.github/dependabot.yml` | no security update can be delivered, and the run fails every day |

## #1556 — options read from the resolved payload

The option reader opened the entry tsconfig and regex-matched `"numeric": true`
and friends. That file is only the entry of an `extends` chain, so an option
declared in a base was invisible: the compile succeeded and typia generated a
weaker validator than the project configured, silently.

Differential compile of the same source at `429099bf`:

| config | emitted `feature.js` |
| --- | --- |
| no `numeric` | 3184 bytes |
| `"numeric": true` inline | 3306 bytes |
| the same option through `extends` | **3184 — byte-identical to no option** |

What was lost is the `!Number.isNaN(...)` guard in the generated validator.

ttsc resolves the whole chain before it builds `--plugins-json`, and
`plugin.ParsePlan` already parses each entry's config, so the authoritative value
was in hand and unused. Options now come from there, typia's own entry winning
over any other entry carrying the key, so a project that sets them on the
composing `@nestia/core` entry keeps working.

**I corrected an overstatement on the issue while implementing this.** The body
claimed the weakening reached every validator generated for a `@nestia/core`
decorator. It does not — every `nestiaCoreTypiaContext` call site passes hardcoded
literals, so the decorator path never consulted these options at all. The affected
surface is bare `typia.assert<T>()`-style call sites in the project's own source.
The correction is on the issue thread; whether decorators *should* honor these
options is a separate product question I did not fold in.

## #1557 — security updates ungated

`allow` governs security updates as well as version updates, so an allow list of
four catalog anchors excluded every alert outside those names — and Dependabot
answers a vulnerable dependency with no permitted version by failing the run
(`all_versions_ignored`), not by skipping it. 34 open alerts, 17 high, zero pull
requests, one red run per day.

Version updates are now off outright via `open-pull-requests-limit: 0`, documented
to leave security updates running under their own internal limit. That suppresses
more version noise than the allow list did and stops suppressing what mattered.

The anchors lose automated version pull requests. Every Dependabot pull request in
the recent history was closed rather than merged, and the anchors are bumped by
hand at release time, so the cost is small. The reason the alias entries can never
be listed is preserved in the file — that constraint is unchanged.

This one is **verifiable only after merge**: the scheduled run should stop failing
and the high-severity alerts should start producing pull requests within a day. I
have stated that plainly rather than claiming CI proves it.

## Verification

| Command | Result |
| --- | --- |
| `go build ./...` + `go vet ./...`, both native modules | pass |
| `pnpm test:go` | pass — core 7.3s, sdk 25.6s |
| new `TestTypiaPluginOptionsFromPayload` | pass |
| YAML parse of `.github/dependabot.yml` | `limit: 0`, no `allow` |

Mutation sensitivity for #1556: with the reader forced back to ignoring the
payload, `TestTypiaPluginOptionsFromPayload` fails on exactly the missing
`Number.isNaN` guard; restored, it passes. The test carries its own negative twin —
the same fixture without the option must **not** produce the guard, so the positive
case cannot pass for an unrelated reason.

## Honest status

- Local Node is 22.21.0 against the repository's 24.x contract, so this pull request's CI is the authoritative lane.
- The `packages/core/native` change is integration-sensitive; `origin/master` is `6d52822d` and unchanged, so the prospective merge is a fast-forward and this run is the gate.
- Package versions stay frozen. The native source change will need a release version assigned separately, in a maintainer-owned release change.
- Process note: the claim commit was pushed before the pull request was opened rather than at the same moment, so this body is written after the first implementation commit rather than before it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
