### PR TITLE
fix(test): wait for a stopped child before deleting its directory

### DIFF
--- a/tests/test-sdk/start.js
+++ b/tests/test-sdk/start.js
@@ -698,7 +698,16 @@ const runSwaggerWatchFeature = async () => {
     );
   } finally {
     await stopChild(child);
-    await fs.promises.rm(cwd, { force: true, recursive: true });
+    // Windows does not release a watcher's handles the instant the process
+    // exits, and rmdir fails while any remain. `maxRetries` is what Node
+    // documents for EBUSY / ENOTEMPTY / EPERM; without it a correct teardown
+    // still loses a race it cannot see.
+    await fs.promises.rm(cwd, {
+      force: true,
+      recursive: true,
+      maxRetries: 10,
+      retryDelay: 100,
+    });
   }
 };
 
@@ -981,17 +990,23 @@ const waitUntil = async (title, predicate, exit, output) => {
   );
 };
 
+// Stop a child and do not return until it is actually gone.
+//
+// The previous shape raced the exit against `delay(2000).then(() => kill())`,
+// and that second branch resolves as soon as SIGKILL has been *sent*. A child
+// that ignores the first signal for two seconds -- a watch-mode compiler in the
+// middle of work is entitled to -- therefore let this resolve while the process
+// was still shutting down, and callers that delete the child's working
+// directory next hit EBUSY on Windows, where an open handle blocks rmdir.
 const stopChild = async (child) => {
   if (child.exitCode !== null || child.signalCode !== null) return;
   const exited = new Promise((resolve) => child.once("exit", resolve));
   child.kill();
-  await Promise.race([
-    exited,
-    delay(2_000).then(() => {
-      if (child.exitCode === null && child.signalCode === null)
-        child.kill("SIGKILL");
-    }),
-  ]);
+  await Promise.race([exited, delay(2_000)]);
+  if (child.exitCode === null && child.signalCode === null) {
+    child.kill("SIGKILL");
+    await Promise.race([exited, delay(2_000)]);
+  }
 };
 
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));


### PR DESCRIPTION
## Intent

Close #1614. `test-sdk`'s `swagger-watch` feature failed on Windows at roughly half of runs, always in teardown, and leaked its temporary directory every time it did.

```
EBUSY: resource busy or locked, rmdir '.tmp-swagger-watch-40840'
```

Because `test-sdk` stops the recursive run at the first failed feature, one flake also cost `test-transform-options` its turn — so the practical effect on Windows was a coin flip on the whole suite, not on one feature.

## Cause

The race is in `stopChild`, which is shared rather than specific to this feature:

```js
await Promise.race([
  exited,
  delay(2_000).then(() => {
    if (child.exitCode === null && child.signalCode === null)
      child.kill("SIGKILL");
  }),
]);
```

That second branch resolves as soon as `SIGKILL` has been **sent**, not after the process exits. A child that ignores the first `kill()` for two seconds — a watch-mode compiler doing work is entitled to — let `stopChild` return while the process was still shutting down, and the caller then deleted the directory that process was still watching. On Windows an open handle blocks `rmdir`; on Linux it does not, which is why no CI lane has ever seen this.

## Scope

Two changes, both in `tests/test-sdk/start.js`:

- `stopChild` awaits the exit it forced, under a second bound, instead of returning on the signal.
- The `runSwaggerWatchFeature` removal gets `maxRetries` / `retryDelay` — what Node documents for `EBUSY`, `ENOTEMPTY` and `EPERM` — because even a correctly awaited exit leaves a short window where Windows has not released the handles.

Deliberately scoped rather than sprayed across the harness. `runSwaggerWatchFeature` is the only site that spawns a long-lived child and then deletes its working directory; `stopChild` has no other caller today; the other `fs.promises.rm` sites (`runCliArgumentDiagnosticsFeature`, `runBundlePreserveFeature`) follow short-lived children that have already exited, and none has been observed to fail. Adding retries there would be speculation, not coverage.

## Verification

By repetition, because one pass proves nothing about a coin flip. Windows 11 / Node 24.19.0, `pnpm --filter ./tests/test-sdk start -- --only swagger-watch`:

| run | before the fix | after the fix |
| --- | --- | --- |
| 1 | 13,418 ms pass | 12,416 ms pass |
| 2 | **failed** — EBUSY | 12,673 ms pass |
| 3 | — | 12,608 ms pass |
| 4 | — | 12,381 ms pass |

Zero `.tmp-swagger-watch-*` directories survived any of the four runs. Before the fix, the second isolated run found one still present from an earlier failure.

The feature's own assertions are untouched — the failure was always after both `waitUntil` checks had already passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UpgzpPfMkrt8W6rAoofbkW
