### PR TITLE
Fix #1573 inherited MCP route discovery

### DIFF
--- a/packages/core/src/adaptors/McpAdaptor.ts
+++ b/packages/core/src/adaptors/McpAdaptor.ts
@@ -73,30 +73,38 @@ export class McpAdaptor {
       for (const wrapper of module.controllers.values()) {
         const instance = wrapper.instance;
         if (!instance) continue;
-        const proto = Object.getPrototypeOf(instance);
-        for (const key of Object.getOwnPropertyNames(proto)) {
-          if (key === "constructor") continue;
-          const method = proto[key];
-          if (typeof method !== "function") continue;
+        const visited: Set<string> = new Set();
+        for (
+          let proto: any = Object.getPrototypeOf(instance);
+          proto !== null && proto !== Object.prototype;
+          proto = Object.getPrototypeOf(proto)
+        ) {
+          for (const key of Object.getOwnPropertyNames(proto)) {
+            if (key === "constructor" || visited.has(key)) continue;
+            visited.add(key);
+            const method = proto[key];
+            if (typeof method !== "function") continue;
 
-          const meta: IMcpRouteReflect | undefined = Reflect.getMetadata(
-            "nestia/McpRoute",
-            method,
-          );
-          if (!meta) continue;
+            const meta: IMcpRouteReflect | undefined = Reflect.getMetadata(
+              "nestia/McpRoute",
+              method,
+            );
+            if (!meta) continue;
 
-          const params: IMcpRouteReflect.IArgument[] =
-            Reflect.getMetadata("nestia/McpRoute/Parameters", proto, key) ?? [];
-          const paramValidator = params.find(
-            (p) => p.category === "params",
-          )?.validate;
+            const params: IMcpRouteReflect.IArgument[] =
+              Reflect.getMetadata("nestia/McpRoute/Parameters", proto, key) ??
+              [];
+            const paramValidator = params.find(
+              (p) => p.category === "params",
+            )?.validate;
 
-          tools.push({
-            meta,
-            source: `${wrapper.metatype?.name ?? proto.constructor?.name ?? "UnknownController"}.${String(key)}`,
-            validateArgs: paramValidator,
-            handler: async (args) => method.call(instance, args),
-          });
+            tools.push({
+              meta,
+              source: `${wrapper.metatype?.name ?? proto.constructor?.name ?? "UnknownController"}.${String(key)}`,
+              validateArgs: paramValidator,
+              handler: async (args) => method.call(instance, args),
+            });
+          }
         }
       }
     }

--- a/tests/test-sdk/features/mcp/src/Backend.ts
+++ b/tests/test-sdk/features/mcp/src/Backend.ts
@@ -4,11 +4,17 @@ import { NestFactory } from "@nestjs/core";
 import { Singleton } from "tstl";
 
 import { CalculatorController } from "./controllers/CalculatorController";
+import { InheritedMcpController } from "./controllers/InheritedMcpController";
 import { ImportAliasController } from "./controllers/ImportAliasController";
 import { WeatherController } from "./controllers/WeatherController";
 
 @Module({
-  controllers: [CalculatorController, ImportAliasController, WeatherController],
+  controllers: [
+    CalculatorController,
+    InheritedMcpController,
+    ImportAliasController,
+    WeatherController,
+  ],
 })
 class McpModule {}
 

--- a/tests/test-sdk/features/mcp/src/controllers/InheritedMcpController.ts
+++ b/tests/test-sdk/features/mcp/src/controllers/InheritedMcpController.ts
@@ -1,0 +1,38 @@
+import core from "@nestia/core";
+import { Controller } from "@nestjs/common";
+
+export interface IInheritedMcpInput {
+  a: number;
+  b: number;
+}
+
+export interface IInheritedMcpResult {
+  result: number;
+}
+
+export class InheritedMcpControllerBase {
+  /** Return the product of two numbers. */
+  @core.McpRoute("multiply")
+  public async multiply(
+    @core.McpRoute.Params() params: IInheritedMcpInput,
+  ): Promise<IInheritedMcpResult> {
+    return { result: params.a * params.b };
+  }
+
+  /** This MCP tool must be hidden by the derived override. */
+  @core.McpRoute("hidden")
+  public async hidden(
+    @core.McpRoute.Params() params: IInheritedMcpInput,
+  ): Promise<IInheritedMcpResult> {
+    return { result: params.a + params.b };
+  }
+}
+
+@Controller()
+export class InheritedMcpController extends InheritedMcpControllerBase {
+  public async hidden(
+    params: IInheritedMcpInput,
+  ): Promise<IInheritedMcpResult> {
+    return { result: params.a - params.b };
+  }
+}

--- a/tests/test-sdk/features/mcp/src/test/features/test_mcp_tools_call.ts
+++ b/tests/test-sdk/features/mcp/src/test/features/test_mcp_tools_call.ts
@@ -40,6 +40,13 @@ export const test_mcp_tools_call = async (
     const addPayload = JSON.parse(addResult.content[0].text);
     TestValidator.equals("add result", addPayload.result, 5);
 
+    const multiplyResult: any = await client.callTool({
+      name: "multiply",
+      arguments: { a: 2, b: 3 },
+    });
+    const multiplyPayload = JSON.parse(multiplyResult.content[0].text);
+    TestValidator.equals("multiply result", multiplyPayload.result, 6);
+
     const weatherResult: any = await client.callTool({
       name: "get_weather",
       arguments: { location: "Tokyo", unit: "celsius" },

--- a/tests/test-sdk/features/mcp/src/test/features/test_mcp_tools_list.ts
+++ b/tests/test-sdk/features/mcp/src/test/features/test_mcp_tools_list.ts
@@ -31,7 +31,7 @@ export const test_mcp_tools_list = async (
   );
   try {
     const { tools } = await client.listTools();
-    TestValidator.equals("tool count", tools.length, 6);
+    TestValidator.equals("tool count", tools.length, 7);
 
     const names: string[] = tools.map((t) => t.name).sort();
     TestValidator.equals("tool names", names, [
@@ -39,6 +39,7 @@ export const test_mcp_tools_list = async (
       "divide",
       "echo_client",
       "get_weather",
+      "multiply",
       "notify",
       "subtract",
     ]);


### PR DESCRIPTION
Closes #1573.

## Summary

- discover MCP route methods across controller prototype chains
- keep derived overrides authoritative, including undecorated overrides
- cover inherited MCP tool listing and invocation in the SDK integration fixture

## Validation

- Not run locally by request.
- Awaiting the repository's Node 24 CI matrix.