### PR TITLE
fix(core): validate transforms without emit

### DIFF
--- a/packages/core/native/transform/build.go
+++ b/packages/core/native/transform/build.go
@@ -68,23 +68,54 @@ func runBuild(args []string) int {
 		return 2
 	}
 	if len(diags) > 0 {
+		if prog != nil {
+			prog.Close()
+		}
 		driver.WritePrettyDiagnostics(stderr, diags, cwd)
 		return 2
 	}
-	defer prog.Close()
-	releaseTypiaRegistries := registerTypiaDefaultLibraryClassifier(prog)
-	defer releaseTypiaRegistries()
 	if profile {
 		started = time.Now()
 	}
 	if diags := prog.Diagnostics(); len(diags) > 0 {
 		profileBuildStep(profile, "diagnostics", started)
+		prog.Close()
 		driver.WritePrettyDiagnostics(stderr, diags, cwd)
 		return 2
 	}
 	profileBuildStep(profile, "diagnostics", started)
 
 	shouldEmit := !prog.ParsedConfig.ParsedConfig.CompilerOptions.NoEmit.IsTrue()
+	if !shouldEmit {
+		// Plugin transformers are part of tsgo's emit pipeline. Reload with emit
+		// enabled so check/noEmit traverses the same source set, then discard every
+		// generated output below. The original program already proved the project's
+		// diagnostics; diagnosing this private reload would reject valid analysis-
+		// only options such as allowImportingTsExtensions.
+		prog.Close()
+		if profile {
+			started = time.Now()
+		}
+		prog, diags, err = driver.LoadProgram(cwd, *tsconfigPath, driver.LoadProgramOptions{
+			ForceEmit: true,
+			OutDir:    *outDir,
+		})
+		profileBuildStep(profile, "load-transform-program", started)
+		if err != nil {
+			fmt.Fprintf(stderr, "ttsc-nestia build: %v\n", err)
+			return 2
+		}
+		if len(diags) > 0 {
+			if prog != nil {
+				prog.Close()
+			}
+			driver.WritePrettyDiagnostics(stderr, diags, cwd)
+			return 2
+		}
+	}
+	defer prog.Close()
+	releaseTypiaRegistries := registerTypiaDefaultLibraryClassifier(prog)
+	defer releaseTypiaRegistries()
 	if !*quiet {
 		fmt.Fprintf(
 			stdout,
@@ -96,9 +127,6 @@ func runBuild(args []string) int {
 			plan.Typia,
 			shouldEmit,
 		)
-	}
-	if !shouldEmit {
-		return 0
 	}
 
 	// AST-integration emit: typia's per-file transformer and @nestia/core's own
@@ -132,10 +160,14 @@ func runBuild(args []string) int {
 	transforms := append([]driver.PluginTransform{typiaTransform, coreTransform}, contributorTransforms...)
 
 	emitted := []string{}
+	pending := []buildPendingOutput{}
 	writeFile := shimcompiler.WriteFile(func(fileName, text string, data *shimcompiler.WriteFileData) error {
 		_ = data
-		emitted = append(emitted, fileName)
-		return driver.DefaultWriteFile(fileName, text)
+		if shouldEmit {
+			emitted = append(emitted, fileName)
+			pending = append(pending, buildPendingOutput{FileName: fileName, Text: text})
+		}
+		return nil
 	})
 
 	// Declaration emit: ttsc delegates the whole emit of a transform-plugin
@@ -145,7 +177,7 @@ func runBuild(args []string) int {
 	// core runtime transforms never change the public type surface, so the
 	// declarations are taken from the pristine program — done before the JS
 	// transform runs so it reads the un-mutated AST.
-	if prog.ParsedConfig.ParsedConfig.CompilerOptions.Declaration.IsTrue() {
+	if shouldEmit && prog.ParsedConfig.ParsedConfig.CompilerOptions.Declaration.IsTrue() {
 		if profile {
 			started = time.Now()
 		}
@@ -162,10 +194,6 @@ func runBuild(args []string) int {
 		fmt.Fprintf(stderr, "ttsc-nestia build: emit failed: %v\n", err)
 		return 3
 	}
-	if len(transformDiags) > 0 {
-		WriteTypiaTransformDiagnostics(stderr, transformDiags, cwd)
-		return 3
-	}
 	emitHasError := false
 	for _, d := range eDiags {
 		fmt.Fprintln(stderr, "  -", d.String())
@@ -173,29 +201,46 @@ func runBuild(args []string) int {
 			emitHasError = true
 		}
 	}
+	if len(transformDiags) > 0 {
+		WriteTypiaTransformDiagnostics(stderr, transformDiags, cwd)
+		return 3
+	}
 	if emitHasError {
 		return 3
 	}
-	if *manifestPath != "" {
-		data, err := json.Marshal(emitted)
-		if err != nil {
-			fmt.Fprintf(stderr, "ttsc-nestia build: manifest marshal failed: %v\n", err)
-			return 3
+	if shouldEmit {
+		for _, output := range pending {
+			if err := driver.DefaultWriteFile(output.FileName, output.Text); err != nil {
+				fmt.Fprintf(stderr, "ttsc-nestia build: emit write failed: %v\n", err)
+				return 3
+			}
 		}
-		if err := os.MkdirAll(filepath.Dir(*manifestPath), 0o755); err != nil {
-			fmt.Fprintf(stderr, "ttsc-nestia build: manifest mkdir failed: %v\n", err)
-			return 3
+		if *manifestPath != "" {
+			data, err := json.Marshal(emitted)
+			if err != nil {
+				fmt.Fprintf(stderr, "ttsc-nestia build: manifest marshal failed: %v\n", err)
+				return 3
+			}
+			if err := os.MkdirAll(filepath.Dir(*manifestPath), 0o755); err != nil {
+				fmt.Fprintf(stderr, "ttsc-nestia build: manifest mkdir failed: %v\n", err)
+				return 3
+			}
+			if err := os.WriteFile(*manifestPath, data, 0o644); err != nil {
+				fmt.Fprintf(stderr, "ttsc-nestia build: manifest write failed: %v\n", err)
+				return 3
+			}
 		}
-		if err := os.WriteFile(*manifestPath, data, 0o644); err != nil {
-			fmt.Fprintf(stderr, "ttsc-nestia build: manifest write failed: %v\n", err)
-			return 3
+		if !*quiet {
+			fmt.Fprintf(stdout, "// ttsc-nestia build: emitted=%d files\n", len(emitted))
 		}
-	}
-	if !*quiet {
-		fmt.Fprintf(stdout, "// ttsc-nestia build: emitted=%d files\n", len(emitted))
 	}
 	profileBuildStep(profile, "total", totalStarted)
 	return 0
+}
+
+type buildPendingOutput struct {
+	FileName string
+	Text     string
 }
 
 // emitDeclarations runs tsgo's standard declaration emitter for the program.
@@ -220,39 +265,7 @@ func emitDeclarations(prog *driver.Program, writeFile shimcompiler.WriteFile) {
 }
 
 func runCheck(args []string) int {
-	fs := flag.NewFlagSet("check", flag.ContinueOnError)
-	fs.SetOutput(stderr)
-	tsconfigPath := fs.String("tsconfig", "tsconfig.json", "path to tsconfig.json")
-	cwdOverride := fs.String("cwd", "", "override the working directory")
-	pluginsJSON := fs.String("plugins-json", "", "ordered ttsc plugin payload")
-	if err := fs.Parse(args); err != nil {
-		return 2
-	}
-	if _, err := plugin.ParsePlan(*pluginsJSON); err != nil {
-		fmt.Fprintf(stderr, "ttsc-nestia check: %v\n", err)
-		return 2
-	}
-	cwd, ok := resolveCWD("ttsc-nestia check", *cwdOverride)
-	if !ok {
-		return 2
-	}
-	prog, diags, err := driver.LoadProgram(cwd, *tsconfigPath, driver.LoadProgramOptions{
-		ForceNoEmit: true,
-	})
-	if err != nil {
-		fmt.Fprintf(stderr, "ttsc-nestia check: %v\n", err)
-		return 2
-	}
-	if len(diags) > 0 {
-		driver.WritePrettyDiagnostics(stderr, diags, cwd)
-		return 2
-	}
-	defer prog.Close()
-	if diags := prog.Diagnostics(); len(diags) > 0 {
-		driver.WritePrettyDiagnostics(stderr, diags, cwd)
-		return 2
-	}
-	return 0
+	return runBuild(append([]string{"--noEmit"}, args...))
 }
 
 type Diagnostic struct {

--- a/packages/core/native/transform/build.go
+++ b/packages/core/native/transform/build.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	shimcompiler "github.com/microsoft/typescript-go/shim/compiler"
@@ -161,9 +162,15 @@ func runBuild(args []string) int {
 
 	emitted := []string{}
 	pending := []buildPendingOutput{}
+	var writeMu sync.Mutex
 	writeFile := shimcompiler.WriteFile(func(fileName, text string, data *shimcompiler.WriteFileData) error {
 		_ = data
 		if shouldEmit {
+			// TypeScript-Go emits declarations in parallel. Serialize the shared
+			// slices so buffering cannot lose an artifact or race while the
+			// declaration workers call this callback concurrently.
+			writeMu.Lock()
+			defer writeMu.Unlock()
 			emitted = append(emitted, fileName)
 			pending = append(pending, buildPendingOutput{FileName: fileName, Text: text})
 		}

--- a/packages/core/test/build_no_emit_preserves_analysis_only_options_test.go
+++ b/packages/core/test/build_no_emit_preserves_analysis_only_options_test.go
@@ -1,0 +1,45 @@
+package test
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestBuildNoEmitPreservesAnalysisOnlyOptions verifies the private transform
+// traversal does not invalidate compiler options that are legal only in a
+// no-emit project.
+//
+// `allowImportingTsExtensions` is accepted with noEmit but rejected by a normal
+// emitting configuration. The private ForceEmit program exists only to invoke
+// transformers, so repeating TypeScript diagnostics against that overridden
+// configuration would turn a valid analysis-only build into a false failure.
+//
+//  1. Create a valid no-emit TypedRoute project with the analysis-only option.
+//  2. Run the native build path and require a clean exit.
+//  3. Prove the private traversal publishes no output or build metadata.
+func TestBuildNoEmitPreservesAnalysisOnlyOptions(t *testing.T) {
+	project := writeLlmRouteBuildProject(t, llmRouteBuildProjectOptions{
+		NoEmit:                     true,
+		AllowImportingTsExtensions: true,
+		Valid:                      true,
+	})
+	out, errText, code := runCoreNative([]string{
+		"build",
+		"--cwd", project.Root,
+		"--tsconfig", "tsconfig.json",
+		"--manifest", project.Manifest,
+		"--plugins-json", project.PluginsJSON,
+	})
+	if code != 0 {
+		t.Fatalf("valid analysis-only project failed with code %d\nstdout=%s\nstderr=%s", code, out, errText)
+	}
+	if strings.TrimSpace(out) != "" || strings.TrimSpace(errText) != "" {
+		t.Fatalf("quiet analysis-only build wrote output:\nstdout=%s\nstderr=%s", out, errText)
+	}
+	for _, path := range []string{project.OutDir, project.BuildInfo, project.Manifest} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("analysis-only traversal published %s: %v", path, err)
+		}
+	}
+}

--- a/packages/core/test/build_no_emit_reports_llm_route_diagnostic_test.go
+++ b/packages/core/test/build_no_emit_reports_llm_route_diagnostic_test.go
@@ -1,0 +1,101 @@
+package test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestBuildNoEmitReportsLlmRouteDiagnostic verifies every analysis-only entry
+// path runs the same @TypedRoute LLM validation as an emitting build.
+//
+// A tuple response is valid JSON but invalid as an LLM schema. Before this
+// regression fix, check, an explicit --noEmit, and tsconfig-owned noEmit all
+// returned success before the core transformer ran, contradicting the runtime
+// error's advice to use `ttsc --noEmit` for the underlying diagnostic.
+//
+//  1. Create equivalent tuple-return TypedRoute projects for all no-emit paths.
+//  2. Require the preserved source location, decorator code, and LLM reason.
+//  3. Prove every analysis-only path publishes no compiler artifact.
+func TestBuildNoEmitReportsLlmRouteDiagnostic(t *testing.T) {
+	cases := []struct {
+		name       string
+		configured bool
+		verbose    bool
+		command    func(llmRouteBuildProject) []string
+	}{
+		{
+			name: "check-command",
+			command: func(project llmRouteBuildProject) []string {
+				return []string{
+					"check",
+					"--cwd", project.Root,
+					"--tsconfig", "tsconfig.json",
+					"--manifest", project.Manifest,
+					"--plugins-json", project.PluginsJSON,
+				}
+			},
+		},
+		{
+			name:    "explicit-no-emit",
+			verbose: true,
+			command: func(project llmRouteBuildProject) []string {
+				return []string{
+					"build",
+					"--cwd", project.Root,
+					"--tsconfig", "tsconfig.json",
+					"--noEmit",
+					"--manifest", project.Manifest,
+					"--verbose",
+					"--plugins-json", project.PluginsJSON,
+				}
+			},
+		},
+		{
+			name:       "configured-no-emit",
+			configured: true,
+			command: func(project llmRouteBuildProject) []string {
+				return []string{
+					"build",
+					"--cwd", project.Root,
+					"--tsconfig", "tsconfig.json",
+					"--manifest", project.Manifest,
+					"--plugins-json", project.PluginsJSON,
+				}
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			project := writeLlmRouteBuildProject(t, llmRouteBuildProjectOptions{
+				NoEmit: tc.configured,
+			})
+			out, errText, code := runCoreNative(tc.command(project))
+			if code != 3 {
+				t.Fatalf("analysis-only LLM transform should fail with code 3, got %d\nstdout=%s\nstderr=%s", code, out, errText)
+			}
+			normalized := filepath.ToSlash(errText)
+			mustContainAll(t, normalized,
+				"src/main.ts:8:4 - error TS(nestia.core.TypedRoute): unsupported type detected",
+				"- IResponse.pair: [string, number]",
+				"- LLM schema does not support tuple type.",
+			)
+			if strings.Contains(errText, "JSON does not support tuple type") {
+				t.Fatalf("tuple witness should isolate the LLM validator:\n%s", errText)
+			}
+			if tc.verbose {
+				if !strings.Contains(out, "emit=false") {
+					t.Fatalf("verbose no-emit summary missing:\n%s", out)
+				}
+			} else if strings.TrimSpace(out) != "" {
+				t.Fatalf("quiet no-emit run wrote stdout:\n%s", out)
+			}
+			for _, path := range []string{project.OutDir, project.BuildInfo, project.Manifest} {
+				if _, err := os.Stat(path); !os.IsNotExist(err) {
+					t.Fatalf("analysis-only run published %s: %v", path, err)
+				}
+			}
+		})
+	}
+}

--- a/packages/core/test/build_transform_diagnostic_publishes_no_artifacts_test.go
+++ b/packages/core/test/build_transform_diagnostic_publishes_no_artifacts_test.go
@@ -1,0 +1,45 @@
+package test
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestBuildTransformDiagnosticPublishesNoArtifacts verifies an emitting build
+// cannot leave runnable, untransformed JavaScript after a transform rejection.
+//
+// The emitter discovers decorator diagnostics while generating JavaScript. It
+// previously wrote declarations and JavaScript before checking that diagnostic
+// collection, so a caller that ignored exit code 3 could execute a bare
+// TypedRoute decorator and receive NoTransformConfigurationError at runtime.
+//
+//  1. Build a tuple-return TypedRoute project with LLM validation enabled.
+//  2. Require the transform exit code and exact LLM diagnostic.
+//  3. Assert no output, build-info, or manifest artifact was published.
+func TestBuildTransformDiagnosticPublishesNoArtifacts(t *testing.T) {
+	project := writeLlmRouteBuildProject(t, llmRouteBuildProjectOptions{})
+	out, errText, code := runCoreNative([]string{
+		"build",
+		"--cwd", project.Root,
+		"--tsconfig", "tsconfig.json",
+		"--manifest", project.Manifest,
+		"--plugins-json", project.PluginsJSON,
+	})
+	if code != 3 {
+		t.Fatalf("invalid emitting build should fail with code 3, got %d\nstdout=%s\nstderr=%s", code, out, errText)
+	}
+	mustContainAll(t, errText,
+		"error TS(nestia.core.TypedRoute): unsupported type detected",
+		"- IResponse.pair: [string, number]",
+		"- LLM schema does not support tuple type.",
+	)
+	if strings.TrimSpace(out) != "" {
+		t.Fatalf("quiet failed build wrote stdout:\n%s", out)
+	}
+	for _, path := range []string{project.OutDir, project.BuildInfo, project.Manifest} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("failed build published %s: %v", path, err)
+		}
+	}
+}

--- a/packages/core/test/check_passes_on_valid_feature_test.go
+++ b/packages/core/test/check_passes_on_valid_feature_test.go
@@ -10,11 +10,11 @@ import (
 // feature program, runs tsgo type diagnostics with ForceNoEmit, and exits 0
 // without writing any file.
 //
-// check is the analysis-only seam ttsc uses for `--noEmit` type verification; it
-// shares plugin parsing and program loading with build/transform but skips the
-// transform stage entirely. A regression that accidentally emitted, or that
-// surfaced clean programs as failures, would break the no-emit contract. Running
-// it against a known-good DTO pins the success branch end to end.
+// check is the analysis-only seam ttsc uses for `--noEmit` verification. It
+// shares the complete transform traversal with build while discarding every
+// generated artifact. A regression that accidentally emitted, or that surfaced
+// clean programs as failures, would break the no-emit contract. Running it
+// against a known-good DTO pins the success branch end to end.
 //
 //  1. Run check against a clean body-feature DTO via an extending tsconfig.
 //  2. Assert the exit code is 0.

--- a/packages/core/test/check_reports_type_error_test.go
+++ b/packages/core/test/check_reports_type_error_test.go
@@ -11,11 +11,11 @@ import (
 // TestCheckReportsTypeError verifies the check subcommand surfaces a genuine
 // tsgo type error as exit 2 via the prog.Diagnostics() branch.
 //
-// runCheck loads the program with ForceNoEmit and fails when either config
-// diagnostics or type diagnostics are present; the type-diagnostics branch is
-// the analysis half of the no-emit contract ttsc relies on for `--noEmit`. A
-// clean feature never reaches it, so we synthesize a one-line type error in a
-// temp source file (no tracked fixture) and assert check rejects it.
+// The check route first loads the program with ForceNoEmit and fails when either
+// config diagnostics or type diagnostics are present; only a TypeScript-clean
+// program proceeds to its private transform traversal. We synthesize a one-line
+// type error in a temp source file (no tracked fixture) and assert check rejects
+// it before transformation.
 //
 //  1. Write a temp .ts assigning a string to a number and a tsconfig including it.
 //  2. Run check against it.

--- a/packages/core/test/helpers_test.go
+++ b/packages/core/test/helpers_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -8,6 +9,20 @@ import (
 
 	"github.com/samchon/nestia/packages/core/native/transform"
 )
+
+type llmRouteBuildProject struct {
+	Root        string
+	OutDir      string
+	BuildInfo   string
+	Manifest    string
+	PluginsJSON string
+}
+
+type llmRouteBuildProjectOptions struct {
+	NoEmit                     bool
+	AllowImportingTsExtensions bool
+	Valid                      bool
+}
 
 // repoRootForCore walks up from the external test module directory
 // (packages/core/test) to the monorepo root so the in-process tests can point
@@ -80,6 +95,112 @@ func mustContainAll(t *testing.T, haystack string, needles ...string) {
 			t.Fatalf("output missing %q\n%s", needle, haystack)
 		}
 	}
+}
+
+// writeLlmRouteBuildProject creates an isolated TypeScript project whose
+// @nestia/core declaration is deliberately minimal: the native transform only
+// needs the real module specifier and decorator shape, while the return DTO
+// remains fully visible to the checker. Invalid projects use a tuple because
+// JSON supports it but the LLM schema does not, isolating the llm option from
+// ordinary response-stringifier validation.
+func writeLlmRouteBuildProject(t *testing.T, options llmRouteBuildProjectOptions) llmRouteBuildProject {
+	t.Helper()
+	root := t.TempDir()
+	src := filepath.Join(root, "src")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	declaration := `declare module "@nestia/core" {
+  export namespace TypedRoute {
+    function Get(): MethodDecorator;
+  }
+}
+`
+	if err := os.WriteFile(filepath.Join(src, "core.d.ts"), []byte(declaration), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	property := `pair: [string, number];`
+	value := `{ pair: ["one", 1] }`
+	if options.Valid {
+		property = `value: string;`
+		value = `{ value: "ok" }`
+	}
+	source := `import { TypedRoute } from "@nestia/core";
+
+interface IResponse {
+  ` + property + `
+}
+
+export class Controller {
+  @TypedRoute.Get()
+  public get(): IResponse {
+    return ` + value + `;
+  }
+}
+`
+	if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(source), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	noEmit := ""
+	if options.NoEmit {
+		noEmit = `,
+    "noEmit": true`
+	}
+	allowImporting := ""
+	if options.AllowImportingTsExtensions {
+		allowImporting = `,
+    "allowImportingTsExtensions": true`
+	}
+	buildInfo := filepath.Join(root, "cache.tsbuildinfo")
+	config := `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "ignoreDeprecations": "6.0",
+    "experimentalDecorators": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "incremental": true,
+    "tsBuildInfoFile": "cache.tsbuildinfo"` + noEmit + allowImporting + `
+  },
+  "files": ["src/core.d.ts", "src/main.ts"]
+}
+`
+	if err := os.WriteFile(filepath.Join(root, "tsconfig.json"), []byte(config), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return llmRouteBuildProject{
+		Root:      root,
+		OutDir:    filepath.Join(root, "dist"),
+		BuildInfo: buildInfo,
+		Manifest:  filepath.Join(root, "artifacts", "manifest.json"),
+		PluginsJSON: `[{
+  "name": "@nestia/core",
+  "stage": "transform",
+  "config": {
+    "transform": "@nestia/core/lib/transform",
+    "validate": "assert",
+    "stringify": "assert",
+    "llm": true
+  }
+}]`,
+	}
+}
+
+// runCoreNative captures both process streams around one in-process native
+// command. Tests stay sequential because RunWithOutput temporarily redirects
+// package-global writers.
+func runCoreNative(args []string) (string, string, int) {
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := transform.RunWithOutput(args, &out, &errOut)
+	return out.String(), errOut.String(), code
 }
 
 // writeExtendingTsconfig writes a tsconfig under temp that extends a feature

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,11 +31,11 @@ catalogs:
       version: 1.1.5
   samchon:
     '@typia/interface':
-      specifier: ^14.0.1
-      version: 14.0.1
+      specifier: ^14.0.2
+      version: 14.0.2
     '@typia/utils':
-      specifier: ^14.0.1
-      version: 14.0.1
+      specifier: ^14.0.2
+      version: 14.0.2
     tgrid:
       specifier: ^1.2.1
       version: 1.2.1
@@ -43,8 +43,8 @@ catalogs:
       specifier: ^3.0.0
       version: 3.0.0
     typia:
-      specifier: ^14.0.1
-      version: 14.0.1
+      specifier: ^14.0.2
+      version: 14.0.2
   typescript:
     '@trivago/prettier-plugin-sort-imports':
       specifier: ^4.3.0
@@ -171,7 +171,7 @@ importers:
         version: 3.0.0
       typia:
         specifier: catalog:samchon
-        version: 14.0.1(ttsc@0.28.1)
+        version: 14.0.2(ttsc@0.28.1)
     devDependencies:
       '@types/autocannon':
         specifier: ^7.9.0
@@ -245,10 +245,10 @@ importers:
         version: link:../fetcher
       '@typia/interface':
         specifier: catalog:samchon
-        version: 14.0.1
+        version: 14.0.2
       '@typia/utils':
         specifier: catalog:samchon
-        version: 14.0.1
+        version: 14.0.2
       get-function-location:
         specifier: ^2.0.0
         version: 2.0.0
@@ -272,7 +272,7 @@ importers:
         version: 1.2.1
       typia:
         specifier: catalog:samchon
-        version: 14.0.1(ttsc@0.28.1)
+        version: 14.0.2(ttsc@0.28.1)
       ws:
         specifier: ^7.5.3
         version: 7.5.10
@@ -333,7 +333,7 @@ importers:
         version: link:../migrate
       '@typia/interface':
         specifier: catalog:samchon
-        version: 14.0.1
+        version: 14.0.2
       fflate:
         specifier: ^0.8.2
         version: 0.8.3
@@ -348,7 +348,7 @@ importers:
         version: 0.5.2(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1))(@mui/icons-material@5.18.0(@mui/material@5.18.0(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.28)(react@18.3.1))(@mui/material@5.18.0(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.28)(prop-types@15.8.1)
       typia:
         specifier: catalog:samchon
-        version: 14.0.1(ttsc@0.28.1)
+        version: 14.0.2(ttsc@0.28.1)
     devDependencies:
       '@eslint/js':
         specifier: ^9.13.0
@@ -415,10 +415,10 @@ importers:
     dependencies:
       '@typia/interface':
         specifier: catalog:samchon
-        version: 14.0.1
+        version: 14.0.2
       '@typia/utils':
         specifier: catalog:samchon
-        version: 14.0.1
+        version: 14.0.2
     devDependencies:
       '@types/node':
         specifier: catalog:utils
@@ -440,10 +440,10 @@ importers:
         version: 0.28.1
       '@typia/interface':
         specifier: catalog:samchon
-        version: 14.0.1
+        version: 14.0.2
       '@typia/utils':
         specifier: catalog:samchon
-        version: 14.0.1
+        version: 14.0.2
       commander:
         specifier: 10.0.0
         version: 10.0.0
@@ -461,7 +461,7 @@ importers:
         version: 3.0.0
       typia:
         specifier: catalog:samchon
-        version: 14.0.1(ttsc@0.28.1)
+        version: 14.0.2(ttsc@0.28.1)
     devDependencies:
       '@types/inquirer':
         specifier: ^9.0.7
@@ -495,10 +495,10 @@ importers:
         version: 0.28.1
       '@typia/interface':
         specifier: catalog:samchon
-        version: 14.0.1
+        version: 14.0.2
       '@typia/utils':
         specifier: catalog:samchon
-        version: 14.0.1
+        version: 14.0.2
       get-function-location:
         specifier: ^2.0.0
         version: 2.0.0
@@ -522,7 +522,7 @@ importers:
         version: 0.28.1
       typia:
         specifier: catalog:samchon
-        version: 14.0.1(ttsc@0.28.1)
+        version: 14.0.2(ttsc@0.28.1)
     devDependencies:
       '@modelcontextprotocol/sdk':
         specifier: catalog:modelcontextprotocol
@@ -571,7 +571,7 @@ importers:
         version: 11.1.21(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.21)
       typia:
         specifier: catalog:samchon
-        version: 14.0.1(ttsc@0.28.1)
+        version: 14.0.2(ttsc@0.28.1)
       uuid:
         specifier: catalog:utils
         version: 13.0.2
@@ -624,7 +624,7 @@ importers:
         version: link:../../packages/fetcher
       typia:
         specifier: catalog:samchon
-        version: 14.0.1(ttsc@0.28.1)
+        version: 14.0.2(ttsc@0.28.1)
     devDependencies:
       '@types/node':
         specifier: catalog:utils
@@ -692,7 +692,7 @@ importers:
         version: 4.1.8
       '@typia/interface':
         specifier: catalog:samchon
-        version: 14.0.1
+        version: 14.0.2
       chalk:
         specifier: 4.1.2
         version: 4.1.2
@@ -728,7 +728,7 @@ importers:
         version: 3.0.0
       typia:
         specifier: catalog:samchon
-        version: 14.0.1(ttsc@0.28.1)
+        version: 14.0.2(ttsc@0.28.1)
     devDependencies:
       '@nestia/sdk':
         specifier: workspace:^
@@ -792,10 +792,10 @@ importers:
         version: 11.4.3(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.21)(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)
       '@typia/interface':
         specifier: catalog:samchon
-        version: 14.0.1
+        version: 14.0.2
       '@typia/utils':
         specifier: catalog:samchon
-        version: 14.0.1
+        version: 14.0.2
       express:
         specifier: ^4.21.1
         version: 4.22.2
@@ -819,7 +819,7 @@ importers:
         version: 3.0.0
       typia:
         specifier: catalog:samchon
-        version: 14.0.1(ttsc@0.28.1)
+        version: 14.0.2(ttsc@0.28.1)
       uuid:
         specifier: catalog:utils
         version: 13.0.2
@@ -865,7 +865,7 @@ importers:
         version: 11.1.21(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       typia:
         specifier: catalog:samchon
-        version: 14.0.1(ttsc@0.28.1)
+        version: 14.0.2(ttsc@0.28.1)
     devDependencies:
       '@types/node':
         specifier: catalog:utils
@@ -2236,11 +2236,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@typia/interface@14.0.1':
-    resolution: {integrity: sha512-aDIu4B9JVH+2QwhrhIEEVd9PILzIyMDGJ0P4wULbg8LU6c5CmIWShCAR7TteOfk3UZiAzUHXnBpHdUlPO44JXg==}
+  '@typia/interface@14.0.2':
+    resolution: {integrity: sha512-2P/f5s3js/Yw3x7JJuM6jjhyWON3/asnXGE0p2n6WV4KxTgTWO1Qj/euPN8Y5+mfiYQuq8TcIRBekVyjyFlVWQ==}
 
-  '@typia/utils@14.0.1':
-    resolution: {integrity: sha512-iyGP+mQ5qW/ESyjZCPneZdgw3umC6corMmIilUuUbSMc6hVH/ns300Gbft+LuQa9RWHE+PLtiHLwoTkmF7JF8w==}
+  '@typia/utils@14.0.2':
+    resolution: {integrity: sha512-lDeWtIv6IF06bhuJJGxu/BkUrasJyxSYgIZ246lFTZxW53BhNnRoc+LaJSmbj/V39409PY3n7dotNVdVytY7fA==}
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -4229,8 +4229,8 @@ packages:
     engines: {node: '>=16.20.0'}
     hasBin: true
 
-  typia@14.0.1:
-    resolution: {integrity: sha512-ate2e5EBbV0EsvYtBhfAhN1kh9ges4Om/hmeX0H1+CfjgdqMVzmiS7T0DojODT6l+irGZG4LH+SQPDY7qX+Tvg==}
+  typia@14.0.2:
+    resolution: {integrity: sha512-yyqPAX+/0Wg1L4W/eglQjeZvEOQJrV9tH8m6rOJ06qEDXmZDsDidjysOSuuxEBha623hNPgwnU/YpymKn4PRlQ==}
     peerDependencies:
       ttsc: '>=0.19.2'
     peerDependenciesMeta:
@@ -5723,11 +5723,11 @@ snapshots:
   '@typescript/typescript-win32-x64@7.0.2':
     optional: true
 
-  '@typia/interface@14.0.1': {}
+  '@typia/interface@14.0.2': {}
 
-  '@typia/utils@14.0.1':
+  '@typia/utils@14.0.2':
     dependencies:
-      '@typia/interface': 14.0.1
+      '@typia/interface': 14.0.2
 
   '@vitejs/plugin-react@4.7.0(vite@5.4.21(@types/node@25.9.0)(terser@5.47.1))':
     dependencies:
@@ -8049,10 +8049,10 @@ snapshots:
       '@typescript/typescript-win32-arm64': 7.0.2
       '@typescript/typescript-win32-x64': 7.0.2
 
-  typia@14.0.1(ttsc@0.28.1):
+  typia@14.0.2(ttsc@0.28.1):
     dependencies:
-      '@typia/interface': 14.0.1
-      '@typia/utils': 14.0.1
+      '@typia/interface': 14.0.2
+      '@typia/utils': 14.0.2
       randexp: 0.5.3
     optionalDependencies:
       ttsc: 0.28.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,7 +12,7 @@ catalogs:
     '@nestjs/platform-fastify': *nestjs
     rxjs: ^7.1.0
   samchon:
-    typia: &typia ^14.0.1
+    typia: &typia ^14.0.2
     '@typia/interface': *typia
     '@typia/utils': *typia
     tgrid: ^1.2.1

--- a/tests/test-transform-options/start.js
+++ b/tests/test-transform-options/start.js
@@ -118,7 +118,30 @@ const main = () => {
         source,
         plugin: { llm: { strict: true } },
         fail: true,
+        expectedDiagnostics:
+          source === "llm-route"
+            ? [
+                "src/llm-route.ts:11:4 - error TS(nestia.core.TypedRoute): unsupported type detected",
+                "- IArticle.weak: WeakMap",
+                "- LLM schema does not support WeakMap type.",
+              ]
+            : undefined,
       });
+  });
+
+  measure("llm route no-emit diagnostics", () => {
+    compile({
+      name: "llm-route-no-emit",
+      source: "llm-route",
+      plugin: { llm: true },
+      noEmit: true,
+      fail: true,
+      expectedDiagnostics: [
+        "src/llm-route.ts:11:4 - error TS(nestia.core.TypedRoute): unsupported type detected",
+        "- IArticle.weak: WeakMap",
+        "- LLM schema does not support WeakMap type.",
+      ],
+    });
   });
 
   measure("disabled transform", () => {
@@ -339,9 +362,11 @@ const transformEnvelope = () => {
 
 const compile = (props) => {
   const project = writeProject(props);
+  const args = [TTSC, "--cache-dir", CACHE, "-p", project];
+  if (props.noEmit === true) args.push("--noEmit");
   const result = cp.spawnSync(
     NODE,
-    [TTSC, "--cache-dir", CACHE, "-p", project],
+    args,
     {
       cwd: __dirname,
       encoding: "utf8",
@@ -361,6 +386,20 @@ const compile = (props) => {
   if (props.fail === true) {
     if (result.status === 0)
       throw new Error(`${props.name}: compilation was expected to fail.`);
+    const diagnostics = `${result.stdout ?? ""}\n${result.stderr ?? ""}`.replaceAll(
+      "\\",
+      "/",
+    );
+    for (const expected of props.expectedDiagnostics ?? [])
+      assert(
+        diagnostics.includes(expected),
+        `${props.name}: diagnostic missing ${JSON.stringify(expected)}\n${diagnostics}`,
+      );
+    const output = path.join(LIB, props.name);
+    assert(
+      !fs.existsSync(output),
+      `${props.name}: failed compilation published ${output}`,
+    );
     return null;
   }
   if (result.status !== 0) {


### PR DESCRIPTION
## Intent

Make `ttsc --noEmit`, configured `noEmit`, and the native `check` command surface the same typia/core/SDK contributor diagnostics as an emitting nestia build, while ensuring failed builds cannot leave runnable untransformed output.

Closes #1624.

## Scope

- reload a private emit-enabled program after the original no-emit program passes TypeScript diagnostics, then run the complete composed transform pipeline with every output discarded;
- route `check` through the same no-emit build path so the two commands cannot diverge;
- buffer declarations, JavaScript, maps, and build metadata until emit and transform diagnostics are clean;
- pin LLM-only tuple return diagnostics for `TypedRoute` across check, explicit `--noEmit`, configured `noEmit`, and normal failed emit paths;
- assert the real `ttsc` CLI reports the detailed `nestia.core.TypedRoute` diagnostic and publishes no failed output;
- update typia, `@typia/interface`, and `@typia/utils` to 14.0.2 so nestia consumes the upstream runtime guidance release.

`@nestia/sdk` needs no separate execution change: its compiler already propagates the core host's nonzero status and stderr. No package version fields are changed; release versioning remains maintainer-owned.

## Local verification

- `go test ./... -run 'TestBuild(NoEmitReportsLlmRouteDiagnostic|TransformDiagnosticPublishesNoArtifacts|NoEmitPreservesAnalysisOnlyOptions)$' -count=1 -v`
- `pnpm --filter ./tests/test-transform-options start`
- `pnpm format`
- `git diff --cached --check`

The full `pnpm --filter @nestia/core test:go` run was intentionally stopped before completion at maintainer direction; the complete repository matrix is deferred to GitHub Actions.
