### PR TITLE
docs(setup): fix the watch script race and document the plugin cache

### DIFF
--- a/website/src/content/docs/setup.mdx
+++ b/website/src/content/docs/setup.mdx
@@ -108,7 +108,7 @@ Replace NestJS CLI build commands with `ttsc` / `ttsx`.
   "scripts": {
     "build": "ttsc",
     "start": "node dist/main.js",
-    "start:dev": "concurrently \"ttsc --watch\" \"node --watch dist/main.js\"",
+    "start:dev": "ttsc && concurrently \"ttsc --watch\" \"node --watch dist/main.js\"",
     "start:script": "ttsx src/main.ts"
   }
 }
@@ -116,6 +116,24 @@ Replace NestJS CLI build commands with `ttsc` / `ttsx`.
 
 `nest build`, `nest start`, `tsc`, `ts-node`, and `tsx` do not run the Nestia
 transform. Use `ttsc` for builds and `ttsx` for direct TypeScript execution.
+
+`start:dev` builds once before starting the watchers on purpose. `concurrently` starts both commands immediately, and `node --watch` exits with `Cannot find module` if its entry does not exist yet — it only begins watching after a successful first load — so without the leading build it loses the race against the initial `ttsc --watch` compile and never comes back.
+
+### Plugin cache
+
+`ttsc` compiles the Nestia transform from Go source, which is why the first build reports `building source plugin "@nestia/core"`. It is compiled once per cache key and reused afterwards; the message appears again only when something in that key changes.
+
+Two caches decide whether that work repeats. The compiled plugin lives in `TTSC_CACHE_DIR`, defaulting to `<workspace>/node_modules/.cache/ttsc`, and the Go build cache lives in `TTSC_GO_CACHE_DIR` or `GOCACHE`. Neither falls back to a location outside the workspace, so `rm -rf node_modules` reclaims both — and discards both.
+
+The cache key covers the `ttsc` and TypeScript-Go versions, the platform, the Go toolchain, and the plugin's own source. **It does not cover your application code.** A container image that installs dependencies in one layer and copies sources in a later one can therefore warm the plugin during the dependency layer and keep it across every source change, or mount both caches:
+
+```dockerfile filename="Dockerfile" showLineNumbers copy
+RUN --mount=type=cache,target=/ttsc-cache \
+    --mount=type=cache,target=/go-cache \
+    TTSC_CACHE_DIR=/ttsc-cache TTSC_GO_CACHE_DIR=/go-cache pnpm build
+```
+
+`ttsc` needs a Go toolchain on `PATH`; point `TTSC_GO_BINARY` at an absolute path when the image keeps it somewhere unusual.
 
 ## Generate
 


### PR DESCRIPTION
## Intent

Close #1596, which reported two separate things.

**The `start:dev` snippet in the guide did not work.** `concurrently` starts its commands at once, and `node --watch` exits with `Cannot find module` when its entry does not exist yet — it only begins watching after a successful first load, so it does not recover when the file later appears. Against a cold `dist/` it lost the race with the initial `ttsc --watch` compile and stayed dead while the compiler kept running, which reads as "the watcher silently does nothing".

Verified rather than reasoned about:

| command | behaviour |
| --- | --- |
| `node --watch dist/main.js`, entry missing | prints `Cannot find module`, exits |
| `node --watch dist/main.js`, entry present | prints `Waiting for file changes before restarting...`, stays |

The snippet now builds once first, and says why, so the leading `ttsc` does not look like a redundant step someone can tidy away.

**The plugin build costs one to two minutes on every fresh build**, which is painful in Docker. That is cache behaviour rather than a fixed cost, and nothing in the guide said so.

## What the new section says

Read from `buildSourcePlugin`'s own cache-root resolution and cache-key composition at the pinned `ttsc`, not from the link in the console message:

- the compiled plugin lives in `TTSC_CACHE_DIR`, defaulting to `<workspace>/node_modules/.cache/ttsc`;
- the Go build cache lives in `TTSC_GO_CACHE_DIR` or `GOCACHE`;
- neither falls back outside the workspace, so `rm -rf node_modules` reclaims **and discards** both;
- the cache key covers the `ttsc` and TypeScript-Go versions, the platform, the Go toolchain and the plugin's own source — **not** the application code.

That last point is what actually answers the Docker case: a dependency layer can warm the plugin and keep it across every source change. A BuildKit mount is shown for images that would rather not rely on layer ordering.

## Not changed

The reporter also asked whether `ts-patch` can come back. It cannot — the transform *is* the Go plugin now, and there is no TypeScript-side transformer to fall back to. That is answered on the issue rather than in the guide, which already states that `tsc`, `nest build`, SWC and Babel skip the transform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UpgzpPfMkrt8W6rAoofbkW
