### PR TITLE
fix(sdk): read typia's duplicate-name marker, and restore what its absence blocked

### DIFF
--- a/packages/core/native/go.mod
+++ b/packages/core/native/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/microsoft/typescript-go/shim/printer v0.0.0
 	github.com/microsoft/typescript-go/shim/scanner v0.0.0
 	github.com/samchon/ttsc/packages/ttsc v0.0.0
-	github.com/samchon/typia/packages/typia/native v0.0.0-20260709134626-fd1c6686950f
+	github.com/samchon/typia/packages/typia/native v0.0.0-20260813121538-087cfadaf755
 )
 
 require (

--- a/packages/core/native/go.sum
+++ b/packages/core/native/go.sum
@@ -38,8 +38,8 @@ github.com/samchon/ttsc/packages/ttsc/shim/vfs/cachedvfs v0.0.0-20260723023648-0
 github.com/samchon/ttsc/packages/ttsc/shim/vfs/cachedvfs v0.0.0-20260723023648-017b4d808689/go.mod h1:XS3LhXkn5xadyRe3tW+9+suW/7gh7dPdL43Q+s/lUDo=
 github.com/samchon/ttsc/packages/ttsc/shim/vfs/osvfs v0.0.0-20260723023648-017b4d808689 h1:8eS5wzCbyYiHUqPI3ee2mMuwTwET3QNPpRrn5BSeMlI=
 github.com/samchon/ttsc/packages/ttsc/shim/vfs/osvfs v0.0.0-20260723023648-017b4d808689/go.mod h1:otX+qw8aZLNCoBmCwMAn53Nw0RQTPzSoId3DxmE67So=
-github.com/samchon/typia/packages/typia/native v0.0.0-20260709134626-fd1c6686950f h1:8axuxtT7YdYhJy7so6SDxVK2oJPDkq8vl55K+nTudtw=
-github.com/samchon/typia/packages/typia/native v0.0.0-20260709134626-fd1c6686950f/go.mod h1:SJDrfiCEK5dtObhJeAl0iqelqmmFm/JIjfJ6z0kID60=
+github.com/samchon/typia/packages/typia/native v0.0.0-20260813121538-087cfadaf755 h1:bZrCYN5otJWieefGZBkcVQf2TmnyX9N43cAPxVs1bNM=
+github.com/samchon/typia/packages/typia/native v0.0.0-20260813121538-087cfadaf755/go.mod h1:pUTSG5IZxw8Hohle//RsDXnE+8ZhAus7mPDKFqzvZnk=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
 github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/xxh3 v1.1.0 h1:s7DLGDK45Dyfg7++yxI0khrfwq9661w9EN78eP/UZVs=

--- a/packages/core/native/transform/build.go
+++ b/packages/core/native/transform/build.go
@@ -72,6 +72,8 @@ func runBuild(args []string) int {
 		return 2
 	}
 	defer prog.Close()
+	releaseTypiaRegistries := registerTypiaDefaultLibraryClassifier(prog)
+	defer releaseTypiaRegistries()
 	if profile {
 		started = time.Now()
 	}

--- a/packages/core/native/transform/transform.go
+++ b/packages/core/native/transform/transform.go
@@ -14,6 +14,7 @@ import (
 	shimprinter "github.com/microsoft/typescript-go/shim/printer"
 	"github.com/samchon/nestia/packages/core/native/plugin"
 	"github.com/samchon/ttsc/packages/ttsc/driver"
+	schemametadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
 )
 
 type transformProjectOutput struct {
@@ -34,6 +35,13 @@ type transformProjectOutput struct {
 	// its narrow per-file one. Omitted only for a nil or unloaded program, which
 	// cannot happen here: LoadProgram failures return before this point.
 	Graph *driver.TransformGraph `json:"graph,omitempty"`
+	// Dependencies maps each transformed file (same keys as TypeScript) to the
+	// source files owning the declarations typia's metadata analysis consulted
+	// while generating that file's validators and stringifiers. A consumer
+	// unions them with Graph rather than choosing between them, so the list is
+	// additive: an omission costs nothing, and narrowing would require the
+	// separate `dependenciesComplete` declaration this envelope does not make.
+	Dependencies map[string][]string `json:"dependencies,omitempty"`
 }
 
 type transformCompilerDiagnostic struct {
@@ -83,6 +91,8 @@ func runTransform(args []string) int {
 		return 2
 	}
 	defer prog.Close()
+	releaseTypiaRegistries := registerTypiaDefaultLibraryClassifier(prog)
+	defer releaseTypiaRegistries()
 
 	// AST-integration source-to-source: typia's, core's, and any linked
 	// contributor's per-file node transformers run inside one shared EmitContext
@@ -144,6 +154,23 @@ func runTransformProject(
 	// sets parent pointers on the node tree it walks. ttsc's own `api-transform`
 	// host stamps it at the same point.
 	output.Graph = driver.NewTransformGraph(prog, cwd)
+	// `dependencies` is the second, narrower channel: the declaration files
+	// typia's analysis actually read for each file, reported alongside the graph
+	// rather than instead of it. The two are unioned by the consumer, so this
+	// list can only add inputs.
+	//
+	// The envelope deliberately declares no `dependenciesComplete`. That field
+	// transfers responsibility -- a listed file stops watching everything the
+	// reference closure carries -- and this host cannot honor it: whether a file
+	// is transformed at all depends on symbol resolutions that no listener
+	// reports, including the negative ones, and typia's own trigger set belongs
+	// to typia rather than to this host. See samchon/typia#2357.
+	collector := newTransformDependencyCollector(cwd, func(fileName string) bool {
+		sf := prog.SourceFile(fileName)
+		return sf != nil && prog.TSProgram.IsLibFile(sf)
+	})
+	schemametadata.MetadataDependency_listen(prog.Checker, collector.Touch)
+	defer schemametadata.MetadataDependency_release(prog.Checker)
 	for _, sf := range prog.SourceFiles() {
 		if sf.IsDeclarationFile {
 			continue
@@ -152,8 +179,11 @@ func runTransformProject(
 		if filepath.IsAbs(key) || key == ".." || strings.HasPrefix(key, "../") {
 			continue
 		}
+		collector.Begin(key)
 		output.TypeScript[key] = transformFileToTypeScript(prog, transforms, sf)
+		collector.End()
 	}
+	output.Dependencies = collector.ToJSON()
 	for _, diag := range *transformDiags {
 		output.Diagnostics = append(output.Diagnostics, transformDiagnosticToCompilerDiagnostic(diag))
 	}

--- a/packages/core/native/transform/typia_dependency.go
+++ b/packages/core/native/transform/typia_dependency.go
@@ -1,0 +1,117 @@
+package transform
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// transformDependencyCollector accumulates the declaration files typia's
+// metadata analysis reports while one project file is transformed, attributing
+// them to that file's envelope key.
+//
+// These are the envelope's `dependencies`: the source files owning the
+// declarations the analysis actually read to generate that file's validators and
+// stringifiers. A consumer unions them with the host-owned reference graph, so
+// the list is additive and an omission costs nothing; it never narrows anything
+// on its own. Narrowing is what `dependenciesComplete` would do, and this
+// envelope does not declare it -- see the note in runTransformProject.
+type transformDependencyCollector struct {
+	cwd     string
+	current string
+	files   map[string]map[string]bool
+	// isLibraryFile reports the compiler's own classification of a file as a
+	// default library. Classification must come from the program, never from a
+	// file-name pattern, for the reason registerTypiaDefaultLibraryClassifier
+	// records: a project's own ambient declaration file may legitimately be
+	// named `lib.custom.d.ts`, and dropping it by base name silently loses cache
+	// invalidation for the types it declares.
+	isLibraryFile func(fileName string) bool
+	// values memoizes fileName -> envelope value ("" for a dropped file). The
+	// listener reports the same declaration files repeatedly across call sites.
+	values map[string]string
+}
+
+func newTransformDependencyCollector(
+	cwd string,
+	isLibraryFile func(fileName string) bool,
+) *transformDependencyCollector {
+	return &transformDependencyCollector{
+		cwd:           cwd,
+		isLibraryFile: isLibraryFile,
+		files:         map[string]map[string]bool{},
+		values:        map[string]string{},
+	}
+}
+
+// Begin attributes subsequent touches to the given envelope key.
+func (collector *transformDependencyCollector) Begin(key string) {
+	collector.current = key
+}
+
+// End closes the window Begin opened, so a touch arriving between two files is
+// dropped rather than charged against whichever file happened to run last.
+func (collector *transformDependencyCollector) End() {
+	collector.current = ""
+}
+
+// Touch records one consulted declaration file for the current key. Default
+// library files, virtual URI sources (tsgo's `bundled:///` libraries), and the
+// transformed file itself are dropped: the first two are toolchain-versioned
+// rather than project inputs, and the third is already the cache key.
+func (collector *transformDependencyCollector) Touch(fileName string) {
+	if collector.current == "" {
+		return
+	}
+	value, memoized := collector.values[fileName]
+	if memoized == false {
+		value = collector.value(fileName)
+		collector.values[fileName] = value
+	}
+	if value == "" || value == collector.current {
+		return
+	}
+	set := collector.files[collector.current]
+	if set == nil {
+		set = map[string]bool{}
+		collector.files[collector.current] = set
+	}
+	set[value] = true
+}
+
+// value renders one reported file as its envelope key, or "" when it is dropped.
+// The key is driver.TransformOutputKey, the same one `typescript` and `graph`
+// use, so a consumer joins every section by key.
+func (collector *transformDependencyCollector) value(fileName string) string {
+	if strings.Contains(fileName, "://") || collector.isLibraryFile(fileName) {
+		return ""
+	}
+	return driver.TransformOutputKey(collector.cwd, fileName)
+}
+
+// ToJSON renders the collected sets as the envelope's `dependencies` map with
+// deterministically sorted values, or nil when nothing was collected. The nil
+// keeps the field off the wire entirely, which is what an envelope with nothing
+// to report must send.
+func (collector *transformDependencyCollector) ToJSON() map[string][]string {
+	if len(collector.files) == 0 {
+		return nil
+	}
+	output := map[string][]string{}
+	for key, set := range collector.files {
+		if len(set) == 0 {
+			continue
+		}
+		values := make([]string, 0, len(set))
+		for value := range set {
+			values = append(values, value)
+		}
+		sort.Strings(values)
+		output[key] = values
+	}
+	if len(output) == 0 {
+		return nil
+	}
+	return output
+}

--- a/packages/core/native/transform/typia_registry.go
+++ b/packages/core/native/transform/typia_registry.go
@@ -1,0 +1,40 @@
+package transform
+
+import (
+	shimast "github.com/microsoft/typescript-go/shim/ast"
+	"github.com/samchon/ttsc/packages/ttsc/driver"
+	schemametadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
+)
+
+// registerTypiaDefaultLibraryClassifier hands typia's metadata analysis the
+// program's own default-library classification and returns the release the
+// caller defers.
+//
+// @nestia/core hosts typia's transform rather than reimplementing it, so it
+// owes that analysis the same per-program registrations typia's own host
+// installs. Runtime-native identity is decided from this classifier: a global is
+// the JavaScript built-in only when a runtime authority declares it. With no
+// classifier registered the analysis falls back to a `lib.*.d.ts` base-name
+// test, and a default library is not recognizable from its file name --
+// `libReplacement` points it at `node_modules/@typescript/lib-es2022/index.d.ts`,
+// which does not even start with `lib.`, while `lib.d.ts` is an ordinary
+// published file name any dependency may use. Without this, the same DTO
+// generates one validator through typia's plugin and a different one through
+// nestia's host.
+//
+// The registry is keyed by checker, so the release must run before the program
+// closes; otherwise a closed program's checker stays reachable from a
+// process-global map.
+func registerTypiaDefaultLibraryClassifier(prog *driver.Program) func() {
+	if prog == nil || prog.TSProgram == nil {
+		return func() {}
+	}
+	program := prog.TSProgram
+	checker := prog.Checker
+	schemametadata.MetadataDefaultLibrary_register(checker, func(source *shimast.SourceFile) bool {
+		return source != nil && program.IsLibFile(source)
+	})
+	return func() {
+		schemametadata.MetadataDefaultLibrary_release(checker)
+	}
+}

--- a/packages/core/test/go.mod
+++ b/packages/core/test/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/microsoft/typescript-go/shim/vfs v0.0.0 // indirect
 	github.com/microsoft/typescript-go/shim/vfs/cachedvfs v0.0.0 // indirect
 	github.com/microsoft/typescript-go/shim/vfs/osvfs v0.0.0 // indirect
-	github.com/samchon/typia/packages/typia/native v0.0.0-20260709134626-fd1c6686950f // indirect
+	github.com/samchon/typia/packages/typia/native v0.0.0-20260813121538-087cfadaf755 // indirect
 	github.com/zeebo/xxh3 v1.1.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect

--- a/packages/core/test/go.sum
+++ b/packages/core/test/go.sum
@@ -40,6 +40,8 @@ github.com/samchon/ttsc/packages/ttsc/shim/vfs/osvfs v0.0.0-20260723023648-017b4
 github.com/samchon/ttsc/packages/ttsc/shim/vfs/osvfs v0.0.0-20260723023648-017b4d808689/go.mod h1:otX+qw8aZLNCoBmCwMAn53Nw0RQTPzSoId3DxmE67So=
 github.com/samchon/typia/packages/typia/native v0.0.0-20260709134626-fd1c6686950f h1:8axuxtT7YdYhJy7so6SDxVK2oJPDkq8vl55K+nTudtw=
 github.com/samchon/typia/packages/typia/native v0.0.0-20260709134626-fd1c6686950f/go.mod h1:SJDrfiCEK5dtObhJeAl0iqelqmmFm/JIjfJ6z0kID60=
+github.com/samchon/typia/packages/typia/native v0.0.0-20260813121538-087cfadaf755 h1:bZrCYN5otJWieefGZBkcVQf2TmnyX9N43cAPxVs1bNM=
+github.com/samchon/typia/packages/typia/native v0.0.0-20260813121538-087cfadaf755/go.mod h1:pUTSG5IZxw8Hohle//RsDXnE+8ZhAus7mPDKFqzvZnk=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
 github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/xxh3 v1.1.0 h1:s7DLGDK45Dyfg7++yxI0khrfwq9661w9EN78eP/UZVs=

--- a/packages/core/test/helpers_project_envelope_test.go
+++ b/packages/core/test/helpers_project_envelope_test.go
@@ -15,9 +15,10 @@ import (
 // dropped struct tag would keep a producer-typed decode green while the real
 // consumer — `@ttsc/unplugin`, which reads this JSON — saw nothing.
 type projectTransformEnvelope struct {
-	Diagnostics []map[string]any       `json:"diagnostics"`
-	TypeScript  map[string]string      `json:"typescript"`
-	Graph       *projectTransformGraph `json:"graph"`
+	Diagnostics  []map[string]any       `json:"diagnostics"`
+	TypeScript   map[string]string      `json:"typescript"`
+	Graph        *projectTransformGraph `json:"graph"`
+	Dependencies map[string][]string    `json:"dependencies"`
 }
 
 // projectTransformGraph mirrors ttsc's `ITtscCompilerTransformation.IReferenceGraph`.

--- a/packages/core/test/transform_project_envelope_reports_consulted_declarations_test.go
+++ b/packages/core/test/transform_project_envelope_reports_consulted_declarations_test.go
@@ -1,0 +1,37 @@
+package test
+
+import "testing"
+
+// TestTransformProjectEnvelopeReportsConsultedDeclarations verifies the
+// project-mode envelope's `dependencies` section lists, for a controller whose
+// decorators produced generated validators, the DTO declaration file the
+// analysis read to produce them — and lists nothing for a controller that
+// consulted no declaration at all.
+//
+// The section is the transform's own account of its inputs, next to the
+// compiler-owned `graph`. A consumer unions the two, so this list is additive
+// and an omission costs invalidation breadth rather than correctness. It is
+// still the channel a future `dependenciesComplete` declaration would narrow to,
+// so a wrong entry here is the seed of a stale output later: a file that lands
+// in the list without having been consulted, or a consulted file that never
+// arrives, both misdescribe what the generated code was built from.
+//
+//  1. Run project-mode transform over the body feature with its own cwd.
+//  2. Assert TypedBodyController's entry carries the DTO its `@TypedBody` and
+//     `@TypedRoute` types resolve to, keyed as `typescript` keys it.
+//  3. Assert HealthController — whose route type is a bare literal and whose
+//     imports are only `@nestia/core` and `@nestjs/common` — carries no entry.
+func TestTransformProjectEnvelopeReportsConsultedDeclarations(t *testing.T) {
+	envelope := runProjectTransformEnvelope(t, "body")
+	if envelope.Dependencies == nil {
+		t.Fatalf("project-mode envelope carries no dependencies section")
+	}
+	const controller = "src/controllers/TypedBodyController.ts"
+	const structure = "src/api/structures/IBbsArticle.ts"
+	mustListContain(t, "dependencies["+controller+"]", envelope.Dependencies[controller], structure)
+
+	const health = "src/controllers/HealthController.ts"
+	if entries, ok := envelope.Dependencies[health]; ok {
+		t.Fatalf("dependencies must not carry %q, got %v", health, entries)
+	}
+}

--- a/packages/sdk/native/go.mod
+++ b/packages/sdk/native/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/microsoft/typescript-go/shim/scanner v0.0.0
 	github.com/samchon/nestia/packages/core/native v0.0.0
 	github.com/samchon/ttsc/packages/ttsc v0.0.0
-	github.com/samchon/typia/packages/typia/native v0.0.0-20260709134626-fd1c6686950f
+	github.com/samchon/typia/packages/typia/native v0.0.0-20260813121538-087cfadaf755
 )
 
 require (

--- a/packages/sdk/native/go.sum
+++ b/packages/sdk/native/go.sum
@@ -38,8 +38,8 @@ github.com/samchon/ttsc/packages/ttsc/shim/vfs/cachedvfs v0.0.0-20260723023648-0
 github.com/samchon/ttsc/packages/ttsc/shim/vfs/cachedvfs v0.0.0-20260723023648-017b4d808689/go.mod h1:XS3LhXkn5xadyRe3tW+9+suW/7gh7dPdL43Q+s/lUDo=
 github.com/samchon/ttsc/packages/ttsc/shim/vfs/osvfs v0.0.0-20260723023648-017b4d808689 h1:8eS5wzCbyYiHUqPI3ee2mMuwTwET3QNPpRrn5BSeMlI=
 github.com/samchon/ttsc/packages/ttsc/shim/vfs/osvfs v0.0.0-20260723023648-017b4d808689/go.mod h1:otX+qw8aZLNCoBmCwMAn53Nw0RQTPzSoId3DxmE67So=
-github.com/samchon/typia/packages/typia/native v0.0.0-20260709134626-fd1c6686950f h1:8axuxtT7YdYhJy7so6SDxVK2oJPDkq8vl55K+nTudtw=
-github.com/samchon/typia/packages/typia/native v0.0.0-20260709134626-fd1c6686950f/go.mod h1:SJDrfiCEK5dtObhJeAl0iqelqmmFm/JIjfJ6z0kID60=
+github.com/samchon/typia/packages/typia/native v0.0.0-20260813121538-087cfadaf755 h1:bZrCYN5otJWieefGZBkcVQf2TmnyX9N43cAPxVs1bNM=
+github.com/samchon/typia/packages/typia/native v0.0.0-20260813121538-087cfadaf755/go.mod h1:pUTSG5IZxw8Hohle//RsDXnE+8ZhAus7mPDKFqzvZnk=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
 github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/xxh3 v1.1.0 h1:s7DLGDK45Dyfg7++yxI0khrfwq9661w9EN78eP/UZVs=

--- a/packages/sdk/src/generates/SdkGenerator.ts
+++ b/packages/sdk/src/generates/SdkGenerator.ts
@@ -7,6 +7,7 @@ import { IReflectType } from "../structures/IReflectType";
 import { ITypedApplication } from "../structures/ITypedApplication";
 import { ITypedHttpRoute } from "../structures/ITypedHttpRoute";
 import { ITypedMcpRoute } from "../structures/ITypedMcpRoute";
+import { StringUtil } from "../utils/StringUtil";
 import { CloneGenerator } from "./CloneGenerator";
 import { SdkDistributionComposer } from "./internal/SdkDistributionComposer";
 import { SdkFileProgrammer } from "./internal/SdkFileProgrammer";
@@ -145,11 +146,12 @@ export namespace SdkGenerator {
       });
   };
 
+  // Deliberately not `StringUtil.isImplicit`: that one also answers `object`,
+  // and this asks a different question -- whether a *return type* is unnamed
+  // enough to diagnose. Only the anonymous-marker list is shared, because that
+  // is the part that drifts when typia changes how it spells a duplicate.
   const isImplicitType = (type: IReflectType): boolean =>
-    type.name === "__type" ||
-    type.name === "__object" ||
-    type.name.startsWith("__type.") ||
-    type.name.startsWith("__object.") ||
+    StringUtil.isAnonymous(type.name) ||
     type.name.includes("readonly [") ||
     (!!type.typeArguments?.length && type.typeArguments.some(isImplicitType));
 

--- a/packages/sdk/src/generates/internal/SdkHttpCloneProgrammer.ts
+++ b/packages/sdk/src/generates/internal/SdkHttpCloneProgrammer.ts
@@ -48,7 +48,7 @@ export namespace SdkHttpCloneProgrammer {
     programmer: (importer: ImportDictionary) => Node;
   }) => {
     let next: Map<string, IModule> = props.dict;
-    const accessors: string[] = props.name.split(".");
+    const accessors: string[] = StringUtil.accessorsOf(props.name);
     const modulo: IPointer<IModule> = { value: null! };
 
     accessors.forEach((acc, i) => {
@@ -71,7 +71,7 @@ export namespace SdkHttpCloneProgrammer {
       FilePrinter.description(
         factory.createTypeAliasDeclaration(
           [factory.createToken(SyntaxKind.ExportKeyword)],
-          alias.name.split(".").at(-1)!,
+          StringUtil.accessorsOf(alias.name).at(-1)!,
           [],
           SdkTypeProgrammer.write(project)(importer)(alias.value) as TypeNode,
         ),
@@ -85,7 +85,7 @@ export namespace SdkHttpCloneProgrammer {
       return FilePrinter.description(
         factory.createTypeAliasDeclaration(
           [factory.createToken(SyntaxKind.ExportKeyword)],
-          object.name.split(".").at(-1)!,
+          StringUtil.accessorsOf(object.name).at(-1)!,
           [],
           SdkTypeProgrammer.write_object(project)(importer)(object) as TypeNode,
         ),

--- a/packages/sdk/src/generates/internal/SdkHttpCloneReferencer.ts
+++ b/packages/sdk/src/generates/internal/SdkHttpCloneReferencer.ts
@@ -120,7 +120,7 @@ export namespace SdkHttpCloneReferencer {
   }): void => {
     const enroll = (key: string) => {
       if (key.length && StringUtil.isImplicit(key) === false)
-        p.unique.add(key.split(".")[0]!);
+        p.unique.add(StringUtil.accessorsOf(key)[0]!);
     };
     for (const alias of p.metadata.aliases) enroll(alias.type!.name);
     for (const array of p.metadata.arrays) enroll(array.type!.name);

--- a/packages/sdk/src/generates/internal/SdkTypeProgrammer.ts
+++ b/packages/sdk/src/generates/internal/SdkTypeProgrammer.ts
@@ -18,6 +18,7 @@ import {
   sizeOf,
 } from "../../internal/legacy";
 import { INestiaProject } from "../../structures/INestiaProject";
+import { StringUtil } from "../../utils/StringUtil";
 import { FilePrinter } from "./FilePrinter";
 import { ImportDictionary } from "./ImportDictionary";
 import { SdkTypeTagProgrammer } from "./SdkTypeTagProgrammer";
@@ -53,13 +54,12 @@ export namespace SdkTypeProgrammer {
         union.push(write_array(project)(importer)(array as MetadataArray));
       for (const object of meta.objects) {
         const target = object.type as MetadataObjectType;
-        if (
-          target.name === "object" ||
-          target.name === "__type" ||
-          target.name.startsWith("__type.") ||
-          target.name === "__object" ||
-          target.name.startsWith("__object.")
-        )
+        // One definition of "this type has no name to reference". This was a
+        // second copy of `StringUtil.isImplicit`, and the copies drifted: only
+        // the dotted spelling was listed here, so a duplicated anonymous type
+        // -- `__type-o1` under typia's current separator -- was referenced as a
+        // module that the declaration side had correctly refused to write.
+        if (StringUtil.isImplicit(target.name))
           union.push(write_object(project)(importer)(target));
         else union.push(writeAlias(project)(importer)(target));
       }
@@ -301,7 +301,13 @@ export namespace SdkTypeProgrammer {
     (importer: ImportDictionary) =>
     (meta: MetadataAliasType | MetadataObjectType): TypeNode => {
       importInternalFile(project)(importer)(meta.name);
-      return factory.createTypeReferenceNode(meta.name);
+      // The reference has to spell the accessor path the declaration was
+      // written under, not the raw metadata name: a duplicated name carries
+      // typia's `-o<counter>` marker, which declares as a namespace member and
+      // therefore refers as `IDirectory.o1`.
+      return factory.createTypeReferenceNode(
+        StringUtil.accessorsOf(meta.name).join("."),
+      );
     };
 
   const write_native = (name: string): TypeNode =>
@@ -377,12 +383,14 @@ const importInternalFile =
   (project: INestiaProject) =>
   (importer: ImportDictionary) =>
   (name: string) => {
-    const top: string = name.split(".")[0]!;
+    // The file is named after the first accessor, so a duplicated name lands
+    // in its base type's file rather than inventing `IDirectory-o1.ts`.
+    const top: string = StringUtil.accessorsOf(name)[0]!;
     if (importer.file === `${project.config.output}/structures/${top}.ts`)
       return;
     importer.internal({
       declaration: true,
-      file: `${project.config.output}/structures/${name.split(".")[0]}`,
+      file: `${project.config.output}/structures/${top}`,
       type: "element",
       name: top,
     });

--- a/packages/sdk/src/utils/StringUtil.ts
+++ b/packages/sdk/src/utils/StringUtil.ts
@@ -7,11 +7,51 @@ export namespace StringUtil {
     (change: string): string =>
       keep.includes(change) ? escapeDuplicate(keep)(`_${change}`) : change;
 
-  export const isImplicit = (str: string) =>
-    str === "object" ||
+  /**
+   * The marker names typia gives a type that has no identity of its own: an
+   * anonymous object literal, and the same literal after a duplicate id was
+   * minted for it.
+   *
+   * One definition because the spellings drift. typia qualifies with `.` and
+   * disambiguates a duplicate with `-o<counter>`, so the same anonymous type
+   * reads `__type`, `__type.o1` or `__type-o1` depending on the release and on
+   * whether its name collided. Three call sites carried their own copy of this
+   * list, only one of them learned the `-` spelling, and the two that did not
+   * declared and referenced modules that do not exist.
+   */
+  export const isAnonymous = (str: string): boolean =>
     str === "__type" ||
     str === "__object" ||
     str.startsWith("__type.") ||
     str.startsWith("__object.") ||
-    str.includes("readonly [");
+    str.startsWith("__type-") ||
+    str.startsWith("__object-");
+
+  export const isImplicit = (str: string) =>
+    str === "object" || isAnonymous(str) || str.includes("readonly [");
+
+  /**
+   * Split a typia metadata name into the accessor path a generated SDK declares
+   * it under.
+   *
+   * Typia separates a qualified name with `.` and a _duplicated_ name from its
+   * disambiguating counter with a trailing `-o<counter>`
+   * (`MetadataCollection.composeName`). Those are different relations and only
+   * the first is a namespace boundary -- which is exactly why typia stopped
+   * spelling the second one with a dot, where the two were indistinguishable.
+   *
+   * A duplicate still has to become some declarable identifier, and the counter
+   * is rendered as the last accessor: `IDirectory-o1` declares as `namespace
+   * IDirectory { type o1 }`, byte-identical to what the previous
+   * `IDirectory.o1` spelling produced. Reading the marker here rather than
+   * guessing at the name is what the new separator makes possible -- `-` cannot
+   * occur in a qualified name, so unlike the old spelling this cannot be
+   * confused with one.
+   */
+  export const accessorsOf = (name: string): string[] => {
+    const duplicated: RegExpMatchArray | null = name.match(/^(.+)-o(\d+)$/);
+    return duplicated === null
+      ? name.split(".")
+      : [...duplicated[1]!.split("."), `o${duplicated[2]!}`];
+  };
 }

--- a/packages/sdk/test/go.mod
+++ b/packages/sdk/test/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/microsoft/typescript-go/shim/vfs v0.0.0 // indirect
 	github.com/microsoft/typescript-go/shim/vfs/cachedvfs v0.0.0 // indirect
 	github.com/microsoft/typescript-go/shim/vfs/osvfs v0.0.0 // indirect
-	github.com/samchon/typia/packages/typia/native v0.0.0-20260709134626-fd1c6686950f // indirect
+	github.com/samchon/typia/packages/typia/native v0.0.0-20260813121538-087cfadaf755 // indirect
 	github.com/zeebo/xxh3 v1.1.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect

--- a/packages/sdk/test/go.sum
+++ b/packages/sdk/test/go.sum
@@ -40,6 +40,8 @@ github.com/samchon/ttsc/packages/ttsc/shim/vfs/osvfs v0.0.0-20260723023648-017b4
 github.com/samchon/ttsc/packages/ttsc/shim/vfs/osvfs v0.0.0-20260723023648-017b4d808689/go.mod h1:otX+qw8aZLNCoBmCwMAn53Nw0RQTPzSoId3DxmE67So=
 github.com/samchon/typia/packages/typia/native v0.0.0-20260709134626-fd1c6686950f h1:8axuxtT7YdYhJy7so6SDxVK2oJPDkq8vl55K+nTudtw=
 github.com/samchon/typia/packages/typia/native v0.0.0-20260709134626-fd1c6686950f/go.mod h1:SJDrfiCEK5dtObhJeAl0iqelqmmFm/JIjfJ6z0kID60=
+github.com/samchon/typia/packages/typia/native v0.0.0-20260813121538-087cfadaf755 h1:bZrCYN5otJWieefGZBkcVQf2TmnyX9N43cAPxVs1bNM=
+github.com/samchon/typia/packages/typia/native v0.0.0-20260813121538-087cfadaf755/go.mod h1:pUTSG5IZxw8Hohle//RsDXnE+8ZhAus7mPDKFqzvZnk=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
 github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/xxh3 v1.1.0 h1:s7DLGDK45Dyfg7++yxI0khrfwq9661w9EN78eP/UZVs=

--- a/tests/test-transform-options/src/native-global/lib.custom.d.ts
+++ b/tests/test-transform-options/src/native-global/lib.custom.d.ts
@@ -1,0 +1,13 @@
+/**
+ * A user-authored global that borrows a runtime native's name, in a file whose
+ * name borrows a default library's shape.
+ *
+ * Both halves matter. `Blob` is a name typia gives runtime-native identity, and
+ * `lib.*.d.ts` is the pattern the metadata analysis falls back to when no host
+ * tells it which files the program actually treats as default libraries.
+ * Nothing here is a runtime authority, so this `Blob` must be validated
+ * structurally.
+ */
+interface Blob {
+  customField: string;
+}

--- a/tests/test-transform-options/src/native-global/runtime.ts
+++ b/tests/test-transform-options/src/native-global/runtime.ts
@@ -1,0 +1,7 @@
+import typia from "typia";
+
+export interface IRuntimeGlobal {
+  blob: Blob;
+}
+
+export const check = typia.createIs<IRuntimeGlobal>();

--- a/tests/test-transform-options/src/native-global/user.ts
+++ b/tests/test-transform-options/src/native-global/user.ts
@@ -1,0 +1,7 @@
+import typia from "typia";
+
+export interface IUserGlobal {
+  blob: Blob;
+}
+
+export const check = typia.createIs<IUserGlobal>();

--- a/tests/test-transform-options/start.js
+++ b/tests/test-transform-options/start.js
@@ -200,6 +200,83 @@ const main = () => {
         result.graph.configs,
       )}`,
     );
+
+    // `dependencies` is the second channel: the declarations the analysis
+    // actually read for this file, reported alongside the graph and unioned
+    // with it by the consumer.
+    assert(
+      result.dependencies !== undefined,
+      "envelope carries no dependencies section",
+    );
+    assert(
+      (result.dependencies[CONTROLLER_KEY] ?? []).includes(DTO_KEY),
+      `dependencies[${CONTROLLER_KEY}] omits ${DTO_KEY}: ${JSON.stringify(
+        result.dependencies[CONTROLLER_KEY],
+      )}`,
+    );
+    // Negative twin: a file the transform generated nothing for consulted no
+    // declaration, so it gets no entry rather than an empty or inherited one.
+    assert(
+      result.dependencies[UNRELATED_KEY] === undefined,
+      `dependencies must not carry ${UNRELATED_KEY}: ${JSON.stringify(
+        result.dependencies[UNRELATED_KEY],
+      )}`,
+    );
+  });
+
+  // Runtime-native identity, decided from the program's own default-library set
+  // rather than from a file name. `@nestia/core` hosts typia's transform, so it
+  // owes that analysis the classification typia's own host installs; without it
+  // the analysis falls back to a `lib.*.d.ts` base-name test and any file that
+  // matches the pattern is taken for a runtime authority.
+  //
+  // The consequence is not cosmetic. A type promoted to native identity loses
+  // its members to an `instanceof` check, so a purely user-authored global is
+  // validated by a constructor that need not exist at runtime -- a
+  // `ReferenceError` where the members would have been checked.
+  measure("user-authored global keeps its members", () => {
+    const user = loadRaw(
+      compile({
+        name: "native-global-user",
+        source: "native-global/user",
+        plugin: {},
+        // No DOM, no `@types`, so this program's only `Blob` is the one
+        // `lib.custom.d.ts` declares beside it.
+        compilerOptions: { lib: ["ESNext"], types: [] },
+        include: [
+          "../src/native-global/lib.custom.d.ts",
+          "../src/native-global/user.ts",
+        ],
+      }),
+    );
+    assert(
+      user.check({ blob: { customField: "x" } }) === true,
+      "a user-authored global Blob was not validated structurally",
+    );
+    assert(
+      user.check({ blob: {} }) === false,
+      "a user-authored global Blob accepted a value missing its member",
+    );
+
+    // The one-axis twin: same type name, same shape of use, real provenance.
+    // `Blob` from `lib.dom.d.ts` is a runtime authority, so it must keep
+    // native identity and reject a structural lookalike.
+    const runtime = loadRaw(
+      compile({
+        name: "native-global-runtime",
+        source: "native-global/runtime",
+        plugin: {},
+        compilerOptions: { lib: ["ESNext", "DOM"], types: [] },
+      }),
+    );
+    assert(
+      runtime.check({ blob: { customField: "x" } }) === false,
+      "a real DOM Blob lost its native identity to a structural check",
+    );
+    assert(
+      runtime.check({ blob: new Blob([]) }) === true,
+      "a real DOM Blob rejected an actual Blob instance",
+    );
   });
 
   measure("aliased core imports", () => {
@@ -319,6 +396,7 @@ const writeProject = (props) => {
         compilerOptions: {
           outDir: `./${props.name}`,
           rootDir: "../src",
+          ...props.compilerOptions,
           plugins: [
             {
               transform: "typia/lib/transform",
@@ -385,6 +463,15 @@ const load = (file) => {
     Module._load = original;
   }
   return captured;
+};
+
+// `load`'s counterpart for a module that exports the transform's product
+// directly instead of feeding it to a decorator. Nothing needs stubbing: these
+// fixtures import only `typia`, whose runtime helpers the emitted code calls for
+// real, which is the point — the assertion is on behavior, not on text.
+const loadRaw = (file) => {
+  delete require.cache[file];
+  return require(file);
 };
 
 const assertValidate = (option, validator) => {


### PR DESCRIPTION
## Intent

Close #1604 and #1601, and close the typia skew the two of them were holding open.

`897af4ab` withdrew `679355e8` because the Go `typia` pin it carried broke four `test-sdk` features. The break was never in the transform: typia mints a duplicated metadata name as `<base>-o<counter>` from 13.1.19 onward, and `@nestia/sdk`'s clone generator read that name as a dot-separated qualified name. So #1601 has been blocked on #1604 ever since, and no typia version separates them — the symbol #1601 needs arrives in 13.2.0, the separator that breaks the reader arrives one release earlier.

Two commits: fix the reader, then restore what the withdrawal took with it.

## `6178bc18` — read the marker where it is minted

typia moved off the dot deliberately. A qualified name separates a namespace from its member with `.`, so an invented id could not be told apart from a real one and the loser was dropped from the document outright. The new separator is what makes reading it *safe*: `-` cannot occur in a qualified name, so unlike the old spelling it cannot be confused with one.

`StringUtil.accessorsOf` is the one place that knows this, and it renders the counter as the last accessor — `IDirectory-o1` declares as `namespace IDirectory { type o1 }`, byte-identical to what the previous spelling produced. **No generated name changes**, so no consumer of a generated SDK sees a rename.

**The bug was one predicate copied three times**, of which only one ever learned the new spelling — `StringUtil.isImplicit`, an inline copy in `SdkTypeProgrammer`, and `SdkGenerator.isImplicitType`. Patching each copy is what produced this class of defect in the first place, so the shared part is extracted as `StringUtil.isAnonymous` and all three call it. No `__type` literal survives outside `StringUtil.ts`.

Deliberately **not** merged further: `isImplicitType` also answers `object` and `isImplicit` does not, because they ask different questions — "is this return type unnamed enough to diagnose" versus "does this name refer to a declarable module". Unifying them would newly diagnose `object` return types, a behaviour change no issue asked for.

Six accessor sites now share `accessorsOf`. The first round of this fix corrected only the declarations and *looked* like it worked — `namespace IDirectory { type o1 }` was back and no `__type-oN` module was written — but the references still spelled `IDirectory-o1` across 13 files. The audit, not the symptom, decided the scope.

## `060de80d` — restore what the withdrawal took

A revert of the revert, bringing back `typia_registry.go` (#1601) and `typia_dependency.go` (#1598 step 2), both of which were blocked by the same pin.

One deliberate difference from a plain revert: **the pin stays at 13.3.0** rather than returning to the 13.2.0 that `679355e8` set. `897af4ab`'s own reasoning is why — it withdrew the pin because the reader misread the name shape, not because the version was wrong. What has to come back is the code, not the older version.

## Verification

| check | result |
| --- | --- |
| `packages/core/native` and `packages/sdk/native` `go build` against typia 13.3.0 | 0 — proves both restored symbols exist there, rather than assuming |
| all eight `clone*` features | green, including the four `897af4ab` withdrew for |
| `-o` residue in any generated file | **0** |
| `__type-oN` modules written | **0** |
| `namespace IDirectory { export type o1 }` | restored |
| `pnpm build`, `pnpm test:go` both modules | 0 |
| `tests/test-transform-options` | all seven cases, including `transform envelope graph` and `user-authored global keeps its members` — #1601's own one-axis pair |

Before the fix, the same pin produced `ITextFile-o1.ts`, `__type-o1.ts` and a TypeScript parse error.

The skew this closes: `catalog:samchon` moved to typia `^13.3.0` in #1613 while the Go generator stayed between 13.0.0 and 13.0.1. Both sides are now 13.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UpgzpPfMkrt8W6rAoofbkW
