### PR TITLE
fix(sdk): omit a request body that has no shape to describe

### DIFF
--- a/packages/sdk/src/generates/internal/SwaggerOperationComposer.ts
+++ b/packages/sdk/src/generates/internal/SwaggerOperationComposer.ts
@@ -99,13 +99,7 @@ export namespace SwaggerOperationComposer {
           }),
         )
         .flat(),
-      requestBody: props.route.body
-        ? SwaggerOperationParameterComposer.body({
-            schema: props.schema(props.route.body.metadata)!,
-            jsDocTags: props.route.jsDocTags,
-            parameter: props.route.body,
-          })
-        : undefined,
+      requestBody: writeRequestBody(props),
       responses: SwaggerOperationResponseComposer.compose({
         schema: props.schema,
         route: props.route,
@@ -117,3 +111,41 @@ export namespace SwaggerOperationComposer {
     };
   };
 }
+
+/**
+ * Compose an operation's `requestBody`, or omit it when the body has no shape.
+ *
+ * `props.schema` looks the metadata up in what `SwaggerGenerator.compose`
+ * collected, and that collection drops metadata of size zero -- so a `void`,
+ * `undefined` or `never` body is absent from it and the lookup answers
+ * `undefined`. The call site used to assert the result non-null, which turned a
+ * body with nothing to describe into `content: { "application/json": {} }`: a
+ * media type that says "send me JSON" and then declines to say what JSON.
+ *
+ * The Request Body Object's `content` is required by the specification, so the
+ * honest document for such a route is not a `requestBody` with an empty
+ * `content` -- it is no `requestBody`, which is also what the endpoint
+ * accepts.
+ *
+ * Deliberately not `composeContent`, which decides the same question for
+ * responses. The two rules differ and `@typia/utils`' Swagger 2.0 downgrader is
+ * where that is visible: a response is described by a schema _or_ an example,
+ * while a request body needs the schema -- `{ example }` alone is refused with
+ * `request body examples are not representable`, with or without one. Sharing a
+ * helper across two rules that disagree would trade one defect for another.
+ */
+const writeRequestBody = (props: {
+  schema: (metadata: MetadataSchema) => OpenApi.IJsonSchema | undefined;
+  route: ITypedHttpRoute;
+}): OpenApi.IOperation.IRequestBody | undefined => {
+  if (props.route.body === null) return undefined;
+  const schema: OpenApi.IJsonSchema | undefined = props.schema(
+    props.route.body.metadata,
+  );
+  if (schema === undefined) return undefined;
+  return SwaggerOperationParameterComposer.body({
+    schema,
+    jsDocTags: props.route.jsDocTags,
+    parameter: props.route.body,
+  });
+};

--- a/tests/test-sdk/features/openapi_v2/src/controllers/HealthController.ts
+++ b/tests/test-sdk/features/openapi_v2/src/controllers/HealthController.ts
@@ -17,6 +17,9 @@ import { Controller } from "@nestjs/common";
  * 2. Declare a `void` exception so one error response has none either.
  * 3. Declare a typed exception beside it, so the twin proves the rule narrows
  *    rather than drops every body, through the 2.0 downgrade this time.
+ * 4. Declare a `void` request body, and a shaped one beside it, so the same pair
+ *    holds on the request side -- where the rule is not the response's: a
+ *    request body needs a schema, an example cannot stand in for one.
  */
 @Controller("health")
 export class HealthController {
@@ -24,4 +27,20 @@ export class HealthController {
   @core.TypedException<string>({ status: 500 })
   @core.TypedRoute.Get()
   public get(): void {}
+
+  /** A request body with no shape: the same rule on the request side. */
+  @core.TypedRoute.Post("empty")
+  public empty(@core.TypedBody() input: void): void {
+    input;
+  }
+
+  /** The twin: a body that does have a shape keeps its media type. */
+  @core.TypedRoute.Post("typed")
+  public typed(@core.TypedBody() input: IHealthInput): IHealthInput {
+    return input;
+  }
+}
+
+export interface IHealthInput {
+  value: string;
 }

--- a/tests/test-sdk/features/openapi_v2/src/test/features/test_openapi_v2_request_body_presence.ts
+++ b/tests/test-sdk/features/openapi_v2/src/test/features/test_openapi_v2_request_body_presence.ts
@@ -1,0 +1,44 @@
+import { TestValidator } from "@nestia/e2e";
+import fs from "fs";
+
+/**
+ * Verifies a Swagger 2.0 operation declares a body parameter exactly when the
+ * body has a shape.
+ *
+ * Why: the same operation carries three media types -- the success response,
+ * each declared exception, and the request body -- and the request one was the
+ * last still written unconditionally. A body whose metadata yields no schema
+ * produced `content: { "application/json": {} }`, which says "send me JSON" and
+ * then declines to say what JSON. Its rule is also not the response's: a
+ * response is described by a schema or an example, while a request body needs
+ * the schema, so this pair cannot be folded into the response cases.
+ *
+ * 1. Read the generated 2.0 document.
+ * 2. Assert the `void`-body route declares no body parameter at all, since Swagger
+ *    2.0 renders a request body as a `body` parameter.
+ * 3. Assert the shaped-body route beside it still declares one with a schema, so a
+ *    composer that dropped every request body would not pass.
+ */
+export const test_openapi_v2_request_body_presence =
+  async (): Promise<void> => {
+    const swagger: any = JSON.parse(
+      await fs.promises.readFile(`${__dirname}/../../../swagger.json`, "utf8"),
+    );
+    const bodyParameters = (path: string): any[] =>
+      (swagger.paths[path].post.parameters ?? []).filter(
+        (p: any) => p.in === "body",
+      );
+
+    TestValidator.equals(
+      "void body declares no body parameter",
+      bodyParameters("/health/empty").length,
+      0,
+    );
+
+    const typed: any[] = bodyParameters("/health/typed");
+    TestValidator.equals("shaped body declares one", typed.length, 1);
+    TestValidator.predicate(
+      "shaped body carries a schema",
+      typed[0]?.schema !== undefined,
+    );
+  };


### PR DESCRIPTION
## Intent

Close #1619 — the third and last link of the chain #1606 and #1607 walked.

An operation carries three media types: the success response, each declared exception, and the request body. The first two learned to omit themselves when there is nothing to describe; the third was still written unconditionally, behind a non-null assertion on a lookup that returns `undefined`:

```ts
schema: props.schema(props.route.body.metadata)!,
```

`props.schema` reads the metadata `SwaggerGenerator.compose` collected, and that collection drops metadata of size zero — so a `void`, `undefined` or `never` body is absent from it, and the assertion carried the miss into the document as `"requestBody": { "content": { "application/json": {} } }`.

## The open question, settled

#1599's Self-Review recorded this and explicitly declined to guess:

> whether `@TypedBody() input: void` survives the transform's diagnostics was not established, and a fix without that answer would be a guess

It survives. Adding one route to `openapi_v2` moved the analyzer from 10 routes to 11 — accepted, not diagnosed — and then failed generation:

```
SwaggerV2Downgrader: request media types require a shared schema.
```

## The rule is not the response rule

Measured against the downgrader rather than assumed, because this fix is one `composeContent` call away from looking obvious:

| `requestBody` media type | 2.0 downgrade |
| --- | --- |
| no `requestBody` at all | accepted |
| `{}` | **throws** `request media types require a shared schema` |
| `{ schema: {} }` | accepted |
| `{ example }` without a schema | throws `request body examples are not representable` |
| `{ schema, example }` | throws — request examples are never representable at 2.0 |

A response is described by a schema **or** an example. A request body needs the schema. So this deliberately does **not** reuse `composeContent`: sharing a helper across two rules that disagree would trade one defect for another — the mirror of why three copies of `isImplicit` were merged into one in #1616.

The assertion is removed rather than worked around. It is what turned a missing schema into a malformed document instead of a decision. The Request Body Object's `content` is required by the specification, so the honest document is not a `requestBody` with an empty `content` — it is no `requestBody`, which is also what the endpoint accepts.

## Verification

On the artifact, not only on the suite — "generation stopped throwing" is what #1605 and #1606 were able to claim, and #1599's review found it insufficient:

```
/health/empty  body params: 0
/health/typed  body params: 1  {"$ref":"#/definitions/IHealthInput"}
```

`openapi_v2`'s `HealthController` gains the pair rather than a new feature, so one document pins both directions through the 2.0 downgrade. A composer that dropped every request body would fail the second.

| suite | result |
| --- | --- |
| `openapi_v2`, `openapi_v3` | green |
| the nine `body*` features | green — shaped bodies keep their media type |
| `multipart-form-data` | green |
| `plain` | green — `text/plain` bodies keep theirs |

## Not taken

Whether `@TypedBody() input: void` should be a transform diagnostic in its own right. Fixing the document does not depend on it, and rejecting code that compiles today is a product decision this pull request does not make.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UpgzpPfMkrt8W6rAoofbkW
