### PR TITLE
fix(test): ignore every clone-mode feature's generated structures

### DIFF
--- a/tests/test-sdk/.gitignore
+++ b/tests/test-sdk/.gitignore
@@ -7,7 +7,7 @@ features/*/src/api/functional
 features/*/src/test/features/api/automated
 features/nested-output-directories/generated
 
-features/clone*/src/api/structures
+features/*clone*/src/api/structures
 features/clone-type-create-duplicate/sdk
 features/configurations/src/api/bbs
 features/configurations/src/api/common


### PR DESCRIPTION
## Intent

Close #1617. `features/clone*/src/api/structures` anchors at the start of the feature name, and one clone-mode feature is not named that way — so `websocket-clone`'s generated structures had no ignore rule, and every `pnpm test` run left them in `git status`:

```
?? tests/test-sdk/features/websocket-clone/src/api/
```

That is also how it was found: a `git add -A` in the test tree swept those four files into a commit that had no business carrying them.

## Scope

One character class. The set the rule was describing is "features whose name *contains* `clone`", so the glob now says that rather than enumerating a second literal name — which would leave the same trap for the next clone-mode feature that does not happen to begin with `clone`.

## Verification

Both directions, because a wider ignore rule can hide something the repository owns.

Every feature that generates its structures is now covered:

| feature | files on disk after a run | tracked | `git check-ignore` |
| --- | --- | --- | --- |
| `clone` | 4 | 0 | ignored |
| `clone-and-keyword` | 37 | 0 | ignored |
| `clone-and-propagate` | 37 | 0 | ignored |
| `clone-and-propagate-and-keyword` | 37 | 0 | ignored |
| `clone-native` | 2 | 0 | ignored |
| `clone-tags` | 2 | 0 | ignored |
| `websocket-clone` | 4 | 0 | **ignored (was not)** |

And nothing tracked disappears: `git ls-files` matching `features/*clone*/src/api/structures` returns **0**, so no file currently at `HEAD` becomes invisible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UpgzpPfMkrt8W6rAoofbkW
