### PR TITLE
Fix #1575 inherited route metadata

### DIFF
--- a/packages/core/src/decorators/McpRoute.ts
+++ b/packages/core/src/decorators/McpRoute.ts
@@ -137,11 +137,12 @@ export namespace McpRoute {
     propertyKey: string | symbol,
     value: IMcpRouteReflect.IArgument,
   ) => {
-    const array: IMcpRouteReflect.IArgument[] | undefined = Reflect.getMetadata(
-      "nestia/McpRoute/Parameters",
-      target,
-      propertyKey,
-    );
+    const array: IMcpRouteReflect.IArgument[] | undefined =
+      Reflect.getOwnMetadata(
+        "nestia/McpRoute/Parameters",
+        target,
+        propertyKey,
+      );
     if (array !== undefined) array.push(value);
     else
       Reflect.defineMetadata(

--- a/packages/core/src/decorators/SwaggerCustomizer.ts
+++ b/packages/core/src/decorators/SwaggerCustomizer.ts
@@ -23,8 +23,14 @@ export function SwaggerCustomizer(
     descriptor: TypedPropertyDescriptor<any>,
   ) {
     const array: Array<(props: SwaggerCustomizer.IProps) => unknown> = (() => {
-      if (Reflect.hasMetadata("nestia/SwaggerCustomizer", target, propertyKey))
-        return Reflect.getMetadata(
+      if (
+        Reflect.hasOwnMetadata(
+          "nestia/SwaggerCustomizer",
+          target,
+          propertyKey,
+        )
+      )
+        return Reflect.getOwnMetadata(
           "nestia/SwaggerCustomizer",
           target,
           propertyKey,

--- a/packages/core/src/decorators/SwaggerExample.ts
+++ b/packages/core/src/decorators/SwaggerExample.ts
@@ -160,11 +160,12 @@ const emplaceArrayOfParameters = (
   target: Object,
   propertyKey: string | symbol,
 ): SwaggerExample.IData<any>[] => {
-  const array: SwaggerExample.IData<any>[] | undefined = Reflect.getMetadata(
-    "nestia/SwaggerExample/Parameters",
-    target,
-    propertyKey,
-  );
+  const array: SwaggerExample.IData<any>[] | undefined =
+    Reflect.getOwnMetadata(
+      "nestia/SwaggerExample/Parameters",
+      target,
+      propertyKey,
+    );
   if (array !== undefined) return array;
   const newbie: SwaggerExample.IData<any>[] = [];
   Reflect.defineMetadata(

--- a/packages/core/src/decorators/WebSocketRoute.ts
+++ b/packages/core/src/decorators/WebSocketRoute.ts
@@ -225,7 +225,7 @@ export namespace WebSocketRoute {
     value: IWebSocketRouteReflect.IArgument,
   ) => {
     const array: IWebSocketRouteReflect.IArgument[] | undefined =
-      Reflect.getMetadata(
+      Reflect.getOwnMetadata(
         "nestia/WebSocketRoute/Parameters",
         target,
         propertyKey,

--- a/packages/sdk/src/analyses/ReflectControllerAnalyzer.ts
+++ b/packages/sdk/src/analyses/ReflectControllerAnalyzer.ts
@@ -97,16 +97,25 @@ export namespace ReflectControllerAnalyzer {
   };
 
   function _Get_prototype_entries(creator: any): Array<[string, unknown]> {
-    const keyList = Object.getOwnPropertyNames(creator.prototype);
-    const entries: Array<[string, unknown]> = keyList.map((key) => [
-      key,
-      creator.prototype[key],
-    ]);
+    const visited: Set<string> = new Set();
+    return iterate(creator);
 
-    const parent = Object.getPrototypeOf(creator);
-    if (parent.prototype !== undefined)
-      entries.push(..._Get_prototype_entries(parent));
+    function iterate(target: any): Array<[string, unknown]> {
+      const keyList: string[] = Object.getOwnPropertyNames(
+        target.prototype,
+      ).filter((key) => {
+        if (visited.has(key)) return false;
+        visited.add(key);
+        return true;
+      });
+      const entries: Array<[string, unknown]> = keyList.map((key) => [
+        key,
+        target.prototype[key],
+      ]);
 
-    return entries;
+      const parent: any = Object.getPrototypeOf(target);
+      if (parent.prototype !== undefined) entries.push(...iterate(parent));
+      return entries;
+    }
   }
 }

--- a/tests/test-sdk/features/mcp/src/controllers/InheritedMcpController.ts
+++ b/tests/test-sdk/features/mcp/src/controllers/InheritedMcpController.ts
@@ -10,14 +10,6 @@ export interface IInheritedMcpResult {
   result: number;
 }
 
-export interface IInheritedMcpBaseInput {
-  value: string;
-}
-
-export interface IInheritedMcpDerivedInput {
-  value: number;
-}
-
 export class InheritedMcpControllerBase {
   /** Return the product of two numbers. */
   @core.McpRoute("multiply")
@@ -38,9 +30,9 @@ export class InheritedMcpControllerBase {
   /** Must be replaced by the derived tool metadata. */
   @core.McpRoute("base_override")
   public async override(
-    @core.McpRoute.Params() params: IInheritedMcpBaseInput,
+    @core.McpRoute.Params() params: IInheritedMcpInput,
   ): Promise<IInheritedMcpResult> {
-    return { result: params.value.length };
+    return { result: params.a + params.b };
   }
 }
 
@@ -52,11 +44,11 @@ export class InheritedMcpController extends InheritedMcpControllerBase {
     return { result: params.a - params.b };
   }
 
-  /** Return the derived input doubled. */
+  /** Return the difference of the derived input fields. */
   @core.McpRoute("derived_override")
   public async override(
-    @core.McpRoute.Params() params: IInheritedMcpDerivedInput,
+    @core.McpRoute.Params() params: IInheritedMcpInput,
   ): Promise<IInheritedMcpResult> {
-    return { result: params.value * 2 };
+    return { result: params.a - params.b };
   }
 }

--- a/tests/test-sdk/features/mcp/src/controllers/InheritedMcpController.ts
+++ b/tests/test-sdk/features/mcp/src/controllers/InheritedMcpController.ts
@@ -10,6 +10,14 @@ export interface IInheritedMcpResult {
   result: number;
 }
 
+export interface IInheritedMcpBaseInput {
+  value: string;
+}
+
+export interface IInheritedMcpDerivedInput {
+  value: number;
+}
+
 export class InheritedMcpControllerBase {
   /** Return the product of two numbers. */
   @core.McpRoute("multiply")
@@ -26,6 +34,14 @@ export class InheritedMcpControllerBase {
   ): Promise<IInheritedMcpResult> {
     return { result: params.a + params.b };
   }
+
+  /** Must be replaced by the derived tool metadata. */
+  @core.McpRoute("base_override")
+  public async override(
+    @core.McpRoute.Params() params: IInheritedMcpBaseInput,
+  ): Promise<IInheritedMcpResult> {
+    return { result: params.value.length };
+  }
 }
 
 @Controller()
@@ -34,5 +50,13 @@ export class InheritedMcpController extends InheritedMcpControllerBase {
     params: IInheritedMcpInput,
   ): Promise<IInheritedMcpResult> {
     return { result: params.a - params.b };
+  }
+
+  /** Return the derived input doubled. */
+  @core.McpRoute("derived_override")
+  public async override(
+    @core.McpRoute.Params() params: IInheritedMcpDerivedInput,
+  ): Promise<IInheritedMcpResult> {
+    return { result: params.value * 2 };
   }
 }

--- a/tests/test-sdk/features/mcp/src/test/features/test_mcp_tools_call.ts
+++ b/tests/test-sdk/features/mcp/src/test/features/test_mcp_tools_call.ts
@@ -49,7 +49,7 @@ export const test_mcp_tools_call = async (
 
     const overrideResult: any = await client.callTool({
       name: "derived_override",
-      arguments: { value: 3 },
+      arguments: { a: 9, b: 3 },
     });
     const overridePayload = JSON.parse(overrideResult.content[0].text);
     TestValidator.equals("derived override result", overridePayload.result, 6);

--- a/tests/test-sdk/features/mcp/src/test/features/test_mcp_tools_call.ts
+++ b/tests/test-sdk/features/mcp/src/test/features/test_mcp_tools_call.ts
@@ -47,6 +47,13 @@ export const test_mcp_tools_call = async (
     const multiplyPayload = JSON.parse(multiplyResult.content[0].text);
     TestValidator.equals("multiply result", multiplyPayload.result, 6);
 
+    const overrideResult: any = await client.callTool({
+      name: "derived_override",
+      arguments: { value: 3 },
+    });
+    const overridePayload = JSON.parse(overrideResult.content[0].text);
+    TestValidator.equals("derived override result", overridePayload.result, 6);
+
     const weatherResult: any = await client.callTool({
       name: "get_weather",
       arguments: { location: "Tokyo", unit: "celsius" },

--- a/tests/test-sdk/features/mcp/src/test/features/test_mcp_tools_list.ts
+++ b/tests/test-sdk/features/mcp/src/test/features/test_mcp_tools_list.ts
@@ -31,11 +31,12 @@ export const test_mcp_tools_list = async (
   );
   try {
     const { tools } = await client.listTools();
-    TestValidator.equals("tool count", tools.length, 7);
+    TestValidator.equals("tool count", tools.length, 8);
 
     const names: string[] = tools.map((t) => t.name).sort();
     TestValidator.equals("tool names", names, [
       "add",
+      "derived_override",
       "divide",
       "echo_client",
       "get_weather",

--- a/tests/test-sdk/features/swagger-customizer/src/controllers/SwaggerController.ts
+++ b/tests/test-sdk/features/swagger-customizer/src/controllers/SwaggerController.ts
@@ -82,21 +82,25 @@ export class InheritedSwaggerControllerBase {
   @SwaggerCustomizer((props: SwaggerCustomizer.IProps) => {
     (props.route as any)["x-metadata-base"] = true;
   })
-  @TypedRoute.Get(":value")
-  public route(
-    @SwaggerExample.Parameter("base") @TypedParam("value") value: string,
-  ): string {
-    return value;
+  @TypedRoute.Get("route")
+  public route(): string {
+    return "base";
   }
 
   @SwaggerCustomizer((props: SwaggerCustomizer.IProps) => {
     (props.route as any)["x-metadata-inherited"] = true;
   })
-  @TypedRoute.Get("inherited/:value")
-  public inherited(
-    @SwaggerExample.Parameter("inherited")
-    @TypedParam("value")
-    value: string,
+  @TypedRoute.Get("inherited")
+  public inherited(): string {
+    return "inherited";
+  }
+
+  public example(@SwaggerExample.Parameter("base") value: string): string {
+    return value;
+  }
+
+  public inheritedExample(
+    @SwaggerExample.Parameter("inherited") value: string,
   ): string {
     return value;
   }
@@ -107,12 +111,12 @@ export class InheritedSwaggerController extends InheritedSwaggerControllerBase {
   @SwaggerCustomizer((props: SwaggerCustomizer.IProps) => {
     (props.route as any)["x-metadata-derived"] = true;
   })
-  @TypedRoute.Get(":value")
-  public route(
-    @SwaggerExample.Parameter("derived")
-    @TypedParam("value")
-    value: string,
-  ): string {
+  @TypedRoute.Get("route")
+  public route(): string {
+    return "derived";
+  }
+
+  public example(@SwaggerExample.Parameter("derived") value: string): string {
     return value;
   }
 }

--- a/tests/test-sdk/features/swagger-customizer/src/controllers/SwaggerController.ts
+++ b/tests/test-sdk/features/swagger-customizer/src/controllers/SwaggerController.ts
@@ -1,4 +1,9 @@
-import { SwaggerCustomizer, TypedParam, TypedRoute } from "@nestia/core";
+import {
+  SwaggerCustomizer,
+  SwaggerExample,
+  TypedParam,
+  TypedRoute,
+} from "@nestia/core";
 import { Controller, Param } from "@nestjs/common";
 import { tags } from "typia";
 
@@ -69,5 +74,45 @@ export class CustomController {
       readonlyProperty: [],
       readonlyBoth: [],
     };
+  }
+}
+
+@Controller("custom/inheritance/base")
+export class InheritedSwaggerControllerBase {
+  @SwaggerCustomizer((props: SwaggerCustomizer.IProps) => {
+    (props.route as any)["x-metadata-base"] = true;
+  })
+  @TypedRoute.Get(":value")
+  public route(
+    @SwaggerExample.Parameter("base") @TypedParam("value") value: string,
+  ): string {
+    return value;
+  }
+
+  @SwaggerCustomizer((props: SwaggerCustomizer.IProps) => {
+    (props.route as any)["x-metadata-inherited"] = true;
+  })
+  @TypedRoute.Get("inherited/:value")
+  public inherited(
+    @SwaggerExample.Parameter("inherited")
+    @TypedParam("value")
+    value: string,
+  ): string {
+    return value;
+  }
+}
+
+@Controller("custom/inheritance/derived")
+export class InheritedSwaggerController extends InheritedSwaggerControllerBase {
+  @SwaggerCustomizer((props: SwaggerCustomizer.IProps) => {
+    (props.route as any)["x-metadata-derived"] = true;
+  })
+  @TypedRoute.Get(":value")
+  public route(
+    @SwaggerExample.Parameter("derived")
+    @TypedParam("value")
+    value: string,
+  ): string {
+    return value;
   }
 }

--- a/tests/test-sdk/features/swagger-customizer/src/test/features/test_swagger_inherited_metadata.ts
+++ b/tests/test-sdk/features/swagger-customizer/src/test/features/test_swagger_inherited_metadata.ts
@@ -1,0 +1,55 @@
+import { TestValidator } from "@nestia/e2e";
+import fs from "fs";
+
+export const test_swagger_inherited_metadata = async (): Promise<void> => {
+  const swagger: any = JSON.parse(
+    await fs.promises.readFile(`${__dirname}/../../../swagger.json`, "utf8"),
+  );
+  const base: any =
+    swagger.paths["/custom/inheritance/base/{value}"].get;
+  const derived: any =
+    swagger.paths["/custom/inheritance/derived/{value}"].get;
+  const inherited: any =
+    swagger.paths["/custom/inheritance/derived/inherited/{value}"].get;
+
+  TestValidator.equals(
+    "base parameter example",
+    base.parameters[0].example,
+    "base",
+  );
+  TestValidator.equals(
+    "derived parameter example",
+    derived.parameters[0].example,
+    "derived",
+  );
+  TestValidator.equals(
+    "inherited parameter example",
+    inherited.parameters[0].example,
+    "inherited",
+  );
+  TestValidator.equals(
+    "base customizer",
+    base["x-metadata-base"],
+    true,
+  );
+  TestValidator.equals(
+    "base excludes derived customizer",
+    base["x-metadata-derived"],
+    undefined,
+  );
+  TestValidator.equals(
+    "derived excludes base customizer",
+    derived["x-metadata-base"],
+    undefined,
+  );
+  TestValidator.equals(
+    "derived customizer",
+    derived["x-metadata-derived"],
+    true,
+  );
+  TestValidator.equals(
+    "inherited customizer",
+    inherited["x-metadata-inherited"],
+    true,
+  );
+};

--- a/tests/test-sdk/features/swagger-customizer/src/test/features/test_swagger_inherited_metadata.ts
+++ b/tests/test-sdk/features/swagger-customizer/src/test/features/test_swagger_inherited_metadata.ts
@@ -1,30 +1,50 @@
 import { TestValidator } from "@nestia/e2e";
 import fs from "fs";
 
+import {
+  InheritedSwaggerController,
+  InheritedSwaggerControllerBase,
+} from "../../controllers/SwaggerController";
+
 export const test_swagger_inherited_metadata = async (): Promise<void> => {
   const swagger: any = JSON.parse(
     await fs.promises.readFile(`${__dirname}/../../../swagger.json`, "utf8"),
   );
   const base: any =
-    swagger.paths["/custom/inheritance/base/{value}"].get;
+    swagger.paths["/custom/inheritance/base/route"].get;
   const derived: any =
-    swagger.paths["/custom/inheritance/derived/{value}"].get;
+    swagger.paths["/custom/inheritance/derived/route"].get;
   const inherited: any =
-    swagger.paths["/custom/inheritance/derived/inherited/{value}"].get;
+    swagger.paths["/custom/inheritance/derived/inherited"].get;
+  const baseExamples: Array<{ example: string }> = Reflect.getOwnMetadata(
+    "nestia/SwaggerExample/Parameters",
+    InheritedSwaggerControllerBase.prototype,
+    "example",
+  );
+  const derivedExamples: Array<{ example: string }> = Reflect.getOwnMetadata(
+    "nestia/SwaggerExample/Parameters",
+    InheritedSwaggerController.prototype,
+    "example",
+  );
+  const inheritedExamples: Array<{ example: string }> = Reflect.getMetadata(
+    "nestia/SwaggerExample/Parameters",
+    InheritedSwaggerController.prototype,
+    "inheritedExample",
+  );
 
   TestValidator.equals(
-    "base parameter example",
-    base.parameters[0].example,
+    "base parameter example metadata",
+    baseExamples[0]?.example,
     "base",
   );
   TestValidator.equals(
-    "derived parameter example",
-    derived.parameters[0].example,
+    "derived parameter example metadata",
+    derivedExamples[0]?.example,
     "derived",
   );
   TestValidator.equals(
-    "inherited parameter example",
-    inherited.parameters[0].example,
+    "inherited parameter example metadata",
+    inheritedExamples[0]?.example,
     "inherited",
   );
   TestValidator.equals(

--- a/tests/test-sdk/features/websocket/src/controllers/CalculateController.ts
+++ b/tests/test-sdk/features/websocket/src/controllers/CalculateController.ts
@@ -1,3 +1,22 @@
+import { WebSocketRoute } from "@nestia/core";
+import { WebSocketAcceptor } from "tgrid";
+
+import { ICalcConfig } from "@api/lib/interfaces/ICalcConfig";
+import { ICalcEventListener } from "@api/lib/interfaces/ICalcEventListener";
+import { ISimpleCalculator } from "@api/lib/interfaces/ISimpleCalculator";
+
 import { CalculateControllerBase } from "./CalculateControllerBase";
 
-export class CalculateController extends CalculateControllerBase("calculate") {}
+export class CalculateController extends CalculateControllerBase("calculate") {
+  @WebSocketRoute("simple")
+  public async simple(
+    @WebSocketRoute.Acceptor()
+    acceptor: WebSocketAcceptor<
+      ICalcConfig,
+      ISimpleCalculator,
+      ICalcEventListener
+    >,
+  ): Promise<void> {
+    await super.simple(acceptor);
+  }
+}


### PR DESCRIPTION
Closes #1575.

Summary:
- keep MCP, WebSocket, Swagger example, and Swagger customizer writes on the owning prototype
- suppress overridden base members while reflecting SDK routes
- cover derived overrides and unchanged inherited Swagger metadata in transformed fixtures

Validation:
- Not run locally by request.
- Awaiting repository Node 24 CI.