### PR TITLE
fix: validate index result order

### DIFF
--- a/packages/e2e/src/TestValidator.ts
+++ b/packages/e2e/src/TestValidator.ts
@@ -362,9 +362,7 @@ export namespace TestValidator {
     gotten = gotten.slice(0, length);
 
     const xIds: string[] = get_ids(expected).slice(0, length);
-    const yIds: string[] = get_ids(gotten)
-      .filter((id) => id >= xIds[0]!)
-      .slice(0, length);
+    const yIds: string[] = get_ids(gotten).slice(0, length);
 
     const equals: boolean = xIds.every((x, i) => x === yIds[i]);
     if (equals === true) return;
@@ -616,7 +614,7 @@ interface IEntity<Type extends string | number | bigint> {
 
 /** @internal */
 function get_ids<Entity extends IEntity<any>>(entities: Entity[]): string[] {
-  return entities.map((entity) => entity.id).sort((x, y) => (x < y ? -1 : 1));
+  return entities.map((entity) => entity.id.toString());
 }
 
 /** @internal */

--- a/tests/test-e2e/src/features/test_validate_index.ts
+++ b/tests/test-e2e/src/features/test_validate_index.ts
@@ -11,6 +11,11 @@ export async function test_validate_index(): Promise<void> {
     [{ id: "b" }, { id: "a" }],
     [{ id: "b" }, { id: "a" }],
   );
+  TestValidator.index(
+    "numeric identifiers",
+    [{ id: 2 }, { id: 1 }],
+    [{ id: 2 }, { id: 1 }],
+  );
   TestValidator.error("error", () =>
     TestValidator.index(
       "index",

--- a/tests/test-e2e/src/features/test_validate_index.ts
+++ b/tests/test-e2e/src/features/test_validate_index.ts
@@ -6,6 +6,11 @@ export async function test_validate_index(): Promise<void> {
   const { data } = generate_random_articles();
 
   TestValidator.index("index", data, data);
+  TestValidator.index(
+    "descending identifiers",
+    [{ id: "b" }, { id: "a" }],
+    [{ id: "b" }, { id: "a" }],
+  );
   TestValidator.error("error", () =>
     TestValidator.index(
       "index",
@@ -18,6 +23,13 @@ export async function test_validate_index(): Promise<void> {
         ...data.slice(1),
       ],
       false,
+    ),
+  );
+  TestValidator.error("order", () =>
+    TestValidator.index(
+      "index",
+      [{ id: "a" }, { id: "b" }],
+      [{ id: "b" }, { id: "a" }],
     ),
   );
 }


### PR DESCRIPTION
Closes #1569

- compare index result IDs in the supplied sequence
- remove the ID-range filter that rejected valid descending identifiers
- cover reversed and descending-ID cases

Validation is intentionally GitHub Actions Node 24 CI only; no local build or test was run.