### PR TITLE
Fix #1571 case-insensitive request media types

### DIFF
--- a/packages/core/src/decorators/EncryptedBody.ts
+++ b/packages/core/src/decorators/EncryptedBody.ts
@@ -13,6 +13,7 @@ import { Singleton } from "../utils/Singleton";
 import { ENCRYPTION_METADATA_KEY } from "./internal/EncryptedConstant";
 import { get_text_body } from "./internal/get_text_body";
 import { headers_to_object } from "./internal/headers_to_object";
+import { is_media_type } from "./internal/is_media_type";
 import { validate_request_body } from "./internal/validate_request_body";
 
 /**
@@ -47,7 +48,7 @@ export function EncryptedBody<T>(
     const request: express.Request | FastifyRequest = context
       .switchToHttp()
       .getRequest();
-    if (isTextPlain(request.headers["content-type"]) === false)
+    if (is_media_type(request.headers["content-type"], "text/plain") === false)
       throw new BadRequestException(`Request body type is not "text/plain".`);
 
     const param: IEncryptionPassword | IEncryptionPassword.Closure | undefined =
@@ -87,11 +88,3 @@ const decrypt = (body: string, key: string, iv: string): string => {
     else throw exp;
   }
 };
-
-/** @internal */
-const isTextPlain = (text?: string): boolean =>
-  text !== undefined &&
-  text
-    .split(";")
-    .map((str) => str.trim())
-    .some((str) => str === "text/plain");

--- a/packages/core/src/decorators/PlainBody.ts
+++ b/packages/core/src/decorators/PlainBody.ts
@@ -7,8 +7,8 @@ import type express from "express";
 import type { FastifyRequest } from "fastify";
 
 import { get_text_body } from "./internal/get_text_body";
-import { is_request_body_undefined } from "./internal/is_request_body_undefined";
 import { is_media_type } from "./internal/is_media_type";
+import { is_request_body_undefined } from "./internal/is_request_body_undefined";
 import { validate_request_body } from "./internal/validate_request_body";
 
 /**

--- a/packages/core/src/decorators/PlainBody.ts
+++ b/packages/core/src/decorators/PlainBody.ts
@@ -8,6 +8,7 @@ import type { FastifyRequest } from "fastify";
 
 import { get_text_body } from "./internal/get_text_body";
 import { is_request_body_undefined } from "./internal/is_request_body_undefined";
+import { is_media_type } from "./internal/is_media_type";
 import { validate_request_body } from "./internal/validate_request_body";
 
 /**
@@ -56,7 +57,7 @@ export function PlainBody(
       (checker ?? (() => null))(undefined as any) === null
     )
       return undefined;
-    else if (!isTextPlain(request.headers["content-type"]))
+    else if (!is_media_type(request.headers["content-type"], "text/plain"))
       throw new BadRequestException(`Request body type is not "text/plain".`);
     const value: string = await get_text_body(request);
     if (checker) {
@@ -66,11 +67,3 @@ export function PlainBody(
     return value;
   })();
 }
-
-/** @internal */
-const isTextPlain = (text?: string): boolean =>
-  text !== undefined &&
-  text
-    .split(";")
-    .map((str) => str.trim())
-    .some((str) => str === "text/plain");

--- a/packages/core/src/decorators/TypedBody.ts
+++ b/packages/core/src/decorators/TypedBody.ts
@@ -7,8 +7,8 @@ import type express from "express";
 import type { FastifyRequest } from "fastify";
 
 import { IRequestBodyValidator } from "../options/IRequestBodyValidator";
-import { is_request_body_undefined } from "./internal/is_request_body_undefined";
 import { is_media_type } from "./internal/is_media_type";
+import { is_request_body_undefined } from "./internal/is_request_body_undefined";
 import { validate_request_body } from "./internal/validate_request_body";
 
 /**

--- a/packages/core/src/decorators/TypedBody.ts
+++ b/packages/core/src/decorators/TypedBody.ts
@@ -8,6 +8,7 @@ import type { FastifyRequest } from "fastify";
 
 import { IRequestBodyValidator } from "../options/IRequestBodyValidator";
 import { is_request_body_undefined } from "./internal/is_request_body_undefined";
+import { is_media_type } from "./internal/is_media_type";
 import { validate_request_body } from "./internal/validate_request_body";
 
 /**
@@ -37,7 +38,10 @@ export function TypedBody<T>(
       .getRequest();
     if (is_request_body_undefined(request) && checker(undefined as T) === null)
       return undefined;
-    else if (isApplicationJson(request.headers["content-type"]) === false)
+    else if (
+      is_media_type(request.headers["content-type"], "application/json") ===
+      false
+    )
       throw new BadRequestException(
         `Request body type is not "application/json".`,
       );
@@ -47,11 +51,3 @@ export function TypedBody<T>(
     return request.body;
   })();
 }
-
-/** @internal */
-const isApplicationJson = (text?: string): boolean =>
-  text !== undefined &&
-  text
-    .split(";")
-    .map((str) => str.trim())
-    .some((str) => str === "application/json");

--- a/packages/core/src/decorators/TypedFormData.ts
+++ b/packages/core/src/decorators/TypedFormData.ts
@@ -9,6 +9,7 @@ import type ExpressMulter from "multer";
 
 import type { IRequestFormDataProps } from "../options/IRequestFormDataProps";
 import { Singleton } from "../utils/Singleton";
+import { is_media_type } from "./internal/is_media_type";
 import { validate_request_form_data } from "./internal/validate_request_form_data";
 
 /**
@@ -95,7 +96,12 @@ export namespace TypedFormData {
     ): Promise<T> {
       const http: HttpArgumentsHost = context.switchToHttp();
       const request: express.Request = http.getRequest();
-      if (isMultipartFormData(request.headers["content-type"]) === false)
+      if (
+        is_media_type(
+          request.headers["content-type"],
+          "multipart/form-data",
+        ) === false
+      )
         throw new BadRequestException(
           `Request body type is not "multipart/form-data".`,
         );
@@ -177,11 +183,3 @@ const parseFiles =
             }),
           );
   };
-
-/** @internal */
-const isMultipartFormData = (text?: string): boolean =>
-  text !== undefined &&
-  text
-    .split(";")
-    .map((str) => str.trim())
-    .some((str) => str === "multipart/form-data");

--- a/packages/core/src/decorators/TypedQuery.ts
+++ b/packages/core/src/decorators/TypedQuery.ts
@@ -21,6 +21,7 @@ import typia from "typia";
 import { IRequestQueryValidator } from "../options/IRequestQueryValidator";
 import { IResponseBodyQuerifier } from "../options/IResponseBodyQuerifier";
 import { get_path_and_querify } from "./internal/get_path_and_querify";
+import { is_media_type } from "./internal/is_media_type";
 import { route_error } from "./internal/route_error";
 import { validate_request_query } from "./internal/validate_request_query";
 
@@ -79,7 +80,12 @@ export namespace TypedQuery {
       const request: express.Request | FastifyRequest = context
         .switchToHttp()
         .getRequest();
-      if (isApplicationQuery(request.headers["content-type"]) === false)
+      if (
+        is_media_type(
+          request.headers["content-type"],
+          "application/x-www-form-urlencoded",
+        ) === false
+      )
         throw new BadRequestException(
           `Request body type is not "application/x-www-form-urlencoded".`,
         );
@@ -170,17 +176,6 @@ export namespace TypedQuery {
 function tail(url: string): string {
   const index: number = url.indexOf("?");
   return index === -1 ? "" : url.substring(index + 1);
-}
-
-/** @internal */
-function isApplicationQuery(text?: string): boolean {
-  return (
-    text !== undefined &&
-    text
-      .split(";")
-      .map((str) => str.trim())
-      .some((str) => str === "application/x-www-form-urlencoded")
-  );
 }
 
 /** @internal */

--- a/packages/core/src/decorators/internal/is_media_type.ts
+++ b/packages/core/src/decorators/internal/is_media_type.ts
@@ -1,0 +1,10 @@
+/** @internal */
+export const is_media_type = (
+  text: string | undefined,
+  expected: string,
+): boolean =>
+  text !== undefined &&
+  text
+    .split(";")
+    .map((str) => str.trim().toLowerCase())
+    .some((str) => str === expected.toLowerCase());

--- a/tests/test-sdk/features/body-optional/src/test/features/api/test_api_body_content_type_case.ts
+++ b/tests/test-sdk/features/body-optional/src/test/features/api/test_api_body_content_type_case.ts
@@ -40,5 +40,5 @@ export const test_api_body_content_type_case = async (
     },
   );
   TestValidator.equals("text status", textResponse.status, 201);
-  TestValidator.equals("text body", await textResponse.text(), text);
+  TestValidator.equals("text body", await textResponse.json(), text);
 };

--- a/tests/test-sdk/features/body-optional/src/test/features/api/test_api_body_content_type_case.ts
+++ b/tests/test-sdk/features/body-optional/src/test/features/api/test_api_body_content_type_case.ts
@@ -20,6 +20,16 @@ export const test_api_body_content_type_case = async (
   TestValidator.equals("json status", jsonResponse.status, 201);
   TestValidator.equals("json body", await jsonResponse.json(), json);
 
+  const invalidResponse: Response = await fetch(
+    `${connection.host}/body/optional/json`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/xml" },
+      body: JSON.stringify(json),
+    },
+  );
+  TestValidator.equals("invalid status", invalidResponse.status, 400);
+
   const text = "case-insensitive media type";
   const textResponse: Response = await fetch(
     `${connection.host}/body/optional/plain`,

--- a/tests/test-sdk/features/body-optional/src/test/features/api/test_api_body_content_type_case.ts
+++ b/tests/test-sdk/features/body-optional/src/test/features/api/test_api_body_content_type_case.ts
@@ -1,0 +1,34 @@
+import { TestValidator } from "@nestia/e2e";
+
+import api from "@api";
+
+export const test_api_body_content_type_case = async (
+  connection: api.IConnection,
+): Promise<void> => {
+  const json = {
+    id: "7e630852-2db9-48e4-9de2-11f9d43871db",
+    value: 3,
+  };
+  const jsonResponse: Response = await fetch(
+    `${connection.host}/body/optional/json`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "Application/JSON; Charset=UTF-8" },
+      body: JSON.stringify(json),
+    },
+  );
+  TestValidator.equals("json status", jsonResponse.status, 201);
+  TestValidator.equals("json body", await jsonResponse.json(), json);
+
+  const text = "case-insensitive media type";
+  const textResponse: Response = await fetch(
+    `${connection.host}/body/optional/plain`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "TEXT/PLAIN; Charset=UTF-8" },
+      body: text,
+    },
+  );
+  TestValidator.equals("text status", textResponse.status, 201);
+  TestValidator.equals("text body", await textResponse.text(), text);
+};

--- a/tests/test-sdk/features/query/src/test/features/api/test_api_query_body_content_type_case.ts
+++ b/tests/test-sdk/features/query/src/test/features/api/test_api_query_body_content_type_case.ts
@@ -1,0 +1,28 @@
+import { TestValidator } from "@nestia/e2e";
+
+import api from "@api";
+
+export const test_api_query_body_content_type_case = async (
+  connection: api.IConnection,
+): Promise<void> => {
+  const input = new URLSearchParams({
+    atomic: "atomic",
+    limit: "10",
+    enforce: "true",
+    values: "value",
+  });
+  const response: Response = await fetch(`${connection.host}/query/body`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "Application/X-Www-Form-Urlencoded; Charset=UTF-8",
+    },
+    body: input,
+  });
+  TestValidator.equals("status", response.status, 201);
+
+  const output = new URLSearchParams(await response.text());
+  TestValidator.equals("atomic", output.get("atomic"), input.get("atomic"));
+  TestValidator.equals("limit", output.get("limit"), input.get("limit"));
+  TestValidator.equals("enforce", output.get("enforce"), input.get("enforce"));
+  TestValidator.equals("values", output.get("values"), input.get("values"));
+};


### PR DESCRIPTION
Closes #1571.

## Summary

- centralize request media-type matching and compare the type/subtype case-insensitively
- use the shared matcher for JSON, plain/encrypted text, URL-encoded query bodies, and multipart form data
- add raw SDK integration requests that retain mixed-case JSON, text/plain, and URL-encoded `Content-Type` values

## Validation

- Not run locally by request.
- Awaiting the repository's Node 24 CI matrix.