### PR TITLE
Fix #1577 runtime Swagger error reporting

### DIFF
--- a/packages/sdk/src/NestiaSwaggerComposer.ts
+++ b/packages/sdk/src/NestiaSwaggerComposer.ts
@@ -101,6 +101,8 @@ export namespace NestiaSwaggerComposer {
           }),
         );
       }
+    if (project.errors.length)
+      throw report({ type: "error", errors: project.errors });
     AccessorAnalyzer.analyze(routes);
     return routes;
   };

--- a/tests/test-sdk/features/app/src/test/features/test_runtime_swagger.ts
+++ b/tests/test-sdk/features/app/src/test/features/test_runtime_swagger.ts
@@ -1,4 +1,22 @@
+import core from "@nestia/core";
+import { TestValidator } from "@nestia/e2e";
+import { Controller, INestApplication, Module } from "@nestjs/common";
+import { NestFactory } from "@nestjs/core";
+import { NestiaSwaggerComposer } from "@nestia/sdk";
 import typia, { OpenApi } from "typia";
+
+@Controller("invalid")
+class InvalidRouteController {
+  @core.TypedRoute.Get()
+  public get(): string {
+    return "valid";
+  }
+}
+
+@Module({
+  controllers: [InvalidRouteController],
+})
+class InvalidRouteModule {}
 
 export const test_runtime_swagger = async (): Promise<void> => {
   const response: Response = await fetch(
@@ -6,4 +24,60 @@ export const test_runtime_swagger = async (): Promise<void> => {
   );
   const document: OpenApi.IDocument = await response.json();
   typia.assert(document);
+};
+
+export const test_runtime_swagger_errors = async (): Promise<void> => {
+  const metadata: any = {
+    parameters: [],
+    success: {
+      type: { name: "bigint" },
+      imports: [],
+      primitive: {
+        success: true,
+        data: {
+          components: { aliases: [], arrays: [], objects: [], tuples: [] },
+          metadata: {
+            aliases: [],
+            any: false,
+            arrays: [],
+            atomics: [{ type: "bigint", tags: [] }],
+            constants: [],
+            escaped: null,
+            functions: [],
+            maps: [],
+            natives: [],
+            nullable: false,
+            objects: [],
+            optional: false,
+            required: true,
+            rest: null,
+            sets: [],
+            templates: [],
+            tuples: [],
+          },
+        },
+      },
+      resolved: { success: false, errors: [] },
+    },
+    exceptions: [],
+    description: null,
+    jsDocTags: [],
+  };
+  Reflect.defineMetadata(
+    "nestia/OperationMetadata",
+    metadata,
+    InvalidRouteController.prototype,
+    "get",
+  );
+
+  const app: INestApplication = await NestFactory.create(InvalidRouteModule, {
+    logger: false,
+  });
+  try {
+    await TestValidator.error("route-analysis errors", () =>
+      NestiaSwaggerComposer.document(app, {}),
+    );
+  } finally {
+    await app.close();
+  }
 };


### PR DESCRIPTION
Closes #1577.\n\n- reports route-analysis errors accumulated while composing runtime Swagger documents\n- adds an app fixture regression that requires the runtime composer to reject an invalid typed route\n\nValidation: Node 24 GitHub Actions CI pending; no local build or test was run.