### PR TITLE
fix(core): close @EncryptedBody padding oracle

### DIFF
--- a/packages/core/src/decorators/EncryptedBody.ts
+++ b/packages/core/src/decorators/EncryptedBody.ts
@@ -69,17 +69,35 @@ export function EncryptedBody<T>(
         : param;
 
     // PARSE AND VALIDATE DATA
-    const data: any = JSON.parse(decrypt(body, password.key, password.iv));
+    const data: any = decode(body, password.key, password.iv);
     const error: Error | null = checker(data);
     if (error !== null) throw error;
     return data;
   })();
 }
 
-/** @internal */
-const decrypt = (body: string, key: string, iv: string): string => {
+/**
+ * Decrypt and JSON-parse the request body behind a single failure response.
+ *
+ * `AesPkcs5` is AES-CBC without an authentication tag, so a MITM attacker can
+ * forge ciphertexts. Splitting the two failure modes of a forged body — a bad
+ * PKCS#5 padding (decryption throws) versus valid padding whose plaintext is
+ * not JSON (`JSON.parse` throws) — into two different HTTP status codes turns
+ * this decorator into a padding oracle: one observable bit per request lets the
+ * attacker recover the plaintext byte by byte without the key
+ * (GHSA-pqj4-gvf7-6fq5).
+ *
+ * Both failure modes must therefore collapse into one indistinguishable
+ * `BadRequestException` (identical status, message, and body). Only the
+ * downstream type validation of an already-parsed body may report its own
+ * distinct error, because reaching it requires plaintext the attacker cannot
+ * forge without already knowing it.
+ *
+ * @internal
+ */
+const decode = (body: string, key: string, iv: string): unknown => {
   try {
-    return AesPkcs5.decrypt(body, key, iv);
+    return JSON.parse(AesPkcs5.decrypt(body, key, iv));
   } catch (exp) {
     if (exp instanceof Error)
       throw new BadRequestException(

--- a/tests/test-sdk/features/encrypted/src/test/features/api/test_api_encrypted_padding_oracle.ts
+++ b/tests/test-sdk/features/encrypted/src/test/features/api/test_api_encrypted_padding_oracle.ts
@@ -1,0 +1,96 @@
+import { TestValidator } from "@nestia/e2e";
+import crypto from "crypto";
+
+import api from "@api";
+
+/**
+ * Verifies @EncryptedBody exposes no padding oracle: a forged ciphertext whose
+ * PKCS#5 padding is broken and one whose padding is valid but whose plaintext
+ * is not JSON must produce the identical failure response.
+ *
+ * `AesPkcs5` is unauthenticated AES-CBC, so a body can be forged. The decorator
+ * used to catch the decrypt failure as a 400 while letting the JSON.parse
+ * failure escape as a 500. Those two observable status codes are a padding
+ * oracle (GHSA-pqj4-gvf7-6fq5): one bit per request recovers plaintext byte by
+ * byte without the key. Both failure modes must now collapse into one
+ * indistinguishable 400, and neither may be a 500.
+ *
+ * 1. Encrypt a valid JSON login body with the connection's own key/iv and POST the
+ *    raw ciphertext; it must succeed (the wire format is unchanged).
+ * 2. Flip the last ciphertext byte to break the final block's padding, and flip
+ *    the first ciphertext byte so CBC corrupts the early plaintext into
+ *    non-JSON while the final block's padding survives.
+ * 3. Assert neither forged request returns 500 and that the two responses are
+ *    identical in both status (400) and body.
+ */
+export const test_api_encrypted_padding_oracle = async (
+  connection: api.IConnection,
+): Promise<void> => {
+  const password: { key: string; iv: string } = connection.encryption as {
+    key: string;
+    iv: string;
+  };
+
+  // INDEPENDENT ORACLE: encrypt with Node crypto, not the code under test
+  const encrypt = (plain: string): Buffer => {
+    const cipher = crypto.createCipheriv(
+      `aes-${password.key.length * 8}-cbc`,
+      password.key,
+      password.iv,
+    );
+    return Buffer.concat([cipher.update(plain, "utf8"), cipher.final()]);
+  };
+  const send = async (
+    bytes: Buffer,
+  ): Promise<{ status: number; body: string }> => {
+    const response: Response = await fetch(
+      `${connection.host}/sellers/authenticate/login`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "text/plain" },
+        body: bytes.toString("base64"),
+      },
+    );
+    return { status: response.status, body: await response.text() };
+  };
+
+  // VALID CIPHERTEXT STILL SUCCEEDS (no wire-format change)
+  const ciphertext: Buffer = encrypt(
+    JSON.stringify({
+      email: "someone@someone.com",
+      password: "qweqwe123!",
+    }),
+  );
+  const ok = await send(ciphertext);
+  TestValidator.equals(
+    "valid ciphertext still decrypts",
+    true,
+    ok.status < 300,
+  );
+
+  // (a) BROKEN PKCS#5 PADDING: decrypt throws
+  const flip = (buffer: Buffer, index: number): Buffer => {
+    buffer.writeUInt8(buffer.readUInt8(index) ^ 0x01, index);
+    return buffer;
+  };
+  const brokenPadding: Buffer = flip(
+    Buffer.from(ciphertext),
+    ciphertext.length - 1,
+  );
+
+  // (b) VALID PADDING, NON-JSON PLAINTEXT: JSON.parse throws
+  const garbageJson: Buffer = flip(Buffer.from(ciphertext), 0);
+
+  const a = await send(brokenPadding);
+  const b = await send(garbageJson);
+
+  // NO 500 LEAK, AND THE TWO FAILURES ARE INDISTINGUISHABLE
+  TestValidator.equals("decrypt failure is not a 500", 400, a.status);
+  TestValidator.equals("json failure is not a 500", 400, b.status);
+  TestValidator.equals(
+    "padding oracle closed: same status",
+    a.status,
+    b.status,
+  );
+  TestValidator.equals("padding oracle closed: same body", a.body, b.body);
+};

--- a/website/src/content/docs/core/TypedBody.mdx
+++ b/website/src/content/docs/core/TypedBody.mdx
@@ -124,7 +124,9 @@ Validation failures throw `BadRequestException`, so global exception filters cat
 
 ## EncryptedBody
 
-`@EncryptedBody()` accepts an AES-128/256 CBC encrypted body (PKCS #5 padding, Base64 encoded). Slower than `@TypedBody()` but adds transport-level confidentiality; the generated SDK encrypts requests automatically so consumers send plaintext at the call site.
+`@EncryptedBody()` accepts an AES-128/256 CBC encrypted body (PKCS #5 padding, Base64 encoded). The generated SDK encrypts requests automatically so consumers send plaintext at the call site.
+
+This is an obfuscation layer to run on top of TLS — it hides the request payload from casual inspection (for example a reader opening the browser devtools) and satisfies environments that mandate a second encryption pass. It is not authenticated encryption and is not a substitute for TLS: AES-CBC here carries no message authentication code, so do not rely on it as your only confidentiality or integrity control. Keep HTTPS as the transport.
 
 Encrypted bodies do not appear in Swagger UI (the wire shape is opaque). Only the generated SDK can call them.
 

--- a/website/src/content/docs/core/TypedRoute.mdx
+++ b/website/src/content/docs/core/TypedRoute.mdx
@@ -99,7 +99,9 @@ export namespace EncryptedRoute {
 }
 ```
 
-Same family, but the response body is **AES-128/256 CBC** encrypted with PKCS #5 padding and Base64 encoded. Slower than `TypedRoute`; use when you need transport-level confidentiality the SDK will decrypt automatically.
+Same family, but the response body is **AES-128/256 CBC** encrypted with PKCS #5 padding and Base64 encoded, and the SDK decrypts it automatically.
+
+Like `@EncryptedBody`, this is an obfuscation layer to run on top of TLS, not authenticated encryption. AES-CBC here carries no message authentication code, so treat it as a way to hide the payload from casual inspection or to satisfy a second-encryption-pass mandate, and keep HTTPS as the transport rather than relying on it as your only confidentiality or integrity control.
 
 Encrypted routes do not appear in Swagger UI because the response shape is encrypted. The **generated SDK** (`@nestia/sdk`) handles the decryption on the client side, so consumers see typed, decrypted data.
 


### PR DESCRIPTION
Closes the padding-oracle vector reported in GHSA-pqj4-gvf7-6fq5 and tracked in #1627.

## Intent

`@EncryptedBody` returned `400` when AES-CBC/PKCS#5 decryption failed but `500` when the decrypted bytes were not valid JSON. That status divergence is a padding oracle: an attacker submitting forged ciphertexts recovers plaintext byte by byte without the key. This PR makes every malformed-input failure return one identical `400`, closing the oracle without touching the wire format.

## Scope (owns #1627)

- **Fix:** collapse decrypt failure and `JSON.parse` failure in `EncryptedBody` into a single identical `BadRequestException` (same status, message, and body).
- **Regression:** an e2e test in `tests/test-sdk/features/encrypted` that forges both failure modes and asserts the two responses are identical and neither is `500`.
- **Docs:** stop claiming "transport-level confidentiality" in `TypedBody.mdx` / `TypedRoute.mdx`; describe the obfuscation-over-TLS purpose and the unauthenticated-CBC residual.

## Deferred (breaking, not in this PR)

Unauthenticated CBC with a fixed IV (`IEncryptionPassword.iv`) is the deeper root cause. A real fix (AEAD + per-message random IV) changes the wire format and breaks every deployed `v<=13` peer, so it belongs to a maintainer-owned major release. Documented as residual on #1627 and in the guides.

## Non-breaking

Wire format unchanged; legitimate SDK traffic never reaches the failure path. The only observable change is forged/malformed input returning `400` instead of `500`.

## Verification

Pending — recorded as PR reviews as it lands.
